### PR TITLE
Support hash check in SpotCheck Python3.

### DIFF
--- a/limacharlie/SpotCheck.py
+++ b/limacharlie/SpotCheck.py
@@ -369,7 +369,10 @@ def main( sourceArgs = None ):
             try:
                 hash.decode( 'hex' )
             except:
-                raise Exception( 'hash contains invalid characters' )
+                try:
+                    bytes.fromhex( hash )
+                except:
+                    raise Exception( 'hash contains invalid characters' )
             response = sensor.simpleRequest( 'dir_find_hash "%s" "%s" -d %s --hash %s' % ( directory.replace( "\\", "\\\\" ), filePattern, depth , hash ), timeout = 3600 )
             if not response:
                 raise Exception( 'timeout' )

--- a/limacharlie/__init__.py
+++ b/limacharlie/__init__.py
@@ -1,6 +1,6 @@
 """limacharlie API for limacharlie.io"""
 
-__version__ = "3.18.3"
+__version__ = "3.18.4"
 __author__ = "Maxime Lamothe-Brassard ( Refraction Point, Inc )"
 __author_email__ = "maxime@refractionpoint.com"
 __license__ = "Apache v2"

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-__version__ = "3.18.3"
+__version__ = "3.18.4"
 __author__ = "Maxime Lamothe-Brassard ( Refraction Point, Inc )"
 __author_email__ = "maxime@refractionpoint.com"
 __license__ = "Apache v2"


### PR DESCRIPTION
## Description of the change

Python3 strings do not support `.decode('hex')`. Moving to a quick and dirty check for both.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

