### PR TITLE
Add OAuth authentication support

### DIFF
--- a/OAUTH_README.md
+++ b/OAUTH_README.md
@@ -1,0 +1,151 @@
+# LimaCharlie OAuth Authentication
+
+This document describes the OAuth authentication feature for the LimaCharlie CLI.
+
+## Overview
+
+The LimaCharlie CLI now supports OAuth authentication as an alternative to API keys. This allows users to authenticate using their Google account through a browser-based flow, similar to Firebase CLI and other modern tools.
+
+## Features
+
+- **Browser-based authentication**: Opens your default browser for secure authentication
+- **Automatic token refresh**: Tokens are automatically refreshed when they expire
+- **Backward compatibility**: Existing API key authentication continues to work unchanged
+- **Multiple environments**: OAuth credentials can be stored per environment
+- **Secure credential storage**: OAuth tokens are stored with the same security as API keys
+
+## Usage
+
+### Basic OAuth Login
+
+```bash
+limacharlie login --oauth
+```
+
+This will:
+1. Start a local HTTP server on a random port
+2. Open your browser to the Google OAuth page
+3. After authentication, redirect back to the local server
+4. Exchange the authorization code for Firebase tokens
+5. Store the tokens securely in `~/.limacharlie`
+
+### OAuth Login Without Browser
+
+If you're on a headless system or prefer to copy/paste the URL:
+
+```bash
+limacharlie login --oauth --no-browser
+```
+
+### OAuth Login with Organization ID
+
+```bash
+limacharlie login --oauth --oid YOUR-ORG-ID
+```
+
+### OAuth Login to Named Environment
+
+```bash
+limacharlie login --oauth --environment production
+```
+
+## Configuration
+
+OAuth credentials are stored in the same configuration file as API keys (`~/.limacharlie`):
+
+```yaml
+# Default OAuth credentials
+oid: your-org-id
+oauth:
+  id_token: <firebase-id-token>
+  refresh_token: <refresh-token>
+  expires_at: <unix-timestamp>
+  provider: google
+
+# Named environment with OAuth
+env:
+  production:
+    oid: prod-org-id
+    oauth:
+      id_token: <token>
+      refresh_token: <token>
+      expires_at: <timestamp>
+      provider: google
+```
+
+## Environment Variables
+
+The OAuth feature requires Firebase configuration. These can be set via environment variables:
+
+- `LC_FIREBASE_API_KEY`: Your Firebase Web API key
+- `LC_FIREBASE_AUTH_DOMAIN`: Your Firebase auth domain (e.g., `project.firebaseapp.com`)
+- `LC_GOOGLE_CLIENT_ID`: Your Google OAuth client ID
+
+## Checking Authentication Status
+
+To see your current authentication method and status:
+
+```bash
+limacharlie who
+```
+
+Output for OAuth authentication:
+```
+OID: your-org-id
+UID: your-user-id
+AUTH: OAuth (Provider: google)
+TOKEN: Valid for 45 minutes
+PERMISSIONS:
+  ...
+```
+
+## Token Management
+
+- Tokens are automatically refreshed when they expire
+- The CLI checks token expiry with a 5-minute buffer
+- Refresh tokens are used to obtain new ID tokens without re-authentication
+
+## Backward Compatibility
+
+All existing functionality remains unchanged:
+
+### Traditional API Key Login
+```bash
+limacharlie login
+# Or with arguments:
+limacharlie login --oid ORG-ID --api-key YOUR-KEY
+```
+
+### Using API Keys
+Organizations using API keys will continue to work without any changes.
+
+## Security Considerations
+
+1. OAuth tokens are stored with the same file permissions (600) as API keys
+2. The local callback server only accepts connections from localhost
+3. Authorization codes are single-use and expire quickly
+4. Refresh tokens should be kept secure as they provide long-term access
+
+## Troubleshooting
+
+### Browser doesn't open
+Use `--no-browser` flag and manually copy/paste the URL
+
+### Port conflicts
+The callback server automatically finds a free port. If issues persist, check firewall settings.
+
+### Token expired
+The CLI automatically refreshes expired tokens. If refresh fails, re-authenticate with `limacharlie login --oauth`
+
+### Invalid configuration
+Ensure the required Firebase environment variables are set correctly
+
+## Implementation Details
+
+The OAuth feature is implemented in:
+- `limacharlie/oauth.py`: Main OAuth flow logic
+- `limacharlie/oauth_server.py`: Local callback server
+- `limacharlie/__main__.py`: CLI command updates
+- `limacharlie/Manager.py`: OAuth token handling in API calls
+
+The implementation follows OAuth 2.0 best practices and integrates with Firebase Authentication for token management.

--- a/limacharlie/__init__.py
+++ b/limacharlie/__init__.py
@@ -18,7 +18,7 @@ def _getEnvironmentCreds( name ):
     if credsFile is None:
         credsFile = CONFIG_FILE_PATH
     if not os.path.isfile( credsFile ):
-        return ( None, None, None )
+        return ( None, None, None, None )
     with open( credsFile, 'rb' ) as f:
         credsFile = yaml.safe_load( f.read() )
 
@@ -27,18 +27,20 @@ def _getEnvironmentCreds( name ):
             oid = credsFile.get( 'oid', None )
             uid = credsFile.get( 'uid', None )
             key = credsFile.get( 'api_key', None )
+            oauth = credsFile.get( 'oauth', None )
 
-            return ( oid, uid, key )
+            return ( oid, uid, key, oauth )
 
         if name not in credsFile.get( 'env', {} ):
-            return ( None, None, None )
+            return ( None, None, None, None )
 
         envData = credsFile[ 'env' ][ name ]
         oid = envData.get( 'oid', None )
         uid = envData.get( 'uid', None )
         key = envData.get( 'api_key', None )
+        oauth = envData.get( 'oauth', None )
 
-        return ( oid, uid, key )
+        return ( oid, uid, key, oauth )
 
 # Global credentials are acquired in the following order:
 # 1- LC_OID and LC_API_KEY environment variables.
@@ -47,11 +49,12 @@ def _getEnvironmentCreds( name ):
 GLOBAL_OID = os.environ.get( 'LC_OID', None )
 GLOBAL_UID = os.environ.get( 'LC_UID', None )
 GLOBAL_API_KEY = os.environ.get( 'LC_API_KEY', None )
+GLOBAL_OAUTH = None
 if GLOBAL_API_KEY is None:
     _lcEnv = os.environ.get( 'LC_CURRENT_ENV', 'default' )
     if _lcEnv == '':
         _lcEnv = 'default'
-    GLOBAL_OID, GLOBAL_UID, GLOBAL_API_KEY = _getEnvironmentCreds( _lcEnv )
+    GLOBAL_OID, GLOBAL_UID, GLOBAL_API_KEY, GLOBAL_OAUTH = _getEnvironmentCreds( _lcEnv )
 
 from .Manager import Manager
 from .Firehose import Firehose

--- a/limacharlie/constants.py
+++ b/limacharlie/constants.py
@@ -2,3 +2,7 @@ import os
 
 # Path to the configuration file. Can be overriden for tests.
 CONFIG_FILE_PATH = os.path.expanduser( '~/.limacharlie' )
+
+# OAuth-related constants
+OAUTH_CALLBACK_TIMEOUT = 300  # 5 minutes
+OAUTH_TOKEN_REFRESH_BUFFER = 300  # 5 minutes before expiry

--- a/limacharlie/oauth.py
+++ b/limacharlie/oauth.py
@@ -1,0 +1,279 @@
+import json
+import webbrowser
+import urllib.parse
+import requests
+import time
+from typing import Dict, Optional, Tuple
+import os
+import sys
+
+from .oauth_server import OAuthCallbackServer
+from . import utils
+
+
+class OAuthError(Exception):
+    """OAuth-related errors."""
+    pass
+
+
+class OAuthManager:
+    """Manages OAuth authentication flow for LimaCharlie CLI."""
+    
+    # Firebase configuration - these would be provided by LimaCharlie
+    # Using placeholders that should be replaced with actual values
+    FIREBASE_API_KEY = os.environ.get('LC_FIREBASE_API_KEY', 'YOUR_FIREBASE_WEB_API_KEY')
+    FIREBASE_AUTH_DOMAIN = os.environ.get('LC_FIREBASE_AUTH_DOMAIN', 'your-project.firebaseapp.com')
+    
+    # OAuth endpoints
+    GOOGLE_OAUTH_URL = 'https://accounts.google.com/o/oauth2/v2/auth'
+    FIREBASE_TOKEN_EXCHANGE_URL = 'https://identitytoolkit.googleapis.com/v1/accounts:signInWithIdp'
+    FIREBASE_REFRESH_URL = 'https://securetoken.googleapis.com/v1/token'
+    
+    def __init__(self):
+        """Initialize OAuth manager."""
+        self.callback_server = None
+    
+    def start_oauth_flow(self, no_browser: bool = False) -> Dict[str, str]:
+        """
+        Start the OAuth authentication flow.
+        
+        Args:
+            no_browser: If True, print URL instead of opening browser
+            
+        Returns:
+            Dictionary containing tokens and expiry information
+            
+        Raises:
+            OAuthError: If authentication fails
+        """
+        # Start local callback server
+        self.callback_server = OAuthCallbackServer()
+        port = self.callback_server.start()
+        redirect_uri = f'http://localhost:{port}'
+        
+        # Build OAuth URL
+        auth_params = {
+            'client_id': self._get_google_client_id(),
+            'redirect_uri': redirect_uri,
+            'response_type': 'code',
+            'scope': 'openid email profile',
+            'access_type': 'offline',
+            'prompt': 'consent'  # Ensure we get refresh token
+        }
+        
+        auth_url = f"{self.GOOGLE_OAUTH_URL}?{urllib.parse.urlencode(auth_params)}"
+        
+        # Open browser or print URL
+        if no_browser:
+            print(f"\nPlease visit this URL to authenticate:\n{auth_url}\n")
+        else:
+            print(f"Opening browser for authentication...")
+            if not webbrowser.open(auth_url):
+                print(f"\nCould not open browser. Please visit this URL:\n{auth_url}\n")
+        
+        print("Waiting for authentication...")
+        
+        # Wait for callback
+        success, auth_code, error = self.callback_server.wait_for_callback()
+        self.callback_server.stop()
+        
+        if not success:
+            raise OAuthError(f"Authentication failed: {error}")
+        
+        # Exchange authorization code for tokens
+        tokens = self._exchange_code_for_tokens(auth_code, redirect_uri)
+        
+        return tokens
+    
+    def _get_google_client_id(self) -> str:
+        """Get Google OAuth client ID from Firebase config."""
+        # This would typically be fetched from Firebase config
+        # For now, using environment variable or placeholder
+        return os.environ.get('LC_GOOGLE_CLIENT_ID', 'YOUR_GOOGLE_CLIENT_ID.apps.googleusercontent.com')
+    
+    def _exchange_code_for_tokens(self, auth_code: str, redirect_uri: str) -> Dict[str, str]:
+        """
+        Exchange authorization code for Firebase ID token and refresh token.
+        
+        Args:
+            auth_code: Authorization code from OAuth callback
+            redirect_uri: Redirect URI used in OAuth flow
+            
+        Returns:
+            Dictionary with id_token, refresh_token, and expires_in
+            
+        Raises:
+            OAuthError: If token exchange fails
+        """
+        # Exchange with Firebase
+        payload = {
+            'postBody': f'code={auth_code}&providerId=google.com&redirect_uri={redirect_uri}',
+            'requestUri': redirect_uri,
+            'returnIdpCredential': True,
+            'returnSecureToken': True
+        }
+        
+        try:
+            response = requests.post(
+                f"{self.FIREBASE_TOKEN_EXCHANGE_URL}?key={self.FIREBASE_API_KEY}",
+                json=payload,
+                headers={'Content-Type': 'application/json'}
+            )
+            response.raise_for_status()
+            
+            data = response.json()
+            
+            # Calculate expiry timestamp
+            expires_in = int(data.get('expiresIn', '3600'))
+            expires_at = int(time.time()) + expires_in
+            
+            return {
+                'id_token': data['idToken'],
+                'refresh_token': data['refreshToken'],
+                'expires_at': expires_at,
+                'provider': 'google'
+            }
+            
+        except requests.exceptions.RequestException as e:
+            raise OAuthError(f"Failed to exchange authorization code: {str(e)}")
+        except (KeyError, ValueError) as e:
+            raise OAuthError(f"Invalid response from token exchange: {str(e)}")
+    
+    @staticmethod
+    def refresh_token(refresh_token: str) -> Dict[str, str]:
+        """
+        Refresh an expired ID token.
+        
+        Args:
+            refresh_token: The refresh token
+            
+        Returns:
+            Dictionary with new id_token and expires_at
+            
+        Raises:
+            OAuthError: If token refresh fails
+        """
+        payload = {
+            'grant_type': 'refresh_token',
+            'refresh_token': refresh_token
+        }
+        
+        try:
+            response = requests.post(
+                f"{OAuthManager.FIREBASE_REFRESH_URL}?key={OAuthManager.FIREBASE_API_KEY}",
+                data=payload,
+                headers={'Content-Type': 'application/x-www-form-urlencoded'}
+            )
+            response.raise_for_status()
+            
+            data = response.json()
+            
+            # Calculate new expiry
+            expires_in = int(data.get('expires_in', '3600'))
+            expires_at = int(time.time()) + expires_in
+            
+            return {
+                'id_token': data['id_token'],
+                'expires_at': expires_at
+            }
+            
+        except requests.exceptions.RequestException as e:
+            raise OAuthError(f"Failed to refresh token: {str(e)}")
+        except (KeyError, ValueError) as e:
+            raise OAuthError(f"Invalid response from token refresh: {str(e)}")
+    
+    @staticmethod
+    def is_token_expired(expires_at: int) -> bool:
+        """
+        Check if a token is expired.
+        
+        Args:
+            expires_at: Unix timestamp when token expires
+            
+        Returns:
+            True if token is expired or will expire in next 5 minutes
+        """
+        # Add 5 minute buffer to refresh before actual expiry
+        return int(time.time()) >= (expires_at - 300)
+    
+    @staticmethod
+    def validate_oauth_config(config: Dict) -> bool:
+        """
+        Validate OAuth configuration.
+        
+        Args:
+            config: OAuth configuration dictionary
+            
+        Returns:
+            True if configuration is valid
+        """
+        required_fields = ['id_token', 'refresh_token', 'expires_at', 'provider']
+        return all(field in config for field in required_fields)
+
+
+def perform_oauth_login(oid: Optional[str] = None, 
+                       environment: Optional[str] = None,
+                       no_browser: bool = False) -> bool:
+    """
+    Perform OAuth login and save credentials.
+    
+    Args:
+        oid: Organization ID (optional)
+        environment: Environment name (optional)
+        no_browser: If True, print URL instead of opening browser
+        
+    Returns:
+        True if login successful
+    """
+    try:
+        # Initialize OAuth manager
+        oauth_mgr = OAuthManager()
+        
+        # Perform OAuth flow
+        tokens = oauth_mgr.start_oauth_flow(no_browser=no_browser)
+        
+        # Load existing config
+        config = utils.loadCredentials()
+        if config is None:
+            config = {}
+        
+        # Prepare OAuth data
+        oauth_data = {
+            'oauth': tokens
+        }
+        
+        # Add OID if provided
+        if oid:
+            oauth_data['oid'] = oid
+        
+        # Save to appropriate location
+        if environment:
+            # Save to named environment
+            if 'env' not in config:
+                config['env'] = {}
+            if environment not in config['env']:
+                config['env'][environment] = {}
+            config['env'][environment].update(oauth_data)
+            print(f"\nOAuth credentials saved to environment: {environment}")
+        else:
+            # Save to default
+            config.update(oauth_data)
+            print("\nOAuth credentials saved as default")
+        
+        # Write config
+        utils.writeCredentialsToConfig(
+            config.get('oid'),
+            config.get('api_key'),
+            config.get('uid'),
+            environment=environment,
+            oauth_creds=oauth_data.get('oauth')
+        )
+        
+        return True
+        
+    except OAuthError as e:
+        print(f"\nOAuth login failed: {str(e)}", file=sys.stderr)
+        return False
+    except Exception as e:
+        print(f"\nUnexpected error during OAuth login: {str(e)}", file=sys.stderr)
+        return False

--- a/limacharlie/oauth_server.py
+++ b/limacharlie/oauth_server.py
@@ -1,0 +1,174 @@
+import http.server
+import socketserver
+import threading
+import urllib.parse
+import socket
+from typing import Optional, Tuple
+import time
+
+
+class OAuthCallbackHandler(http.server.BaseHTTPRequestHandler):
+    """Handler for OAuth callback requests."""
+    
+    def __init__(self, *args, callback_result=None, **kwargs):
+        self.callback_result = callback_result
+        super().__init__(*args, **kwargs)
+    
+    def do_GET(self):
+        """Handle GET request from OAuth provider redirect."""
+        parsed = urllib.parse.urlparse(self.path)
+        params = urllib.parse.parse_qs(parsed.query)
+        
+        # Extract auth code or error
+        if 'code' in params:
+            self.callback_result['code'] = params['code'][0]
+            self.callback_result['success'] = True
+            
+            # Send success response
+            self.send_response(200)
+            self.send_header('Content-type', 'text/html')
+            self.end_headers()
+            
+            success_html = """
+            <html>
+            <head>
+                <title>LimaCharlie CLI - Authentication Successful</title>
+                <style>
+                    body { font-family: Arial, sans-serif; text-align: center; padding: 50px; }
+                    .success { color: #4CAF50; font-size: 24px; }
+                    .message { margin-top: 20px; color: #666; }
+                </style>
+            </head>
+            <body>
+                <div class="success">✓ Authentication Successful!</div>
+                <div class="message">You can now close this window and return to the CLI.</div>
+            </body>
+            </html>
+            """
+            self.wfile.write(success_html.encode())
+            
+        elif 'error' in params:
+            self.callback_result['error'] = params.get('error_description', ['Unknown error'])[0]
+            self.callback_result['success'] = False
+            
+            # Send error response
+            self.send_response(200)
+            self.send_header('Content-type', 'text/html')
+            self.end_headers()
+            
+            error_html = f"""
+            <html>
+            <head>
+                <title>LimaCharlie CLI - Authentication Failed</title>
+                <style>
+                    body {{ font-family: Arial, sans-serif; text-align: center; padding: 50px; }}
+                    .error {{ color: #f44336; font-size: 24px; }}
+                    .message {{ margin-top: 20px; color: #666; }}
+                </style>
+            </head>
+            <body>
+                <div class="error">✗ Authentication Failed</div>
+                <div class="message">Error: {self.callback_result['error']}</div>
+                <div class="message">Please return to the CLI and try again.</div>
+            </body>
+            </html>
+            """
+            self.wfile.write(error_html.encode())
+        else:
+            # Invalid callback
+            self.send_response(400)
+            self.send_header('Content-type', 'text/plain')
+            self.end_headers()
+            self.wfile.write(b"Invalid OAuth callback")
+    
+    def log_message(self, format, *args):
+        """Suppress log messages."""
+        pass
+
+
+class OAuthCallbackServer:
+    """Local HTTP server for handling OAuth callbacks."""
+    
+    def __init__(self, timeout: int = 300):
+        """
+        Initialize OAuth callback server.
+        
+        Args:
+            timeout: Maximum time to wait for callback (seconds)
+        """
+        self.timeout = timeout
+        self.port = None
+        self.server = None
+        self.callback_result = {'success': False, 'code': None, 'error': None}
+        self.server_thread = None
+    
+    def find_free_port(self) -> int:
+        """Find a free port for the local server."""
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.bind(('', 0))
+            s.listen(1)
+            port = s.getsockname()[1]
+        return port
+    
+    def start(self) -> int:
+        """
+        Start the OAuth callback server.
+        
+        Returns:
+            The port number the server is listening on
+        """
+        self.port = self.find_free_port()
+        
+        # Create handler with callback result reference
+        handler = lambda *args, **kwargs: OAuthCallbackHandler(
+            *args, 
+            callback_result=self.callback_result, 
+            **kwargs
+        )
+        
+        self.server = socketserver.TCPServer(('localhost', self.port), handler)
+        self.server.timeout = 1  # Check for shutdown every second
+        
+        # Start server in separate thread
+        self.server_thread = threading.Thread(target=self._run_server)
+        self.server_thread.daemon = True
+        self.server_thread.start()
+        
+        return self.port
+    
+    def _run_server(self):
+        """Run the server until callback is received or timeout."""
+        start_time = time.time()
+        
+        while not self.callback_result['success'] and not self.callback_result['error']:
+            if time.time() - start_time > self.timeout:
+                self.callback_result['error'] = 'Authentication timeout'
+                break
+            
+            self.server.handle_request()
+        
+        # Handle one more request to send the response
+        if self.callback_result['success'] or self.callback_result['error']:
+            self.server.handle_request()
+    
+    def wait_for_callback(self) -> Tuple[bool, Optional[str], Optional[str]]:
+        """
+        Wait for OAuth callback.
+        
+        Returns:
+            Tuple of (success, auth_code, error_message)
+        """
+        if self.server_thread:
+            self.server_thread.join(timeout=self.timeout + 5)
+        
+        return (
+            self.callback_result['success'],
+            self.callback_result.get('code'),
+            self.callback_result.get('error')
+        )
+    
+    def stop(self):
+        """Stop the OAuth callback server."""
+        if self.server:
+            self.server.shutdown()
+            self.server.server_close()


### PR DESCRIPTION
## Summary
- Implements browser-based OAuth authentication as an alternative to API keys
- Users can authenticate using their Google account via Firebase
- Complete backwards compatibility with existing authentication

## Key Features
- 🔐 New `limacharlie login --oauth` command with browser-based flow
- 🔄 Automatic token refresh when expired
- ✅ Complete backwards compatibility with API key authentication
- 🌍 Support for OAuth in multiple environments
- 🔒 Secure credential storage with same permissions as API keys

## Implementation Details
### New Files
- `limacharlie/oauth.py` - Core OAuth flow implementation
- `limacharlie/oauth_server.py` - Local HTTP callback server
- `OAUTH_README.md` - Comprehensive documentation

### Modified Files
- `limacharlie/__main__.py` - Added `--oauth` flag to login command
- `limacharlie/Manager.py` - OAuth token support in API calls
- `limacharlie/utils.py` - OAuth credential storage functions
- `limacharlie/__init__.py` - OAuth credential loading
- `limacharlie/constants.py` - OAuth-related constants

## Usage
```bash
# OAuth login
limacharlie login --oauth

# OAuth login without browser
limacharlie login --oauth --no-browser

# OAuth login with organization
limacharlie login --oauth --oid YOUR-ORG-ID

# OAuth login to named environment
limacharlie login --oauth --environment production
```

## Configuration Required
The OAuth feature requires Firebase configuration via environment variables:
- `LC_FIREBASE_API_KEY`: Firebase Web API key
- `LC_FIREBASE_AUTH_DOMAIN`: Firebase auth domain
- `LC_GOOGLE_CLIENT_ID`: Google OAuth client ID

## Test Plan
- [ ] Test OAuth login flow with browser
- [ ] Test OAuth login flow without browser (--no-browser)
- [ ] Test token refresh when expired
- [ ] Verify backwards compatibility with API key login
- [ ] Test multiple environments with OAuth
- [ ] Verify secure file permissions on credentials
- [ ] Test error handling for invalid/expired tokens

## Security Considerations
- OAuth tokens stored with same 600 permissions as API keys
- Local callback server only accepts localhost connections
- Single-use authorization codes with expiry
- Automatic token refresh with 5-minute buffer

🤖 Generated with [Claude Code](https://claude.ai/code)