### PR TITLE
Fix listing of orgs from user key.

### DIFF
--- a/limacharlie/Manager.py
+++ b/limacharlie/Manager.py
@@ -346,7 +346,7 @@ class Manager( object ):
             'uid' : self._uid,
             'secret' : self._secret_api_key,
             'with_names' : True,
-        }, altRoot = 'https://app.limacharlie.io/' )
+        }, altRoot = 'https://app.limacharlie.io/', isNoAuth = True )
         return resp
 
     def sensor( self, sid, inv_id = None ):


### PR DESCRIPTION
## Description of the change

Listing orgs from a user key could fail with a 431 because the JWT from LC was too big. This JWT is not actually required for this call, so we add the flag to not attach it to the request.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


