### PR TITLE
Handle jwt-only auth errors better.

### DIFF
--- a/limacharlie/Manager.py
+++ b/limacharlie/Manager.py
@@ -281,6 +281,11 @@ class Manager( object ):
                     if self._onRefreshAuth is not None:
                         self._onRefreshAuth( self )
                     else:
+                        if self._jwt is not None and self._api_key is None:
+                            # This is a case where we likely initialized the manager with a JWT,
+                            # but no API key. In this case, we can't refresh the JWT, so we'll
+                            # just fail.
+                            raise LcApiException( 'Auth error and no API key available: oid=%s uid=%s: %s' % ( self._oid, self._uid, data, ), code=code)
                         self._refreshJWT()
                     continue
                 else:


### PR DESCRIPTION
## Description of the change

When using a JWT-only SDK, if we get an auth error, there is no way for us to refresh the JWT since we don't have an API key, so we will never get ourselves out of the auth error. So instead of reporting an error down the line about missing an API key, return the original auth error here.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
