### PR TITLE
adding the uid, if it's available, to the manager configuration in order to allow the use of user API keys

### DIFF
--- a/limacharlie/Search.py
+++ b/limacharlie/Search.py
@@ -114,8 +114,12 @@ class Search( object ):
 
     def _queryThread( self, results, envName, env, iocType, iocName, info, isCaseInsensitive, isWithWildcards, limit, isPerIoc ):
         try:
-            lc = Manager( env[ 'oid' ], env[ 'api_key' ] )
-
+            # If using a user API key, pass the uid parameter from the env var
+            try:
+                lc = Manager( env[ 'oid' ], env[ 'api_key' ], uid=env['uid'] )
+            except:
+                lc = Manager( env[ 'oid' ], env[ 'api_key' ] )
+                
             try:
                 isInsightEnabled = lc.isInsightEnabled()
             except:


### PR DESCRIPTION
## Description of the change

Adding the `uid`, if it's available, to the manager configuration in order to allow the use of user API keys. Otherwise, when using a uid in the `~/.limacharlie` file, it doesn't get picked up when trying to run IOC searches across multiple environments using a user API key.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
