### PR TITLE
Update cryptography dependency to address CVE-2024-12797

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ tabulate
 termcolor
 pygments
 rich
-cryptography>=42.0.0,<44.0.1
+cryptography>=44.0.1

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup( name = 'limacharlie',
        license = __license__,
        packages = [ 'limacharlie' ],
        zip_safe = True,
-       install_requires = [ 'requests', 'passlib', 'pyyaml', 'tabulate', 'termcolor', 'pygments', 'rich' ],
+       install_requires = [ 'requests', 'passlib', 'pyyaml', 'tabulate', 'termcolor', 'pygments', 'rich', 'cryptography>=44.0.1' ],
        long_description = 'Python API for limacharlie.io, an endpoint detection and response service.',
        entry_points = {
            'console_scripts': [


### PR DESCRIPTION
## Summary
- Updated cryptography dependency from `>=42.0.0,<44.0.1` to `>=44.0.1` to address CVE-2024-12797
- This is a high-severity vulnerability in OpenSSL affecting Raw Public Keys (RPKs) that could allow man-in-the-middle attacks
- Updated both `requirements.txt` and `setup.py` to ensure consistency

## Details
CVE-2024-12797 affects OpenSSL versions used in cryptography packages 42.0.0-44.0.0. The vulnerability exists in the handling of Raw Public Keys (RPKs) during TLS/DTLS handshakes and could allow attackers to impersonate servers when RPKs are enabled.

## Test plan
- [x] Updated dependency version in requirements.txt
- [x] Updated dependency version in setup.py  
- [x] Installed updated dependencies in virtual environment
- [x] Verified cryptography 45.0.5 was installed (>=44.0.1)
- [x] Ran unit tests - all 33 tests passed