### PR TITLE
Adding `service_name` to list of indicator types

### DIFF
--- a/limacharlie/Manager.py
+++ b/limacharlie/Manager.py
@@ -684,7 +684,7 @@ class Manager( object ):
             a dict with the requested information.
         '''
         infoTypes = ( 'summary', 'locations' )
-        objTypes = ( 'user', 'domain', 'ip', 'hash', 'file_path', 'file_name' )
+        objTypes = ( 'user', 'domain', 'ip', 'file_hash', 'file_path', 'file_name', 'service_name' )
 
         if info not in infoTypes:
             raise Exception( 'invalid information type: %s, choose one of %s' % ( info, infoTypes ) )

--- a/limacharlie/Search.py
+++ b/limacharlie/Search.py
@@ -21,7 +21,8 @@ validIOCs = (
     'file_hash',
     'file_name',
     'file_path',
-    'ip', 'domain',
+    'ip', 
+    'domain',
     'user',
     'service_name',
 )


### PR DESCRIPTION
## Description of the change

Adding `service_name` to list of indicator types--was previously listed in the help but not actually usable when running `limacharlie search -t "service_name" ...`.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


