### PR TITLE
spotcheck: fix argument parsing

### DIFF
--- a/limacharlie/SpotCheck.py
+++ b/limacharlie/SpotCheck.py
@@ -396,7 +396,7 @@ def main( sourceArgs = None ):
                     bytes.fromhex( hash )
                 except:
                     raise Exception( 'hash contains invalid characters' )
-            response = sensor.simpleRequest( 'dir_find_hash "%s" "%s" -d %s --hash %s' % ( directory.replace( "\\", "\\\\" ), filePattern, depth , hash ), timeout = 3600 )
+            response = sensor.simpleRequest( 'dir_find_hash "%s" "%s" %s %s' % ( directory.replace( "\\", "\\\\" ), filePattern, depth , hash ), timeout = 3600 )
             if not response:
                 raise Exception( 'timeout' )
 


### PR DESCRIPTION
## Description of the change

Arguments for dir_find_hash changed a while ago and were not reflected in the python library. Remove -d and --hash that aren't required anymore

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

Fix refractionPOINT/tracking#3516
