### PR TITLE
Environment variable parsing support for Config files

### DIFF
--- a/limacharlie/Configs.py
+++ b/limacharlie/Configs.py
@@ -18,6 +18,14 @@ import yaml
 import json
 import glob
 
+# Custom node constructor to handle !ENV
+# tags and replace them with an ENV value
+def env_constructor(loader, node):
+  value = loader.construct_scalar(node)
+  return os.getenv(value)
+
+yaml.SafeLoader.add_constructor('!ENV', env_constructor)
+
 class LcConfigException( Exception ):
     pass
 

--- a/limacharlie/Configs.py
+++ b/limacharlie/Configs.py
@@ -2,7 +2,7 @@ from .Manager import Manager
 from .Replicants import Integrity
 from .Replicants import Logging
 from .Replicants import Exfil
-from .utils import _isStringCompat
+from .utils import _isStringCompat, _enable_env_parsing
 from .Extensions import Extension
 
 # Detect if this is Python 2 or 3
@@ -18,13 +18,7 @@ import yaml
 import json
 import glob
 
-# Custom node constructor to handle !ENV
-# tags and replace them with an ENV value
-def env_constructor(loader, node):
-  value = loader.construct_scalar(node)
-  return os.getenv(value)
-
-yaml.SafeLoader.add_constructor('!ENV', env_constructor)
+_enable_env_parsing()
 
 class LcConfigException( Exception ):
     pass

--- a/limacharlie/utils.py
+++ b/limacharlie/utils.py
@@ -8,6 +8,8 @@ if sys.version_info[ 0 ] < 3:
 
 import threading
 import time
+import yaml
+import os
 
 class LcApiException ( Exception ):
     '''Exception type used for various errors in the LimaCharlie SDK.'''
@@ -232,3 +234,12 @@ class Spinner:
         time.sleep(self.delay)
         if exception is not None:
             return False
+
+# Custom YAML node constructor to handle !ENV
+# tags and replace them with an ENV value
+def _env_constructor(loader, node):
+  value = loader.construct_scalar(node)
+  return os.getenv(value)
+
+def _enable_env_parsing():
+    yaml.SafeLoader.add_constructor('!ENV', _env_constructor)

--- a/limacharlie/utils.py
+++ b/limacharlie/utils.py
@@ -239,7 +239,12 @@ class Spinner:
 # tags and replace them with an ENV value
 def _env_constructor(loader, node):
   value = loader.construct_scalar(node)
-  return os.getenv(value)
+  env_value = os.getenv(value)
+  # Raise an error if the variable is not set
+  if env_value is None:
+    raise ValueError(f"Environment variable {value} is not set.")
+  else:
+    return env_value
 
 def _enable_env_parsing():
     yaml.SafeLoader.add_constructor('!ENV', _env_constructor)


### PR DESCRIPTION
## Description of the change
These changes add support for usage of environment variables in Yaml config files(currently only enabled in the Config module). 
PyYaml supports node tagging, so this uses a custom constructor that replaces nodes tagged with `!ENV` with an environment variable with the same name.

This step will explicitly error if a variable is not set.

Example:
```
foo: !ENV MY_VAR
```
The value for `foo` would be set to the value of the MY_VAR variable.  


## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

N/A

## Describe multi-tenancy segmentation
N/A
