### PR TITLE
Remove requirement for TTL when adding a tag to a sensor

### DIFF
--- a/limacharlie/Sensor.py
+++ b/limacharlie/Sensor.py
@@ -166,7 +166,7 @@ class Sensor( object ):
                     return allResponses
         return None
 
-    def tag( self, tag, ttl ):
+    def tag( self, tag, ttl=None ):
         '''Apply a Tag to the Sensor.
 
         Args:
@@ -176,8 +176,10 @@ class Sensor( object ):
         Returns:
             the REST API response (JSON).
         '''
-
-        req = { 'tags' : str( tag ), 'ttl' : int( ttl ) }
+        if ttl is not None:
+            req = { 'tags' : str( tag ), 'ttl' : int( ttl ) }
+        else:
+            req = { 'tags' : str( tag ) }
         return self._manager._apiCall( '%s/tags' % self.sid, POST, req )
 
     def untag( self, tag ):


### PR DESCRIPTION
## Description of the change

The `sensor.tag` function required you to provide a TTL, even if you didn't want/need one to be applied. Set the default to `None` in the event that there was no need for a TTL to be set and an error is no longer returned when simply sending `sensor.tag("tag")`.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

## Describe multi-tenancy segmentation

