### PR TITLE
Specify yaml v1.1 for infra as code for Go compat.

### DIFF
--- a/limacharlie/Configs.py
+++ b/limacharlie/Configs.py
@@ -181,7 +181,7 @@ class Configs( object ):
 
                 if not isinstance( toConfigFile, dict ):
                     with open( toConfigFile, 'wb' ) as f:
-                        f.write( yaml.safe_dump( asConf, default_flow_style = False ).encode() )
+                        f.write( yaml.safe_dump( asConf, default_flow_style = False, version = (1,1) ).encode() )
             except:
                 print( "An error occurred while fetching changes from via the infrastructure-service, you may use the --use-local-logic flag if you want to proceed without the service" % ( self._man._oid, ) )
                 raise
@@ -269,7 +269,7 @@ class Configs( object ):
             asConf[ 'net-policies' ] = policies
         if not isinstance( toConfigFile, dict ):
             with open( toConfigFile, 'wb' ) as f:
-                f.write( yaml.safe_dump( asConf, default_flow_style = False ).encode() )
+                f.write( yaml.safe_dump( asConf, default_flow_style = False, version = (1,1) ).encode() )
 
     def push( self, fromConfigFile, isForce = False, isDryRun = False, isIgnoreInaccessible = False, isRules = False, isFPs = False, isOutputs = False, isIntegrity = False, isArtifact = False, isExfil = False, isResources = False, isNetPolicy = False, isOrgConfigs = False, isHives={}, isVerbose = False ):
         '''Apply the configuratiion in a local config file to the effective configuration in the cloud.
@@ -331,7 +331,7 @@ class Configs( object ):
                         exfilRules[ 'list' ][ ruleName ] = self._wrapExfilContent( rule )
                     asConf[ 'exfil' ] = exfilRules
 
-                finalConfig = yaml.safe_dump( asConf )
+                finalConfig = yaml.safe_dump( asConf, version = (1,1) )
                 data = self._man.serviceRequest( 'infrastructure-service', {
                     'is_dry_run' : isDryRun,
                     'action' : 'push',


### PR DESCRIPTION
## Description of the change

The Golang YAML libs support yaml v1.1, not 1.2, so make the infra as code in python output in 1.1.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


