### PR TITLE
Add an endpoint to list orgs api key has access to.

### DIFF
--- a/limacharlie/Manager.py
+++ b/limacharlie/Manager.py
@@ -335,6 +335,20 @@ class Manager( object ):
         resp = self._apiCall( 'who', GET, {}, altRoot = ROOT_URL )
         return resp
 
+    def userAccessibleOrgs( self ):
+        '''Query the API with a User API to see which organizations the user has access to.
+
+        Returns:
+            A dict with org OIDs and names.
+        '''
+
+        resp = self._apiCall( '/user_key_info', POST, {}, queryParams = {
+            'uid' : self._uid,
+            'secret' : self._secret_api_key,
+            'with_names' : True,
+        }, altRoot = 'https://app.limacharlie.io/' )
+        return resp
+
     def sensor( self, sid, inv_id = None ):
         '''Get a Sensor object for the specific Sensor ID.
 


### PR DESCRIPTION
## Description of the change

Adding support for the endpoint that lists all the orgs that a user api key has access to.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

