### PR TITLE
Add Hive batch/bulk API support

### DIFF
--- a/samples/demo_hive_batch.py
+++ b/samples/demo_hive_batch.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python
+
+"""
+Demo script showing how to use the Hive Batch API to perform bulk operations.
+
+This script demonstrates:
+1. Creating batch operations
+2. Adding multiple operations to a batch
+3. Executing the batch in a single API call
+4. Handling batch responses
+"""
+
+import sys
+import os
+import json
+
+# Add parent directory to path to import limacharlie
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../')))
+
+from limacharlie import Manager
+from limacharlie.Hive import Hive, HiveID, RecordID, ConfigRecordMutation
+
+
+def demo_batch_operations():
+    """Demonstrate batch operations on a hive"""
+    
+    # Initialize the manager (this will use environment variables or config file)
+    man = Manager()
+    
+    # Create a hive instance
+    hive_name = 'dr'  # Example hive name
+    hive = Hive(man, hive_name)
+    
+    print(f"Creating batch operations for hive '{hive_name}'...")
+    
+    # Create a new batch operations context
+    batch = hive.new_batch_operations()
+    
+    # Create HiveID for our records
+    hive_id = HiveID(hive_name, man._oid)
+    
+    # Example 1: Get multiple records
+    print("\n1. Adding GET operations to batch...")
+    record_ids = [
+        RecordID(hive_id, 'rule1'),
+        RecordID(hive_id, 'rule2'),
+        RecordID(hive_id, 'rule3')
+    ]
+    
+    for record_id in record_ids:
+        batch.get_record(record_id)
+        print(f"   - Added GET for record: {record_id.name}")
+    
+    # Example 2: Set/Update multiple records
+    print("\n2. Adding SET operations to batch...")
+    new_rule_config = ConfigRecordMutation(
+        data={
+            'detect': {
+                'op': 'is',
+                'path': 'event_type',
+                'value': 'NEW_PROCESS'
+            },
+            'respond': {
+                'action': 'report',
+                'name': 'suspicious-process'
+            }
+        },
+        usr_mtd={
+            'enabled': True,
+            'tags': ['demo', 'batch'],
+            'comment': 'Created via batch API demo'
+        }
+    )
+    
+    batch.set_record(
+        RecordID(hive_id, 'demo_batch_rule'),
+        new_rule_config
+    )
+    print("   - Added SET for new rule: demo_batch_rule")
+    
+    # Example 3: Delete a record
+    print("\n3. Adding DELETE operation to batch...")
+    batch.del_record(RecordID(hive_id, 'old_rule_to_delete'))
+    print("   - Added DELETE for record: old_rule_to_delete")
+    
+    # Example 4: Get metadata only
+    print("\n4. Adding GET metadata operations to batch...")
+    batch.get_record_mtd(RecordID(hive_id, 'rule_metadata_check'))
+    print("   - Added GET metadata for record: rule_metadata_check")
+    
+    # Execute all operations in a single API call
+    print("\n5. Executing batch operations...")
+    print(f"   Total operations in batch: {len(batch._requests)}")
+    
+    try:
+        responses = batch.execute()
+        
+        print(f"\n6. Processing {len(responses)} responses...")
+        for i, response in enumerate(responses):
+            if 'error' in response:
+                print(f"   Operation {i+1}: ERROR - {response['error']}")
+            else:
+                print(f"   Operation {i+1}: SUCCESS")
+                if 'data' in response and response['data']:
+                    # Print a snippet of the data
+                    data_str = json.dumps(response['data'])
+                    if len(data_str) > 100:
+                        data_str = data_str[:100] + "..."
+                    print(f"      Data: {data_str}")
+    
+    except Exception as e:
+        print(f"Error executing batch: {e}")
+        return 1
+    
+    # Example 5: Using dict-based record IDs (alternative approach)
+    print("\n7. Alternative: Using dict-based record IDs...")
+    batch2 = hive.new_batch_operations()
+    
+    # You can also pass dicts instead of RecordID objects
+    record_dict = {
+        'hive': {'name': hive_name, 'partition': man._oid},
+        'name': 'another_rule'
+    }
+    batch2.get_record(record_dict)
+    
+    config_dict = {
+        'data': {'some': 'config'},
+        'usr_mtd': {'enabled': False}
+    }
+    batch2.set_record(record_dict, config_dict)
+    
+    print(f"   Added {len(batch2._requests)} operations using dict format")
+    
+    print("\nDemo completed successfully!")
+    return 0
+
+
+def demo_batch_with_transactions():
+    """Demonstrate using batch operations for transactional updates"""
+    
+    man = Manager()
+    hive = Hive(man, 'dr')
+    
+    print("Demonstrating transactional batch operations...")
+    
+    # Create a batch for reading multiple records
+    batch_read = hive.new_batch_operations()
+    hive_id = HiveID('dr', man._oid)
+    
+    rules_to_check = ['rule1', 'rule2', 'rule3']
+    for rule_name in rules_to_check:
+        batch_read.get_record(RecordID(hive_id, rule_name))
+    
+    print(f"Reading {len(rules_to_check)} rules...")
+    responses = batch_read.execute()
+    
+    # Process responses and prepare updates
+    batch_update = hive.new_batch_operations()
+    
+    for i, response in enumerate(responses):
+        if 'data' in response and response['data']:
+            # Modify the rule (example: add a tag)
+            rule_data = response['data']
+            usr_mtd = rule_data.get('usr_mtd', {})
+            tags = usr_mtd.get('tags', [])
+            tags.append('batch-processed')
+            
+            # Use etag for transactional safety
+            sys_mtd = rule_data.get('sys_mtd', {})
+            etag = sys_mtd.get('etag')
+            
+            # Add update operation
+            batch_update.set_record_mtd(
+                RecordID(hive_id, rules_to_check[i]),
+                {'tags': tags, 'enabled': usr_mtd.get('enabled', True)},
+                {'etag': etag} if etag else {}
+            )
+            print(f"Prepared update for {rules_to_check[i]}")
+    
+    if batch_update._requests:
+        print(f"Executing {len(batch_update._requests)} updates...")
+        update_responses = batch_update.execute()
+        print(f"Updates completed: {len(update_responses)} responses")
+    
+    print("Transactional batch demo completed!")
+
+
+if __name__ == '__main__':
+    print("=" * 60)
+    print("LimaCharlie Hive Batch API Demo")
+    print("=" * 60)
+    
+    # Run the main demo
+    result = demo_batch_operations()
+    
+    print("\n" + "=" * 60)
+    
+    # Optionally run the transactional demo
+    # demo_batch_with_transactions()
+    
+    sys.exit(result)

--- a/tests/unit/test_hive_batch.py
+++ b/tests/unit/test_hive_batch.py
@@ -1,0 +1,286 @@
+import unittest
+import json
+from unittest.mock import Mock, patch, MagicMock
+import sys
+import os
+
+# Add the parent directory to the path so we can import limacharlie
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../')))
+
+from limacharlie.Hive import Hive, HiveBatch, HiveID, RecordID, ConfigRecordMutation
+
+
+class TestHiveBatch(unittest.TestCase):
+    
+    def setUp(self):
+        """Set up test fixtures"""
+        self.mock_manager = Mock()
+        self.mock_manager._oid = 'test-org-id'
+        self.hive = Hive(self.mock_manager, 'test-hive', 'test-partition')
+        self.batch = self.hive.new_batch_operations()
+    
+    def test_create_batch_operations(self):
+        """Test creating a new batch operations context"""
+        batch = self.hive.new_batch_operations()
+        self.assertIsInstance(batch, HiveBatch)
+        self.assertEqual(batch._hive, self.hive)
+        self.assertEqual(batch._requests, [])
+    
+    def test_hive_id_creation(self):
+        """Test HiveID creation and serialization"""
+        hive_id = HiveID('test-hive', 'test-partition')
+        self.assertEqual(hive_id.name, 'test-hive')
+        self.assertEqual(hive_id.partition, 'test-partition')
+        
+        expected = {
+            'name': 'test-hive',
+            'partition': 'test-partition'
+        }
+        self.assertEqual(hive_id.to_dict(), expected)
+    
+    def test_record_id_creation(self):
+        """Test RecordID creation and serialization"""
+        hive_id = HiveID('test-hive', 'test-partition')
+        record_id = RecordID(hive_id, 'test-record', 'test-guid')
+        
+        expected = {
+            'hive': {
+                'name': 'test-hive',
+                'partition': 'test-partition'
+            },
+            'name': 'test-record',
+            'guid': 'test-guid'
+        }
+        self.assertEqual(record_id.to_dict(), expected)
+        
+        # Test without guid
+        record_id_no_guid = RecordID(hive_id, 'test-record')
+        expected_no_guid = {
+            'hive': {
+                'name': 'test-hive',
+                'partition': 'test-partition'
+            },
+            'name': 'test-record'
+        }
+        self.assertEqual(record_id_no_guid.to_dict(), expected_no_guid)
+    
+    def test_config_record_mutation(self):
+        """Test ConfigRecordMutation creation and serialization"""
+        config = ConfigRecordMutation(
+            data={'key': 'value'},
+            usr_mtd={'enabled': True},
+            sys_mtd={'etag': 'test-etag'},
+            arl='test-arl'
+        )
+        
+        expected = {
+            'data': {'key': 'value'},
+            'usr_mtd': {'enabled': True},
+            'sys_mtd': {'etag': 'test-etag'},
+            'arl': 'test-arl'
+        }
+        self.assertEqual(config.to_dict(), expected)
+        
+        # Test with minimal data
+        config_minimal = ConfigRecordMutation(data={'key': 'value'})
+        expected_minimal = {
+            'data': {'key': 'value'}
+        }
+        self.assertEqual(config_minimal.to_dict(), expected_minimal)
+    
+    def test_get_record(self):
+        """Test adding a get record operation to the batch"""
+        hive_id = HiveID('test-hive', 'test-partition')
+        record_id = RecordID(hive_id, 'test-record')
+        
+        self.batch.get_record(record_id)
+        
+        self.assertEqual(len(self.batch._requests), 1)
+        expected = {
+            'get_record': {
+                'record_id': {
+                    'hive': {
+                        'name': 'test-hive',
+                        'partition': 'test-partition'
+                    },
+                    'name': 'test-record'
+                }
+            }
+        }
+        self.assertEqual(self.batch._requests[0], expected)
+    
+    def test_get_record_mtd(self):
+        """Test adding a get record metadata operation to the batch"""
+        hive_id = HiveID('test-hive', 'test-partition')
+        record_id = RecordID(hive_id, 'test-record')
+        
+        self.batch.get_record_mtd(record_id)
+        
+        self.assertEqual(len(self.batch._requests), 1)
+        expected = {
+            'get_record_mtd': {
+                'record_id': {
+                    'hive': {
+                        'name': 'test-hive',
+                        'partition': 'test-partition'
+                    },
+                    'name': 'test-record'
+                }
+            }
+        }
+        self.assertEqual(self.batch._requests[0], expected)
+    
+    def test_set_record(self):
+        """Test adding a set record operation to the batch"""
+        hive_id = HiveID('test-hive', 'test-partition')
+        record_id = RecordID(hive_id, 'test-record')
+        config = ConfigRecordMutation(data={'key': 'value'})
+        
+        self.batch.set_record(record_id, config)
+        
+        self.assertEqual(len(self.batch._requests), 1)
+        expected = {
+            'set_record': {
+                'record_id': {
+                    'hive': {
+                        'name': 'test-hive',
+                        'partition': 'test-partition'
+                    },
+                    'name': 'test-record'
+                },
+                'record': {
+                    'data': {'key': 'value'}
+                }
+            }
+        }
+        self.assertEqual(self.batch._requests[0], expected)
+    
+    def test_set_record_mtd(self):
+        """Test adding a set record metadata operation to the batch"""
+        hive_id = HiveID('test-hive', 'test-partition')
+        record_id = RecordID(hive_id, 'test-record')
+        usr_mtd = {'enabled': True}
+        sys_mtd = {'etag': 'test-etag'}
+        
+        self.batch.set_record_mtd(record_id, usr_mtd, sys_mtd)
+        
+        self.assertEqual(len(self.batch._requests), 1)
+        expected = {
+            'set_record_mtd': {
+                'record_id': {
+                    'hive': {
+                        'name': 'test-hive',
+                        'partition': 'test-partition'
+                    },
+                    'name': 'test-record'
+                },
+                'usr_mtd': {'enabled': True},
+                'sys_mtd': {'etag': 'test-etag'}
+            }
+        }
+        self.assertEqual(self.batch._requests[0], expected)
+    
+    def test_del_record(self):
+        """Test adding a delete record operation to the batch"""
+        hive_id = HiveID('test-hive', 'test-partition')
+        record_id = RecordID(hive_id, 'test-record')
+        
+        self.batch.del_record(record_id)
+        
+        self.assertEqual(len(self.batch._requests), 1)
+        expected = {
+            'delete_record': {
+                'record_id': {
+                    'hive': {
+                        'name': 'test-hive',
+                        'partition': 'test-partition'
+                    },
+                    'name': 'test-record'
+                }
+            }
+        }
+        self.assertEqual(self.batch._requests[0], expected)
+    
+    def test_multiple_operations(self):
+        """Test adding multiple operations to the batch"""
+        hive_id = HiveID('test-hive', 'test-partition')
+        record_id1 = RecordID(hive_id, 'test-record-1')
+        record_id2 = RecordID(hive_id, 'test-record-2')
+        config = ConfigRecordMutation(data={'key': 'value'})
+        
+        self.batch.get_record(record_id1)
+        self.batch.set_record(record_id2, config)
+        self.batch.del_record(record_id1)
+        
+        self.assertEqual(len(self.batch._requests), 3)
+    
+    def test_execute_empty_batch(self):
+        """Test executing an empty batch"""
+        result = self.batch.execute()
+        self.assertEqual(result, [])
+        self.mock_manager._apiCall.assert_not_called()
+    
+    def test_execute_batch(self):
+        """Test executing a batch with operations"""
+        # Set up the mock response
+        mock_response = {
+            'responses': [
+                {'data': {'key': 'value1'}},
+                {'error': 'Record not found'}
+            ]
+        }
+        self.mock_manager._apiCall.return_value = mock_response
+        
+        # Add some operations
+        hive_id = HiveID('test-hive', 'test-partition')
+        record_id1 = RecordID(hive_id, 'test-record-1')
+        record_id2 = RecordID(hive_id, 'test-record-2')
+        
+        self.batch.get_record(record_id1)
+        self.batch.get_record(record_id2)
+        
+        # Execute the batch
+        result = self.batch.execute()
+        
+        # Verify the API call was made correctly
+        self.mock_manager._apiCall.assert_called_once()
+        call_args = self.mock_manager._apiCall.call_args
+        self.assertEqual(call_args[0][0], 'hive')  # URL
+        self.assertEqual(call_args[0][1], 'POST')  # Method
+        
+        # Check that the requests were properly formatted
+        params = call_args[0][2]
+        self.assertIn('request', params)
+        self.assertEqual(len(params['request']), 2)
+        
+        # Verify the response
+        self.assertEqual(result, mock_response['responses'])
+    
+    def test_record_id_from_dict(self):
+        """Test creating RecordID from dict in batch operations"""
+        record_dict = {
+            'hive': {'name': 'test-hive', 'partition': 'test-partition'},
+            'name': 'test-record',
+            'guid': 'test-guid'
+        }
+        
+        self.batch.get_record(record_dict)
+        
+        self.assertEqual(len(self.batch._requests), 1)
+        expected = {
+            'get_record': {
+                'record_id': {
+                    'hive': {
+                        'name': 'test-hive',
+                        'partition': 'test-partition'
+                    },
+                    'name': 'test-record',
+                    'guid': 'test-guid'
+                }
+            }
+        }
+        self.assertEqual(self.batch._requests[0], expected)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- Port batch operations functionality from go-limacharlie SDK to Python
- Enable multiple hive operations in a single API call for improved performance
- Maintain full compatibility with existing code

## Changes
- Added `HiveID`, `RecordID`, and `ConfigRecordMutation` data classes for structured batch operations
- Implemented `HiveBatch` class with methods:
  - `get_record()` - Get full record data
  - `get_record_mtd()` - Get record metadata only  
  - `set_record()` - Set/update record with data
  - `set_record_mtd()` - Set record metadata
  - `del_record()` - Delete a record
  - `execute()` - Send all batched operations in single API call
- Added `new_batch_operations()` method to existing `Hive` class for creating batch contexts
- Created comprehensive unit tests (13 tests, all passing)
- Added demo script with usage examples

## Usage Example
```python
hive = Hive(manager, 'dr')
batch = hive.new_batch_operations()

# Add multiple operations
batch.get_record(RecordID(hive_id, 'rule1'))
batch.set_record(RecordID(hive_id, 'rule2'), config)
batch.del_record(RecordID(hive_id, 'rule3'))

# Execute all in one API call
responses = batch.execute()
```

## Testing
- All unit tests passing
- Maintains backward compatibility with existing code
- Mirrors go-limacharlie SDK functionality

🤖 Generated with [Claude Code](https://claude.ai/code)