### PR TITLE
add some unixish error handling (STDERR and return 1 on error)

### DIFF
--- a/limacharlie/__main__.py
+++ b/limacharlie/__main__.py
@@ -387,13 +387,14 @@ def cli():
         print(json.dumps(Manager().getMITREReport(), indent = 2))
     else:
         raise Exception( 'invalid action' )
-    
+
 def main():
     try:
         cli()
     except Exception as e:
-        print("Error:", e)
+        print("Error:", e,file=sys.stderr)
+        return 1
 
 if __name__ == "__main__":
-    main()
- 
+    sys.exit(main())
+


### PR DESCRIPTION
## Description of the change

> Adds UNIX-like handling of errors to the CLI.  Specifically, if an exception is returned from the CLI call it returns an error code of 1 and outputs the error on STDERR.  Potentially breaking only if folks are handling errors by specifically looking at STDOUT

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues
