### PR TITLE
fix incorrect args reference

### DIFF
--- a/limacharlie/Extensions.py
+++ b/limacharlie/Extensions.py
@@ -140,7 +140,7 @@ def _do_request( args, ext ):
     printData( ext.request( args.name, args.ext_action, data, isImpersonated = args.impersonated ) )
 
 def _do_convert_rules(args, ext):
-    printData( ext.convert_rules( args.name, isDryRun = args.impersonated ) )
+    printData( ext.convert_rules( args.name, isDryRun = args.isDryRun ) )
 
 def main( sourceArgs = None ):
     import argparse


### PR DESCRIPTION
## Description of the change
Quick fix. Noticed there was an incorrect args reference. Was affecting cli command syntax when I was playing with it.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

