### PR TITLE
Convert rules svc to ext

### DIFF
--- a/limacharlie/Extensions.py
+++ b/limacharlie/Extensions.py
@@ -23,28 +23,85 @@ class Extension( object ):
             dnr = getattr(hive_record, 'data', None)
             if dnr is not None:
                 stringDnr = str(dnr)
-                if "'action': 'service request', 'name': 'zeek'" in stringDnr:
-                    new_dnr_string = stringDnr.replace(
-                        "'action': 'service request', 'name': 'zeek', 'request': {'action': 'run_on', ", 
-                        "'action': 'extension request', 'extension action': 'run_on', 'extension name': 'ext-zeek', 'extension request': {"
-                        )
+                if extName == 'ext-zeek' and "'action': 'service request', 'name': 'zeek'" in stringDnr:
+                    detect = dnr.get('detect', None)
+                    resp_items = dnr.get('respond', None)
+                    updated_respond = []
+                    if resp_items is not None and detect is not None:                    
+                        # filter respond block, check "action: service request"                
+                        for resp_item in resp_items:
+                                if resp_item['action'] == 'service request':                                     
+                                    # check if org actually has ext installed // send out error if no [Max said to leave this till later]
+                                    request = resp_item['request']
+                                    art_id = '{{ .routing.sid }}' if request['artifact_id'] == '<<routing/log_id>>' else make_transform_exp(request['artifact_id'])
+                                    ext_resp = {
+                                            "action": "extension request",
+                                            "extension action": "run_on",
+                                            "extension name": "ext-zeek",
+                                            "extension request": {
+                                                "artifact_id": art_id,
+                                                "retention": request['retention']
+                                            },
+                                        }
+                                    updated_respond.append(ext_resp)
+                                else :
+                                    updated_respond.append(resp_item)
+                    new_dnr = {
+                                "detect": detect,
+                                "respond": updated_respond,
+                        }
                     zeek_changed_rule = {
                         'r_name': rule_name,
-                        'old_dnr': stringDnr,
-                        'new_dnr': new_dnr_string,
+                        'old_dnr': json.dumps(dnr, indent=2),
+                        'new_dnr': json.dumps(new_dnr, indent=2),
                     }
-                    updated_rules.append(zeek_changed_rule)
+                    updated_rules.append(zeek_changed_rule)  
+                        
+                # stringDnr = str(dnr)
+                # if "'action': 'service request'," in stringDnr:
+                #     print(stringDnr)
+                if "'action': 'service request', 'name': 'atomic-red-team'" in stringDnr:
+                    print(f"Atomic Red Team rule: {stringDnr}")
+                if "'action': 'service request', 'name': 'dumper'" in stringDnr:
+                    print(f"Dumper rule: {stringDnr}")
+                if "'action': 'service request', 'name': 'exfil'" in stringDnr:
+                    print(f"Exfil rule: {stringDnr}")
+                if "'action': 'service request', 'name': 'integrity'" in stringDnr:
+                    print(f"Integrity rule: {stringDnr}")
+                if "'action': 'service request', 'name': 'pager-duty'" in stringDnr:
+                    print(f"Pager-Duty rule: {stringDnr}")
+                if "'action': 'service request', 'name': 'reliable-tasking'" in stringDnr:
+                    print(f"Reliable-tasking rule: {stringDnr}")
+                if "'action': 'service request', 'name': 'sensor-cull'" in stringDnr:
+                    print(f"Sensor-cull rule: {stringDnr}")
+                if "'action': 'service request', 'name': 'snapattack'" in stringDnr:
+                    print(f"Snapattack rule: {stringDnr}")
+                if "'action': 'service request', 'name': 'velociraptor'" in stringDnr:
+                    print(f"Velociraptor rule: {stringDnr}")
+                if "'action': 'service request', 'name': 'yara'" in stringDnr:
+                    print(f"Yara rule: {stringDnr}")
+                # if "'action': 'service request', 'name': 'zeek'" in stringDnr:
+                    # new_dnr_string = stringDnr.replace(
+                    #     "'action': 'service request', 'name': 'zeek', 'request': {'action': 'run_on', ", 
+                    #     "'action': 'extension request', 'extension action': 'run_on', 'extension name': 'ext-zeek', 'extension request': {"
+                    #     )
+                    # zeek_changed_rule = {
+                    #     'r_name': rule_name,
+                    #     'old_dnr': stringDnr,
+                    #     'new_dnr': new_dnr_string,
+                    # }
+                    # updated_rules.append(zeek_changed_rule)
+
         #  if isDryRun, don't send request, print changes
         if isDryRun and len(updated_rules) > 0:
             for updated_rule in updated_rules:
                 print(f"Dry run of change on rule '{updated_rule['r_name']}':")
-                print("\033[91m{{-}}{}\033[0m".format(updated_rule['old_dnr']))
-                print("\033[92m{{+}}{}\033[0m".format(updated_rule['new_dnr']))
+                print("\033[91m- {}\033[0m".format(updated_rule['old_dnr']))
+                print("\033[92m+ {}\033[0m".format(updated_rule['new_dnr']))
         if not isDryRun and len(updated_rules) > 0:
             for updated_rule in updated_rules:
-                formatted_dnr_string = updated_rule['new_dnr'].replace("'", '"')
                 data = {
-                    "data": json.loads(formatted_dnr_string)
+                    "data": updated_rule['new_dnr']
                 }
                 # hive change rule
                 try:
@@ -52,7 +109,7 @@ class Extension( object ):
                     hive.set(hr)
                 except Exception as e:
                     raise LcApiException(f"failed to create detect response for run : {e}")
-            
+      
         print("end of func")
         return  
     
@@ -202,3 +259,8 @@ def main( sourceArgs = None ):
 
 if '__main__' == __name__:
     main()
+
+
+
+def make_transform_exp(str_var):
+    return  '{{' + ' "' + str(str_var) + '" ' + '}}' 

--- a/limacharlie/Extensions.py
+++ b/limacharlie/Extensions.py
@@ -91,7 +91,6 @@ class Extension( object ):
         if isDryRun and len(updated_rules) > 0:
             for updated_rule in updated_rules:
                 print(f"Dry run of change on rule '{updated_rule['r_name']}':")
-                print(updated_rule['h_name'])
                 print("\033[91m- {}\033[0m".format(updated_rule['old_dnr'])) # print red text
                 print("\033[92m+ {}\033[0m".format(updated_rule['new_dnr'])) # print green text
         if not isDryRun and len(updated_rules) > 0:

--- a/limacharlie/Extensions.py
+++ b/limacharlie/Extensions.py
@@ -240,6 +240,16 @@ def convert_response(req, extName):
         sid = '{{ .routing.sid }}' if req['sid'] == '<<routing/sid>>' else make_transform_exp(req['sid'])
     if 'arifact_id' in req:
         art_id = '{{ .routing.log_id }}' if req['artifact_id'] == '<<routing/log_id>>' else make_transform_exp(req['artifact_id'])
+    if 'oid' in req: 
+        oid = '{{ .routing.oid }}' if req['oid'] == '<<routing/oid>>' else make_transform_exp(req['oid'])
+    if 'arch' in req: 
+        arch = '{{ .routing.arch }}' if req['arch'] == '<<routing/arch>>' else req['arch']
+    if 'plat' in req: 
+        plat = '{{ .routing.plat }}' if req['plat'] == '<<routing/plat>>' else req['plat']
+    if 'tags' in req: 
+        tags = '{{ .routing.tags }}' if req['tags'] == '<<routing/tags>>' else req['tags']
+    if 'iid' in req: 
+        iid = '{{ .routing.iid }}' if req['iid'] == '<<routing/iid>>' else make_transform_exp(req['iid'])
     if extName == "ext-zeek":
         ext_zeek_resp = {
             "action": "extension request",
@@ -309,15 +319,20 @@ def convert_response(req, extName):
             }
         }
         return ext_yara_scan_resp
-    elif extName == 'ext-yara' and req['action'] == 'scan_event':
+    elif extName == 'ext-yara' and req['action'] == 'sync':
         ext_yara_scan_event_resp = {
             "action": "extension request",
             "extension action": "scan_event",
             "extension name": "ext-yara",
             "extension request": {
+                "last_updated": req['last_updated'],
                 "sid": sid,
-                "inv_id": req['inv_id'],
-                "event": '{{ .event }}', ### What????
+                "oid": oid, 
+                "plat": plat,
+                "iid": iid, 
+                "arch": arch,
+                "tags": tags,
+                
             }
         }
         return ext_yara_scan_event_resp

--- a/limacharlie/Extensions.py
+++ b/limacharlie/Extensions.py
@@ -13,123 +13,6 @@ class Extension( object ):
     def __init__( self, manager ):
         self._manager = manager
 
-    def convert_rules(self, extName, isDryRun = True): 
-        updated_rules = []
-        # hive get all rules
-        hive = Hive.Hive(self._manager, "dr-general")
-        gen_dr_rules = hive.list()
-        for rule_name in gen_dr_rules:
-            hive_record = hive.get(rule_name)
-            dnr = getattr(hive_record, 'data', None)
-            if dnr is not None:
-                stringDnr = str(dnr)
-                if extName == 'ext-zeek' and "'action': 'service request', 'name': 'zeek'" in stringDnr:
-                    detect = dnr.get('detect', None)
-                    resp_items = dnr.get('respond', None)
-                    updated_respond = []
-                    if resp_items is not None and detect is not None:                    
-                        # filter respond block, check "action: service request"                
-                        for resp_item in resp_items:
-                                if resp_item['action'] == 'service request':                                     
-                                    # check if org actually has ext installed // send out error if no [Max said to leave this till later]
-                                    request = resp_item['request']
-                                    art_id = '{{ .routing.sid }}' if request['artifact_id'] == '<<routing/log_id>>' else make_transform_exp(request['artifact_id'])
-                                    ext_resp = {
-                                            "action": "extension request",
-                                            "extension action": "run_on",
-                                            "extension name": "ext-zeek",
-                                            "extension request": {
-                                                "artifact_id": art_id,
-                                                "retention": request['retention']
-                                            },
-                                        }
-                                    updated_respond.append(ext_resp)
-                                else :
-                                    updated_respond.append(resp_item)
-                    new_dnr = {
-                                "detect": detect,
-                                "respond": updated_respond,
-                        }
-                    zeek_changed_rule = {
-                        'r_name': rule_name,
-                        'old_dnr': json.dumps(dnr, indent=2),
-                        'new_dnr': json.dumps(new_dnr, indent=2),
-                    }
-                    updated_rules.append(zeek_changed_rule)  
-                        
-                # stringDnr = str(dnr)
-                # if "'action': 'service request'," in stringDnr:
-                #     print(stringDnr)
-                if "'action': 'service request', 'name': 'atomic-red-team'" in stringDnr:
-                    print(f"Atomic Red Team rule: {stringDnr}")
-                if "'action': 'service request', 'name': 'dumper'" in stringDnr:
-                    print(f"Dumper rule: {stringDnr}")
-                if "'action': 'service request', 'name': 'exfil'" in stringDnr:
-                    print(f"Exfil rule: {stringDnr}")
-                if "'action': 'service request', 'name': 'integrity'" in stringDnr:
-                    print(f"Integrity rule: {stringDnr}")
-                if "'action': 'service request', 'name': 'pager-duty'" in stringDnr:
-                    print(f"Pager-Duty rule: {stringDnr}")
-                if "'action': 'service request', 'name': 'reliable-tasking'" in stringDnr:
-                    print(f"Reliable-tasking rule: {stringDnr}")
-                if "'action': 'service request', 'name': 'sensor-cull'" in stringDnr:
-                    print(f"Sensor-cull rule: {stringDnr}")
-                if "'action': 'service request', 'name': 'snapattack'" in stringDnr:
-                    print(f"Snapattack rule: {stringDnr}")
-                if "'action': 'service request', 'name': 'velociraptor'" in stringDnr:
-                    print(f"Velociraptor rule: {stringDnr}")
-                if "'action': 'service request', 'name': 'yara'" in stringDnr:
-                    print(f"Yara rule: {stringDnr}")
-                # if "'action': 'service request', 'name': 'zeek'" in stringDnr:
-                    # new_dnr_string = stringDnr.replace(
-                    #     "'action': 'service request', 'name': 'zeek', 'request': {'action': 'run_on', ", 
-                    #     "'action': 'extension request', 'extension action': 'run_on', 'extension name': 'ext-zeek', 'extension request': {"
-                    #     )
-                    # zeek_changed_rule = {
-                    #     'r_name': rule_name,
-                    #     'old_dnr': stringDnr,
-                    #     'new_dnr': new_dnr_string,
-                    # }
-                    # updated_rules.append(zeek_changed_rule)
-
-        #  if isDryRun, don't send request, print changes
-        if isDryRun and len(updated_rules) > 0:
-            for updated_rule in updated_rules:
-                print(f"Dry run of change on rule '{updated_rule['r_name']}':")
-                print("\033[91m- {}\033[0m".format(updated_rule['old_dnr']))
-                print("\033[92m+ {}\033[0m".format(updated_rule['new_dnr']))
-        if not isDryRun and len(updated_rules) > 0:
-            for updated_rule in updated_rules:
-                data = {
-                    "data": updated_rule['new_dnr']
-                }
-                # hive change rule
-                try:
-                    hr = Hive.HiveRecord(updated_rule['r_name'], data)
-                    hive.set(hr)
-                except Exception as e:
-                    raise LcApiException(f"failed to create detect response for run : {e}")
-      
-        print("end of func")
-        return  
-    
-    def migrate( self, extName ):
-        return self._manager._apiCall( 'extension/migrate/%s' % ( extName, ), POST, {
-            'oid' : self._manager._oid,
-        } )
-
-    def request( self, extName, action, data = {}, isImpersonated = False ):
-        req = {
-            'oid' : self._manager._oid,
-            'action' : action,
-            'data' : json.dumps( data ),
-        }
-        if isImpersonated:
-            if self._manager._jwt is None:
-                self._manager._refreshJWT()
-            req[ 'impersonator_jwt' ] = self._manager._jwt
-        return self._manager._apiCall( 'extension/request/%s' % ( extName, ), POST, req )
-    
     def list( self ):
         return self._manager._apiCall( 'orgs/%s/subscriptions' % ( self._manager._oid, ), GET )
 
@@ -159,7 +42,73 @@ class Extension( object ):
     
     def getSchema( self, extName ):
         return self._manager._apiCall( 'extension/schema/%s' % ( extName, ), GET )
+    
+    def migrate( self, extName ):
+        return self._manager._apiCall( 'extension/migrate/%s' % ( extName, ), POST, {
+            'oid' : self._manager._oid,
+        } )
 
+    def request( self, extName, action, data = {}, isImpersonated = False ):
+        req = {
+            'oid' : self._manager._oid,
+            'action' : action,
+            'data' : json.dumps( data ),
+        }
+        if isImpersonated:
+            if self._manager._jwt is None:
+                self._manager._refreshJWT()
+            req[ 'impersonator_jwt' ] = self._manager._jwt
+        return self._manager._apiCall( 'extension/request/%s' % ( extName, ), POST, req )
+    
+    def convert_rules(self, extName, isDryRun = True): 
+        updated_rules = []
+        # hive get all rules
+        hive = Hive.Hive(self._manager, "dr-general")
+        gen_dr_rules = hive.list()
+        for rule_name in gen_dr_rules:
+            hive_record = hive.get(rule_name)
+            dnr = getattr(hive_record, 'data', None)
+            if dnr is not None:
+                detect = dnr.get('detect', None)
+                resp_items = dnr.get('respond', None)  
+                if resp_items is not None and detect is not None:
+                    if extName == 'ext-zeek' and contains_action_name(resp_items, 'zeek'):  
+                        new_zeek_dnr = update_rule(detect, resp_items, extName)
+                        zeek_rule_data = {
+                            'r_name': rule_name,
+                            'old_dnr': json.dumps(dnr, indent=2),
+                            'new_dnr': json.dumps(new_zeek_dnr, indent=2),
+                        }
+                        updated_rules.append(zeek_rule_data)  
+                    if extName == 'ext-pagerduty' and contains_action_name(resp_items, 'pagerduty'):
+                        new_pagerduty_dnr = update_rule(detect, resp_items, extName)
+                        pagerduty_changed_rule = {
+                            'r_name': rule_name,
+                            'old_dnr': json.dumps(dnr, indent=2),
+                            'new_dnr': json.dumps(new_pagerduty_dnr, indent=2),
+                        }
+                        updated_rules.append(pagerduty_changed_rule)     
+        #  if isDryRun, don't send request, print changes
+        if isDryRun and len(updated_rules) > 0:
+            for updated_rule in updated_rules:
+                print(f"Dry run of change on rule '{updated_rule['r_name']}':")
+                print("\033[91m- {}\033[0m".format(updated_rule['old_dnr']))
+                print("\033[92m+ {}\033[0m".format(updated_rule['new_dnr']))
+        if not isDryRun and len(updated_rules) > 0:
+            for updated_rule in updated_rules:
+                data = {
+                    "data": updated_rule['new_dnr']
+                }
+                # hive change rule
+                try:
+                    hr = Hive.HiveRecord(updated_rule['r_name'], data)
+                    hive.set(hr)
+                except Exception as e:
+                    raise LcApiException(f"failed to create detect response for run : {e}")
+      
+        print("end of func")
+        return  
+    
 def printData( data ):
     if isinstance( data, str ):
         print( data )
@@ -262,5 +211,63 @@ if '__main__' == __name__:
 
 
 
+### Convert Rules Helper Functions
+def update_rule(detect, respond_items, extName):
+    print('EXT name in update_rule', extName)
+    # check if org actually has ext installed // send out error if no [Max said to leave this till later]
+    updated_respond = []
+    for resp_item in respond_items:
+        if resp_item['action'] == 'service request':
+            request = resp_item['request']
+            ext_resp = convert_response(request, extName)                                     
+            updated_respond.append(ext_resp)
+        else :
+            updated_respond.append(resp_item)
+    new_dnr = {
+        "detect": detect,
+        "respond": updated_respond,
+    }
+    return new_dnr
+
+def convert_response(req, extName):
+    if extName == "ext-zeek":
+        art_id = '{{ .routing.sid }}' if req['artifact_id'] == '<<routing/log_id>>' else make_transform_exp(req['artifact_id'])
+        ext_zeek_resp = {
+            "action": "extension request",
+            "extension action": "run_on",
+            "extension name": "ext-zeek",
+            "extension request": {
+                "artifact_id": art_id,
+                "retention": req['retention']
+            },
+        }
+        return ext_zeek_resp
+    elif extName == 'ext-pagerduty':
+        ext_pagerduty_resp = {
+            "action": "extension request",
+            "extension action": "run",
+            "extension name": "ext-pagerduty",
+            "extension request": {
+                "class": make_transform_exp(req['class']),
+                "group": make_transform_exp(req['group']),
+                "severity": make_transform_exp(req['severity']),
+                "source": make_transform_exp(req['source']),
+                "component": make_transform_exp(req['component']),
+                "summary": req['summary'],
+                "details": '{{ .event }}',
+            }
+        }
+        return ext_pagerduty_resp
+    elif extName == 'atomic-red-team':
+        return {}
+    else:
+        return {}
+    
+def contains_action_name(respond_items, svc_name):
+    for resp_item in respond_items:
+        if resp_item['action'] == 'service request' and resp_item['name'] == svc_name:
+            return True
+    return False
+ 
 def make_transform_exp(str_var):
     return  '{{' + ' "' + str(str_var) + '" ' + '}}' 

--- a/limacharlie/Extensions.py
+++ b/limacharlie/Extensions.py
@@ -80,7 +80,16 @@ class Extension( object ):
                         updated_rules.append(pagerduty_rule_data)
                     if extName == 'ext-dumper' and contains_action_name(resp_items, 'dumper'):
                         dumper_rule_data = update_rule(rule_name, dnr, detect, resp_items, extName)
-                        updated_rules.append(dumper_rule_data)       
+                        updated_rules.append(dumper_rule_data)
+                    if extName == 'ext-velociraptor' and contains_action_name(resp_items, 'velociraptor'):
+                        velociraptor_rule_data = update_rule(rule_name, dnr, detect, resp_items, extName)
+                        updated_rules.append(velociraptor_rule_data)
+                    if extName == 'ext-yara' and contains_action_name(resp_items, 'yara'):
+                        yara_rule_data = update_rule(rule_name, dnr, detect, resp_items, extName)
+                        updated_rules.append(yara_rule_data)
+                    # if extName == 'ext-reliable-tasking' and contains_action_name(resp_items, 'reliable-tasking'):
+                    #     reliable_tasking_rule_data = update_rule(rule_name, dnr, detect, resp_items, extName)
+                    #     updated_rules.append(reliable_tasking_rule_data)           
         #  if isDryRun, don't send request, print changes
         if isDryRun and len(updated_rules) > 0:
             for updated_rule in updated_rules:
@@ -259,7 +268,6 @@ def convert_response(req, extName):
         }
         return ext_pagerduty_resp
     elif extName == 'ext-dumper':
-        
         ext_dumper_resp = {
             "action": "extension request",
             "extension name": "ext-dumper",
@@ -272,6 +280,47 @@ def convert_response(req, extName):
             }
         }
         return ext_dumper_resp
+    elif extName == 'ext-velociraptor':
+        ext_velociraptor_resp = {
+            "action": "extension request",
+            "extension action": "collect",
+            "extension name": "ext-velociraptor",
+            "extension request": {
+                "artifact_list": req['artifact_list'],
+                "sid": sid,
+                "sensor_selector": make_transform_exp(req['sensor_selector']),
+                "args": make_transform_exp(req['args']),
+                "collection_ttl": req['collection_ttl'],
+                "retention_ttl": req['retention_ttl'],
+                "ignore_cert": req['ignore_cert'],
+            }
+        }
+        return ext_velociraptor_resp
+    elif extName == 'ext-yara' and req['action'] == 'scan':
+        ext_yara_scan_resp = {
+            "action": "extension request",
+            "extension action": "scan",
+            "extension name": "ext-yara",
+            "extension request": {
+                "sources": make_transform_exp(req['sources']),
+                "selector": make_transform_exp(req['selector']),
+                "sid": sid,
+                "yara_scan_ttl": req['yara_scan_ttl'],
+            }
+        }
+        return ext_yara_scan_resp
+    elif extName == 'ext-yara' and req['action'] == 'scan_event':
+        ext_yara_scan_event_resp = {
+            "action": "extension request",
+            "extension action": "scan_event",
+            "extension name": "ext-yara",
+            "extension request": {
+                "sid": sid,
+                "inv_id": req['inv_id'],
+                "event": '{{ .event }}', ### What????
+            }
+        }
+        return ext_yara_scan_event_resp
     else:
         return {}
     

--- a/limacharlie/Extensions.py
+++ b/limacharlie/Extensions.py
@@ -1,5 +1,6 @@
 from limacharlie import Manager
 import json
+import Hive
 
 from .utils import POST
 from .utils import DELETE
@@ -11,6 +12,18 @@ class Extension( object ):
     def __init__( self, manager ):
         self._manager = manager
 
+    def convert_rules(self, extName):
+        # hive get all rules
+        # filter respond block, check "action: service request"
+        if extName == 'ext-zeek':
+            # check if org actually has ext installed // send out error if no [Max said to leave this till later]
+            # switch lines to extension lines
+            #  if isDryRun, don't send request, print changes
+            #  if not isDryRun:
+                # hive change rule
+            return
+
+        return 
     def migrate( self, extName ):
         return self._manager._apiCall( 'extension/migrate/%s' % ( extName, ), POST, {
             'oid' : self._manager._oid,
@@ -89,6 +102,9 @@ def _do_request( args, ext ):
         data = json.loads( args.data )
     printData( ext.request( args.name, args.ext_action, data, isImpersonated = args.impersonated ) )
 
+def _do_convert_rules(args, ext):
+    printData( ext.convert_rules( args.name, isDryRun = args.impersonated ) )
+
 def main( sourceArgs = None ):
     import argparse
 
@@ -100,6 +116,7 @@ def main( sourceArgs = None ):
         'get' : _do_get,
         'get_schema' : _do_get_schema,
         'request' : _do_request,
+        'convert_rules': _do_convert_rules,
     }
 
     parser = argparse.ArgumentParser( prog = 'limacharlie extension' )
@@ -138,6 +155,13 @@ def main( sourceArgs = None ):
                          dest = 'environment',
                          default = None,
                          help = 'the name of the LimaCharlie environment (as defined in ~/.limacharlie) to use, otherwise global creds will be used.' )
+
+    parser.add_argument( '--dry-run',
+                            action = 'store_true',
+                            default = None,
+                            required = False,
+                            dest = 'isDryRun',
+                            help = 'the convert-rules request will be simulated and all rule conversions will be displayed (default is True)' )
 
     args = parser.parse_args( sourceArgs )
 


### PR DESCRIPTION
## Description of the change
New cli command and logic added that converts an org's `dr-general` and `dr-managed` rules using old service request calls into new extension requests

Syntax checks for rules verified in [notion doc](https://www.notion.so/Svc-ext-rules-8b1e189b43bc4a01b821d84b862d29aa)

Rules impacted:
- dumper
- pager-duty
- reliable-tasking
- velociraptor
- yara
- zeek

📷 Sample of cli response from Dry Run of command:
![Screenshot 2024-02-28 9 19 13 PM](https://github.com/refractionPOINT/python-limacharlie/assets/139172067/9ebaa8f1-f5c1-49df-8efc-d585808df837)



## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

