### PR TITLE
fix [refractionPOINT/tracking#3025] Fix Docker image build + push workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@
 
 - Docker image has been updated to be based on top of `python:3.12-slim`.
 
+- Docker images are now versioned. In addition to the `latest` tag, new version
+  specific tags will be available going forward, starting with this release.
+
+  For example:
+
+  * `refractionpoint/limacharlie:latest` -> Always points to the latest release.
+  * `refractionpoint/limacharlie:4.9.13` -> Release version 4.9.13.
+
 ## 4.9.12 - February 21st, 2025
 
 - Add `whoami` alias for `who` command.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 4.9.13 - In Development
+## 4.9.13 - February 24th, 2025
 
 - Fix Docker image build.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 4.9.13 - In Development
+
+- Fix Docker image build.
+
+- Docker image has been updated to be based on top of `python:3.12-slim`.
+
 ## 4.9.12 - February 21st, 2025
 
 - Add `whoami` alias for `who` command.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
-FROM python:slim
+FROM python:3.12-slim
 ADD . /python-limacharlie
 WORKDIR /python-limacharlie
+RUN python -m pip install "setuptools==75.8.0"
 RUN python ./setup.py install
 
 ENTRYPOINT [ "limacharlie" ]

--- a/README.md
+++ b/README.md
@@ -76,6 +76,18 @@ as orginally set by the CLI (600) so other users can't read it.
 If you prefer not to store credentials in a plain text format in a file on disk, use an
 alternative method for authentication (e.g. environment variables, as described above).
 
+## Docker
+
+Docker image with latest version of the tool is available at https://hub.docker.com/r/refractionpoint/limacharlie.
+
+Example usage:
+
+```bash
+docker run refractionpoint/limacharlie:latest whoami
+
+# If you already have a credential file locally, you can mount it inside the Docker container
+docker run -v ${HOME}/.limacharlie:/root/.limacharlie:ro refractionpoint/limacharlie:latest whoami
+```
 ## SDK
 
 The root of the functionality in the SDK is from the `Manager` object. It holds the crendentials

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,16 +1,28 @@
 steps:
-- name: 'gcr.io/${PROJECT_ID}/pytest_3'
-  args: [ '-v', 'tests', '--oid', '${_OID}', '--key', '${_KEY}' ]
-- name: 'gcr.io/cloud-builders/docker'
+- id: "Run Unit Tests"
+  name: 'gcr.io/${PROJECT_ID}/pytest_3'
+  args: [ '-v', 'tests/unit/' ]
+
+- id: "Run Integration Tests"
+  name: 'gcr.io/${PROJECT_ID}/pytest_3'
+  args: [ '-v', 'tests/integration/', '--oid', '${_OID}', '--key', '${_KEY}' ]
+
+- id: "Login to DockerHub"
+  name: 'gcr.io/cloud-builders/docker'
   entrypoint: 'bash'
   args: ['-c', 'docker login --username=$$USERNAME --password=$$PASSWORD']
   secretEnv: ['USERNAME', 'PASSWORD']
-- name: 'gcr.io/cloud-builders/docker'
+
+- id: "Build Docker Image"
+  name: 'gcr.io/cloud-builders/docker'
   entrypoint: 'bash'
   args: ['-c', 'docker build -f ./Dockerfile -t refractionpoint/limacharlie:latest .']
-- name: 'gcr.io/cloud-builders/docker'
+
+- id: "Push Image to Docker Hub"
+  name: 'gcr.io/cloud-builders/docker'
   entrypoint: 'bash'
   args: ['-c', 'docker push refractionpoint/limacharlie:latest']
+
 availableSecrets:
   secretManager:
   - versionName: projects/${PROJECT_ID}/secrets/DOCKERHUB/versions/latest

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,12 +1,28 @@
 steps:
 - id: "Run Unit Tests"
-  name: 'gcr.io/${PROJECT_ID}/pytest_3'
-  args: [ '-v', 'tests/unit/' ]
+  name: "python:3.11-slim"
+  entrypoint: "bash"
+  args:
+    - "-c"
+    - |
+      pip install --upgrade pip
+      pip install -r requirements.txt
+      pip install -r requirements-tests.txt
 
-# TODO: Rebuild this image + use pytest extension to retry on failure to mitigate flaky tests
+      pytest -s -v --durations=10 --reruns 3 --reruns-delay 5 tests/unit/
+
 - id: "Run Integration Tests"
-  name: 'gcr.io/${PROJECT_ID}/pytest_3'
-  args: [ '-v', 'tests/integration/', '--oid', '${_OID}', '--key', '${_KEY}' ]
+  name: "python:3.11-slim"
+  entrypoint: "bash"
+  args:
+    - "-c"
+    - |
+      pip install --upgrade pip
+      pip install -r requirements.txt
+      pip install -r requirements-tests.txt
+
+      # We use rerun since tests are flaky
+      pytest -s -v --durations=10 --reruns 3 --reruns-delay 10 tests/integration/ --oid=${_OID} --key=${_KEY}
 
 - id: "Login to DockerHub"
   name: 'gcr.io/cloud-builders/docker'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -3,6 +3,7 @@ steps:
   name: 'gcr.io/${PROJECT_ID}/pytest_3'
   args: [ '-v', 'tests/unit/' ]
 
+# TODO: Rebuild this image + use pytest extension to retry on failure to mitigate flaky tests
 - id: "Run Integration Tests"
   name: 'gcr.io/${PROJECT_ID}/pytest_3'
   args: [ '-v', 'tests/integration/', '--oid', '${_OID}', '--key', '${_KEY}' ]

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -24,6 +24,17 @@ steps:
       # We use rerun since tests are flaky
       pytest -s -v --durations=10 --reruns 3 --reruns-delay 10 tests/integration/ --oid=${_OID} --key=${_KEY}
 
+- id: "Get Version"
+  name: "python:3.11-slim"
+  entrypoint: "bash"
+  args:
+    - "-c"
+    - |
+      _VERSION=$(python setup.py --version 2> /dev/null)
+      [ -n "$$_VERSION" ] || { echo "ERROR: _VERSION is empty or not set"; exit 1; };
+      echo $$_VERSION > version.txt
+      echo "Using Docker tag version: $$_VERSION"
+
 - id: "Login to DockerHub"
   name: 'gcr.io/cloud-builders/docker'
   entrypoint: 'bash'
@@ -33,12 +44,26 @@ steps:
 - id: "Build Docker Image"
   name: 'gcr.io/cloud-builders/docker'
   entrypoint: 'bash'
-  args: ['-c', 'docker build -f ./Dockerfile -t refractionpoint/limacharlie:latest .']
+  args:
+    - "-c"
+    - |
+      _VERSION=$(cat version.txt)
+      [ -n "$$_VERSION" ] || { echo "ERROR: _VERSION is empty or not set"; exit 1; };
+      docker build -f ./Dockerfile \
+        -t refractionpoint/limacharlie:latest \
+        -t refractionpoint/limacharlie:$$_VERSION \
+        .
 
 - id: "Push Image to Docker Hub"
   name: 'gcr.io/cloud-builders/docker'
   entrypoint: 'bash'
-  args: ['-c', 'docker push refractionpoint/limacharlie:latest']
+  args:
+    - "-c"
+    - |
+      _VERSION=$(cat version.txt)
+      [ -n "$$_VERSION" ] || { echo "ERROR: _VERSION is empty or not set"; exit 1; };
+      docker push refractionpoint/limacharlie:latest
+      docker push refractionpoint/limacharlie:$$_VERSION || true
 
 availableSecrets:
   secretManager:

--- a/cloudbuild_pr.yaml
+++ b/cloudbuild_pr.yaml
@@ -26,7 +26,7 @@ steps:
       pytest -s -v --durations=10 --reruns 3 --reruns-delay 10 tests/integration/ --oid=${_OID} --key=${_KEY}
   waitFor: ["-"]  # Run in parallel with other steps.
 
-- id: "Run dist sanity checks"
+- id: "Run wheel Sanity Checks"
   name: 'python:3.9-slim'
   entrypoint: "bash"
   args:
@@ -40,6 +40,7 @@ steps:
       pip install --upgrade pip setuptools wheel build
 
       # Build package
+      rm -rf dist/*
       python -m build
 
       # Install it
@@ -49,3 +50,28 @@ steps:
       pip show limacharlie
       limacharlie version
   waitFor: ["-"]  # Run in parallel with other steps.
+
+- id: "Run sdist Sanity Checks"
+  name: 'python:3.9-slim'
+  entrypoint: "bash"
+  args:
+    - '-c'
+    - |
+      set -e
+
+      cd /workspace/
+
+      # Install deps
+      pip install --upgrade pip setuptools wheel build
+
+      # Build package
+      rm -rf dist/*
+      python -m build
+
+      # Install it
+      pip install dist/limacharlie-*.tar.gz
+
+      # Verify it works (basic sanity check)
+      pip show limacharlie
+      limacharlie version
+  waitFor: ["Run wheel Sanity Checks"]  # This can't run in parallel with previous step since it shares workspace

--- a/cloudbuild_pr.yaml
+++ b/cloudbuild_pr.yaml
@@ -1,13 +1,29 @@
 steps:
 - id: "Run Unit Tests"
-  name: 'gcr.io/${PROJECT_ID}/pytest_3'
-  args: [ '-v', 'tests/unit/' ]
+  name: "python:3.11-slim"
+  entrypoint: "bash"
+  args:
+    - "-c"
+    - |
+      pip install --upgrade pip
+      pip install -r requirements.txt
+      pip install -r requirements-tests.txt
+
+      pytest -s -v --durations=10 --reruns 3 --reruns-delay 5 tests/unit/
   waitFor: ["-"]  # Run in parallel with other steps.
 
-# TODO: Rebuild this image + use pytest extension to retry on failure to mitigate flaky tests
 - id: "Run Integration Tests"
-  name: 'gcr.io/${PROJECT_ID}/pytest_3'
-  args: [ '-v', 'tests/integration/', '--oid', '${_OID}', '--key', '${_KEY}' ]
+  name: "python:3.11-slim"
+  entrypoint: "bash"
+  args:
+    - "-c"
+    - |
+      pip install --upgrade pip
+      pip install -r requirements.txt
+      pip install -r requirements-tests.txt
+
+      # We use rerun since tests are flaky
+      pytest -s -v --durations=10 --reruns 3 --reruns-delay 10 tests/integration/ --oid=${_OID} --key=${_KEY}
   waitFor: ["-"]  # Run in parallel with other steps.
 
 - id: "Run dist sanity checks"

--- a/cloudbuild_pr.yaml
+++ b/cloudbuild_pr.yaml
@@ -4,6 +4,7 @@ steps:
   args: [ '-v', 'tests/unit/' ]
   waitFor: ["-"]  # Run in parallel with other steps.
 
+# TODO: Rebuild this image + use pytest extension to retry on failure to mitigate flaky tests
 - id: "Run Integration Tests"
   name: 'gcr.io/${PROJECT_ID}/pytest_3'
   args: [ '-v', 'tests/integration/', '--oid', '${_OID}', '--key', '${_KEY}' ]

--- a/limacharlie/__init__.py
+++ b/limacharlie/__init__.py
@@ -1,6 +1,6 @@
 """limacharlie API for limacharlie.io"""
 
-__version__ = "4.9.12"
+__version__ = "4.9.13"
 __author__ = "Maxime Lamothe-Brassard ( Refraction Point, Inc )"
 __author_email__ = "maxime@refractionpoint.com"
 __license__ = "Apache v2"

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,0 +1,2 @@
+pytest==8.3.4
+pytest-rerunfailures==15.0

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-__version__ = "4.9.12"
+__version__ = "4.9.13"
 __author__ = "Maxime Lamothe-Brassard ( Refraction Point, Inc )"
 __author_email__ = "maxime@refractionpoint.com"
 __license__ = "Apache v2"


### PR DESCRIPTION
# Description

This pull request should fix the Cloud Build workflow which runs on `master` branch and builds + publishes Docker Image to Docker Hub.

## Other Improvements

* Re-try flaky tests on failures (common issue with integration tests)
* Test build + verify .tar.gz source distribution
* Version Docker images - in addition to `latest` also publish tag which corresponds to the tool version

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related issues

Fix refractionPOINT/tracking#3051