### PR TITLE
[DONT MERGE] [WIP] Add SDK methods and CLI commands for managing search downloads

### DIFF
--- a/limacharlie/SearchDownload.py
+++ b/limacharlie/SearchDownload.py
@@ -1,0 +1,562 @@
+"""CLI module for managing search download jobs.
+
+This module provides commands for creating and managing long-running
+background jobs that download complete search results to cloud storage.
+
+Available commands:
+    start    - Start a new download job
+    status   - Get the status of a download job
+    list     - List download jobs for the organization
+    cancel   - Cancel a running download job
+    wait     - Wait for a download job to complete
+"""
+
+from limacharlie import Manager
+from limacharlie.time_utils import parse_time_input, format_timestamp
+from limacharlie.utils import LcApiException
+import sys
+import json
+import time
+import signal
+
+
+def format_duration(seconds):
+    """
+    Format a duration in seconds to a human-readable string.
+
+    Parameters:
+        seconds (float): Duration in seconds.
+
+    Returns:
+        str: Formatted duration string (e.g., "1h 23m", "45s").
+    """
+    if seconds < 60:
+        return "%ds" % int(seconds)
+    elif seconds < 3600:
+        return "%dm %ds" % (int(seconds / 60), int(seconds % 60))
+    else:
+        hours = int(seconds / 3600)
+        minutes = int((seconds % 3600) / 60)
+        return "%dh %dm" % (hours, minutes)
+
+
+def format_bytes(num_bytes):
+    """
+    Format bytes to a human-readable string.
+
+    Parameters:
+        num_bytes (int): Number of bytes.
+
+    Returns:
+        str: Formatted string (e.g., "1.5 GB", "256 MB").
+    """
+    if num_bytes >= 1024**3:
+        return "%.2f GB" % (num_bytes / (1024**3))
+    elif num_bytes >= 1024**2:
+        return "%.2f MB" % (num_bytes / (1024**2))
+    elif num_bytes >= 1024:
+        return "%.2f KB" % (num_bytes / 1024)
+    else:
+        return "%d bytes" % num_bytes
+
+
+def print_job_status(status, verbose=False):
+    """
+    Print job status in a human-readable format.
+
+    Parameters:
+        status (dict): Job status dictionary.
+        verbose (bool): If True, print detailed progress information.
+
+    Returns:
+        None
+    """
+    job_id = status.get('jobId', 'unknown')
+    job_status = status.get('status', 'unknown')
+    created_at = status.get('createdAt', '')
+
+    # Status indicator
+    status_icons = {
+        'queued': '⏳',
+        'running': '🔄',
+        'merging': '📦',
+        'completed': '✅',
+        'failed': '❌',
+        'cancelled': '🚫'
+    }
+    icon = status_icons.get(job_status, '❓')
+
+    print(f"{icon} Job: {job_id}")
+    print(f"   Status: {job_status}")
+    print(f"   Created: {created_at}")
+
+    if status.get('startedAt'):
+        print(f"   Started: {status['startedAt']}")
+
+    if status.get('completedAt'):
+        print(f"   Completed: {status['completedAt']}")
+
+    # Progress information
+    progress = status.get('progress', {})
+    if progress and (verbose or job_status in ['running', 'merging']):
+        events = progress.get('eventsProcessed', 0)
+        pages = progress.get('pagesProcessed', 0)
+        bytes_processed = progress.get('bytesProcessed', 0)
+        runtime = progress.get('runtimeSeconds', 0)
+
+        print(f"   Progress:")
+        print(f"     - Events processed: {events:,}")
+        print(f"     - Pages processed: {pages}")
+        print(f"     - Data processed: {format_bytes(bytes_processed)}")
+        if runtime > 0:
+            print(f"     - Runtime: {format_duration(runtime)}")
+
+        # Rate metrics
+        events_per_sec = progress.get('eventsPerSecond', 0)
+        if events_per_sec > 0:
+            print(f"     - Rate: {events_per_sec:.1f} events/sec")
+
+        # Date range progress
+        date_percent = progress.get('dateRangePercent', 0)
+        if date_percent > 0:
+            print(f"     - Date range: {date_percent:.1f}%")
+
+    # Error message
+    if status.get('error'):
+        print(f"   Error: {status['error']}")
+
+    # Result URL
+    if status.get('resultUrl'):
+        print(f"   Result URL: {status['resultUrl']}")
+        if status.get('resultExpiry'):
+            print(f"   URL Expires: {status['resultExpiry']}")
+
+    # Metadata
+    metadata = status.get('metadata', {})
+    if metadata and verbose:
+        print(f"   Metadata:")
+        for key, value in metadata.items():
+            print(f"     - {key}: {value}")
+
+
+def main(sourceArgs=None):
+    """
+    Command line interface for LimaCharlie Search Download API.
+
+    Parameters:
+        sourceArgs (list): Optional list of CLI arguments to parse.
+
+    Returns:
+        None
+    """
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        prog='limacharlie search-download',
+        description='Manage long-running search download jobs'
+    )
+
+    # Create subparsers for different commands
+    subparsers = parser.add_subparsers(dest='command', help='search-download commands')
+    subparsers.required = True
+
+    # Start command - initiate a new download job
+    start_parser = subparsers.add_parser(
+        'start',
+        help='Start a new search download job'
+    )
+    start_parser.add_argument(
+        '-q', '--query',
+        type=str,
+        required=True,
+        dest='query',
+        help='The search query to execute.'
+    )
+    start_parser.add_argument(
+        '-s', '--start',
+        type=str,
+        required=True,
+        dest='start',
+        help='Start time - supports: "now-10m", "now-1h", "2025-12-30 10:00:00", Unix timestamp.'
+    )
+    start_parser.add_argument(
+        '-e', '--end',
+        type=str,
+        required=True,
+        dest='end',
+        help='End time - supports: "now", "now-1h", "2025-12-30 10:00:00", Unix timestamp.'
+    )
+    start_parser.add_argument(
+        '--stream',
+        type=str,
+        default=None,
+        dest='stream',
+        help='Optional stream name (e.g., "event", "detect", "audit").'
+    )
+    start_parser.add_argument(
+        '--compression',
+        type=str,
+        choices=['zip', 'none'],
+        default='zip',
+        dest='compression',
+        help='Compression type for the result file (default: zip).'
+    )
+    start_parser.add_argument(
+        '--token-hours',
+        type=float,
+        default=8.0,
+        dest='token_hours',
+        help='Token validity in hours for the download job (default: 8). Jobs can run up to 6 hours.'
+    )
+    start_parser.add_argument(
+        '--metadata',
+        type=str,
+        default=None,
+        dest='metadata',
+        help='Optional JSON metadata to attach to the job (e.g., \'{"purpose": "forensics"}\').'
+    )
+    start_parser.add_argument(
+        '--wait',
+        action='store_true',
+        default=False,
+        dest='wait',
+        help='Wait for the job to complete instead of returning immediately.'
+    )
+    start_parser.add_argument(
+        '--json',
+        action='store_true',
+        default=False,
+        dest='json_output',
+        help='Output raw JSON instead of formatted text.'
+    )
+
+    # Status command - get job status
+    status_parser = subparsers.add_parser(
+        'status',
+        help='Get the status of a download job'
+    )
+    status_parser.add_argument(
+        'job_id',
+        type=str,
+        help='The job ID to check.'
+    )
+    status_parser.add_argument(
+        '--json',
+        action='store_true',
+        default=False,
+        dest='json_output',
+        help='Output raw JSON instead of formatted text.'
+    )
+    status_parser.add_argument(
+        '-v', '--verbose',
+        action='store_true',
+        default=False,
+        dest='verbose',
+        help='Show detailed progress information.'
+    )
+
+    # List command - list download jobs
+    list_parser = subparsers.add_parser(
+        'list',
+        help='List download jobs for the organization'
+    )
+    list_parser.add_argument(
+        '--limit',
+        type=int,
+        default=20,
+        dest='limit',
+        help='Maximum number of jobs to return (default: 20, max: 1000).'
+    )
+    list_parser.add_argument(
+        '--offset',
+        type=int,
+        default=0,
+        dest='offset',
+        help='Number of jobs to skip for pagination (default: 0).'
+    )
+    list_parser.add_argument(
+        '--json',
+        action='store_true',
+        default=False,
+        dest='json_output',
+        help='Output raw JSON instead of formatted text.'
+    )
+    list_parser.add_argument(
+        '-v', '--verbose',
+        action='store_true',
+        default=False,
+        dest='verbose',
+        help='Show detailed progress information for each job.'
+    )
+
+    # Cancel command - cancel a running job
+    cancel_parser = subparsers.add_parser(
+        'cancel',
+        help='Cancel a running download job'
+    )
+    cancel_parser.add_argument(
+        'job_id',
+        type=str,
+        help='The job ID to cancel.'
+    )
+
+    # Wait command - wait for job completion
+    wait_parser = subparsers.add_parser(
+        'wait',
+        help='Wait for a download job to complete'
+    )
+    wait_parser.add_argument(
+        'job_id',
+        type=str,
+        help='The job ID to wait for.'
+    )
+    wait_parser.add_argument(
+        '--poll-interval',
+        type=int,
+        default=10,
+        dest='poll_interval',
+        help='Seconds between status checks (default: 10).'
+    )
+    wait_parser.add_argument(
+        '--timeout',
+        type=int,
+        default=None,
+        dest='timeout',
+        help='Maximum seconds to wait before timing out (default: no timeout).'
+    )
+    wait_parser.add_argument(
+        '--json',
+        action='store_true',
+        default=False,
+        dest='json_output',
+        help='Output raw JSON instead of formatted text.'
+    )
+    wait_parser.add_argument(
+        '-q', '--quiet',
+        action='store_true',
+        default=False,
+        dest='quiet',
+        help='Suppress progress output, only print final result.'
+    )
+
+    # URL command - get download URL for a completed job
+    url_parser = subparsers.add_parser(
+        'url',
+        help='Get the download URL for a completed job'
+    )
+    url_parser.add_argument(
+        'job_id',
+        type=str,
+        help='The job ID to get the URL for.'
+    )
+
+    args = parser.parse_args(sourceArgs)
+
+    # Create manager instance
+    manager = Manager()
+
+    # Execute the requested command
+    if args.command == 'start':
+        # Parse time inputs
+        try:
+            start_ts = parse_time_input(args.start)
+            end_ts = parse_time_input(args.end)
+        except ValueError as e:
+            print(f"Error parsing time: {e}", file=sys.stderr)
+            sys.exit(1)
+
+        # Parse metadata if provided
+        metadata = None
+        if args.metadata:
+            try:
+                metadata = json.loads(args.metadata)
+                if not isinstance(metadata, dict):
+                    raise ValueError("Metadata must be a JSON object")
+            except json.JSONDecodeError as e:
+                print(f"Error parsing metadata JSON: {e}", file=sys.stderr)
+                sys.exit(1)
+
+        # Generate long-lived token for the job
+        expiry_seconds = int(time.time() + args.token_hours * 3600)
+        try:
+            manager.getJWT(expiry_seconds=expiry_seconds)
+        except LcApiException as e:
+            print(f"Error generating token: {e}", file=sys.stderr)
+            sys.exit(1)
+
+        # Print job info
+        if not args.json_output:
+            print("Starting search download job...", file=sys.stderr)
+            print(f"Query: {args.query}", file=sys.stderr)
+            print(f"Time range: {format_timestamp(start_ts)} to {format_timestamp(end_ts)}", file=sys.stderr)
+            print(f"Token valid for: {args.token_hours} hours", file=sys.stderr)
+            print("", file=sys.stderr)
+
+        try:
+            result = manager.initiateSearchDownload(
+                query=args.query,
+                start_time=start_ts,
+                end_time=end_ts,
+                compression=args.compression,
+                stream=args.stream,
+                metadata=metadata
+            )
+        except LcApiException as e:
+            print(f"Error starting download job: {e}", file=sys.stderr)
+            sys.exit(1)
+
+        job_id = result.get('jobId', 'unknown')
+
+        if args.json_output:
+            print(json.dumps(result, indent=2))
+        else:
+            print(f"Download job started: {job_id}")
+
+            # Print estimated stats if available
+            estimated = result.get('estimatedStats', {})
+            if estimated:
+                events = estimated.get('eventsMatched', 0)
+                price = estimated.get('estimatedPrice', {})
+                if events:
+                    print(f"Estimated events: {events:,}")
+                if price:
+                    print(f"Estimated price: {price.get('price', 0):.4f} {price.get('currency', 'USD')}")
+
+            if result.get('tokenExpiry'):
+                print(f"Token expires: {result['tokenExpiry']}")
+
+        # Wait for completion if requested
+        if args.wait:
+            if not args.json_output:
+                print("\nWaiting for job to complete...", file=sys.stderr)
+
+            def progress_cb(status):
+                if not args.json_output:
+                    progress = status.get('progress', {})
+                    events = progress.get('eventsProcessed', 0)
+                    job_status = status.get('status', '')
+                    runtime = progress.get('runtimeSeconds', 0)
+                    print(f"\r  Status: {job_status} | Events: {events:,} | Runtime: {format_duration(runtime)}   ",
+                          end='', file=sys.stderr, flush=True)
+
+            try:
+                final_status = manager.waitForSearchDownload(
+                    job_id,
+                    poll_interval=10,
+                    progress_callback=progress_cb
+                )
+                if not args.json_output:
+                    print("\n", file=sys.stderr)
+                    print_job_status(final_status, verbose=True)
+                else:
+                    print(json.dumps(final_status, indent=2))
+            except LcApiException as e:
+                print(f"\nError: {e}", file=sys.stderr)
+                sys.exit(1)
+
+    elif args.command == 'status':
+        try:
+            status = manager.getSearchDownloadStatus(args.job_id)
+        except LcApiException as e:
+            print(f"Error: {e}", file=sys.stderr)
+            sys.exit(1)
+
+        if args.json_output:
+            print(json.dumps(status, indent=2))
+        else:
+            print_job_status(status, verbose=args.verbose)
+
+    elif args.command == 'list':
+        try:
+            jobs = manager.listSearchDownloads(limit=args.limit, offset=args.offset)
+        except LcApiException as e:
+            print(f"Error: {e}", file=sys.stderr)
+            sys.exit(1)
+
+        if args.json_output:
+            print(json.dumps({'jobs': jobs}, indent=2))
+        else:
+            if not jobs:
+                print("No download jobs found.")
+            else:
+                print(f"Found {len(jobs)} download job(s):\n")
+                for job in jobs:
+                    print_job_status(job, verbose=args.verbose)
+                    print()
+
+    elif args.command == 'cancel':
+        try:
+            manager.cancelSearchDownload(args.job_id)
+            print(f"Job {args.job_id} cancelled successfully.")
+        except LcApiException as e:
+            print(f"Error: {e}", file=sys.stderr)
+            sys.exit(1)
+
+    elif args.command == 'wait':
+        interrupted = [False]
+
+        def signal_handler(signum, frame):
+            interrupted[0] = True
+            print("\nInterrupted. The job is still running in the background.", file=sys.stderr)
+            print(f"Check status with: limacharlie search-download status {args.job_id}", file=sys.stderr)
+            sys.exit(130)
+
+        signal.signal(signal.SIGINT, signal_handler)
+
+        def progress_cb(status):
+            if not args.quiet and not args.json_output:
+                progress = status.get('progress', {})
+                events = progress.get('eventsProcessed', 0)
+                job_status = status.get('status', '')
+                runtime = progress.get('runtimeSeconds', 0)
+                date_pct = progress.get('dateRangePercent', 0)
+                print(f"\r  Status: {job_status} | Events: {events:,} | Progress: {date_pct:.1f}% | Runtime: {format_duration(runtime)}   ",
+                      end='', file=sys.stderr, flush=True)
+
+        if not args.quiet and not args.json_output:
+            print(f"Waiting for job {args.job_id} to complete...", file=sys.stderr)
+
+        try:
+            final_status = manager.waitForSearchDownload(
+                args.job_id,
+                poll_interval=args.poll_interval,
+                timeout=args.timeout,
+                progress_callback=progress_cb
+            )
+
+            if not args.quiet and not args.json_output:
+                print("\n", file=sys.stderr)
+
+            if args.json_output:
+                print(json.dumps(final_status, indent=2))
+            else:
+                print_job_status(final_status, verbose=True)
+
+        except LcApiException as e:
+            if not args.quiet:
+                print(f"\nError: {e}", file=sys.stderr)
+            sys.exit(1)
+
+    elif args.command == 'url':
+        try:
+            status = manager.getSearchDownloadStatus(args.job_id)
+        except LcApiException as e:
+            print(f"Error: {e}", file=sys.stderr)
+            sys.exit(1)
+
+        if status.get('status') != 'completed':
+            print(f"Job is not completed (status: {status.get('status')})", file=sys.stderr)
+            if status.get('status') in ['queued', 'running', 'merging']:
+                print(f"Wait for completion with: limacharlie search-download wait {args.job_id}", file=sys.stderr)
+            sys.exit(1)
+
+        url = status.get('resultUrl')
+        if not url:
+            print("No result URL available (results may have expired)", file=sys.stderr)
+            sys.exit(1)
+
+        print(url)
+
+    else:
+        parser.print_help()
+        sys.exit(1)

--- a/limacharlie/__main__.py
+++ b/limacharlie/__main__.py
@@ -54,7 +54,7 @@ def cli(args):
     parser = argparse.ArgumentParser( prog = 'limacharlie' )
     parser.add_argument( 'action',
                          type = str,
-                         help = 'management action, currently supported "login" (store credentials), "use" (use specific credentials), "set-oid" (change organization ID), "get-arl" (outputs data returned from ARLs), "dr" (manage Detection & Response rules), "search" (search for Indicators of Compromise), "search-api" (execute Search API queries), "replay" (replay D&R rules on data), "sync" (synchronize configurations from/to an org), "who" get current SDK authentication in effect, "detections" (download detections), "events" (download events), "artifacts" (get or upload artifacts), "users" (manage and invite users)' )
+                         help = 'management action, currently supported "login" (store credentials), "use" (use specific credentials), "set-oid" (change organization ID), "get-token" (generate JWT with custom expiry), "get-arl" (outputs data returned from ARLs), "dr" (manage Detection & Response rules), "search" (search for Indicators of Compromise), "search-api" (execute Search API queries), "search-download" (manage search download jobs), "replay" (replay D&R rules on data), "sync" (synchronize configurations from/to an org), "who" get current SDK authentication in effect, "detections" (download detections), "events" (download events), "artifacts" (get or upload artifacts), "users" (manage and invite users)' )
     parser.add_argument( 'opt_arg',
                          type = str,
                          nargs = "?",
@@ -275,6 +275,9 @@ def cli(args):
         cmdMain( actionArgs )
     elif args.action.lower() == 'search-api':
         from .SearchAPI import main as cmdMain
+        cmdMain( actionArgs )
+    elif args.action.lower() == 'search-download':
+        from .SearchDownload import main as cmdMain
         cmdMain( actionArgs )
     elif args.action.lower() == 'replay':
         from .Replay import main as cmdMain

--- a/tests/unit/test_search_download.py
+++ b/tests/unit/test_search_download.py
@@ -1,0 +1,688 @@
+"""Tests for the search download SDK methods and CLI commands.
+
+These tests verify that:
+1. The Manager download methods correctly call the API
+2. The CLI commands correctly parse arguments and call SDK methods
+3. Error handling works correctly
+4. The getJWT method correctly generates tokens with custom expiry
+"""
+
+import json
+import time
+from unittest.mock import MagicMock, patch, call
+
+import pytest
+
+from limacharlie import Manager
+from limacharlie.SearchDownload import main as search_download_cli
+from limacharlie.utils import LcApiException
+
+
+class TestManagerGetJWT:
+    """Tests for the Manager.getJWT method."""
+
+    def test_get_jwt_with_custom_expiry(self):
+        """Test getJWT generates a token with custom expiry timestamp."""
+        with patch.object(Manager, '__init__', lambda self, **kwargs: None):
+            manager = Manager()
+            manager._secret_api_key = 'test-api-key'
+            manager._oid = 'test-oid'
+            manager._uid = None
+            manager._oauth_creds = None
+            manager._jwt = None
+            manager._onRefreshAuth = None
+
+            custom_expiry = int(time.time()) + 8 * 3600  # 8 hours from now
+
+            with patch('limacharlie.Manager.urlopen') as mock_urlopen:
+                mock_response = MagicMock()
+                mock_response.read.return_value = b'{"jwt": "test-jwt-token"}'
+                mock_urlopen.return_value = mock_response
+
+                result = manager.getJWT(expiry_seconds=custom_expiry)
+
+                assert result == 'test-jwt-token'
+                assert manager._jwt == 'test-jwt-token'
+
+                # Verify the request included the expiry parameter
+                call_args = mock_urlopen.call_args
+                request = call_args[0][0]
+                request_data = request.data.decode()
+                assert f'expiry={custom_expiry}' in request_data
+
+    def test_get_jwt_without_expiry(self):
+        """Test getJWT works without custom expiry (uses default)."""
+        with patch.object(Manager, '__init__', lambda self, **kwargs: None):
+            manager = Manager()
+            manager._secret_api_key = 'test-api-key'
+            manager._oid = 'test-oid'
+            manager._uid = None
+            manager._oauth_creds = None
+            manager._jwt = None
+            manager._onRefreshAuth = None
+
+            with patch('limacharlie.Manager.urlopen') as mock_urlopen:
+                mock_response = MagicMock()
+                mock_response.read.return_value = b'{"jwt": "default-jwt-token"}'
+                mock_urlopen.return_value = mock_response
+
+                result = manager.getJWT()
+
+                assert result == 'default-jwt-token'
+                assert manager._jwt == 'default-jwt-token'
+
+                # Verify no expiry parameter in request
+                call_args = mock_urlopen.call_args
+                request = call_args[0][0]
+                request_data = request.data.decode()
+                assert 'expiry=' not in request_data
+
+    def test_get_jwt_updates_internal_token(self):
+        """Test that getJWT updates the internal _jwt token for subsequent calls."""
+        with patch.object(Manager, '__init__', lambda self, **kwargs: None):
+            manager = Manager()
+            manager._secret_api_key = 'test-api-key'
+            manager._oid = 'test-oid'
+            manager._uid = None
+            manager._oauth_creds = None
+            manager._jwt = 'old-token'
+            manager._onRefreshAuth = None
+
+            with patch('limacharlie.Manager.urlopen') as mock_urlopen:
+                mock_response = MagicMock()
+                mock_response.read.return_value = b'{"jwt": "new-long-lived-token"}'
+                mock_urlopen.return_value = mock_response
+
+                result = manager.getJWT(expiry_seconds=int(time.time()) + 3600)
+
+                # Both the return value and internal token should be updated
+                assert result == 'new-long-lived-token'
+                assert manager._jwt == 'new-long-lived-token'
+
+    def test_get_jwt_failure_raises_exception(self):
+        """Test that getJWT raises LcApiException on failure."""
+        from io import BytesIO
+        from urllib.error import HTTPError
+
+        with patch.object(Manager, '__init__', lambda self, **kwargs: None):
+            manager = Manager()
+            manager._secret_api_key = 'test-api-key'
+            manager._oid = 'test-oid'
+            manager._uid = None
+            manager._oauth_creds = None
+            manager._jwt = None
+            manager._onRefreshAuth = None
+
+            with patch('limacharlie.Manager.urlopen') as mock_urlopen:
+                # Create a proper HTTPError with a readable body
+                error_body = BytesIO(b'{"error": "Unauthorized"}')
+                http_error = HTTPError(
+                    'https://jwt.limacharlie.io',
+                    401,
+                    'Unauthorized',
+                    {},
+                    error_body
+                )
+                mock_urlopen.side_effect = http_error
+
+                with pytest.raises(LcApiException) as exc_info:
+                    manager.getJWT(expiry_seconds=int(time.time()) + 3600)
+
+                assert 'failed to get jwt' in str(exc_info.value).lower()
+
+
+class TestManagerSearchDownloadMethods:
+    """Tests for the Manager search download SDK methods."""
+
+    def test_initiate_search_download_success(self):
+        """Test initiating a download job successfully."""
+        mock_response = {
+            'jobId': 'test-job-123',
+            'estimatedStats': {
+                'eventsScanned': 50000,
+                'eventsMatched': 1000,
+                'estimatedPrice': {'price': 0.25, 'currency': 'USD'}
+            },
+            'tokenExpiry': '2025-01-01T12:00:00Z'
+        }
+
+        with patch.object(Manager, '__init__', lambda self, **kwargs: None):
+            manager = Manager()
+            manager._oid = 'test-oid'
+            manager._jwt = 'test-jwt'
+            manager._search_url = None
+
+            # Mock _getSearchUrl and _restCall
+            manager._getSearchUrl = MagicMock(return_value='https://search.limacharlie.io/v1/search')
+            manager._restCall = MagicMock(return_value=(200, mock_response))
+
+            result = manager.initiateSearchDownload(
+                query='event_type = *',
+                start_time=1700000000,
+                end_time=1700086400,
+                compression='zip',
+                stream='event',
+                metadata={'purpose': 'test'}
+            )
+
+            assert result['jobId'] == 'test-job-123'
+            assert 'estimatedStats' in result
+
+            # Verify the API call
+            manager._restCall.assert_called_once()
+            call_args = manager._restCall.call_args
+            assert call_args[0][0] == 'download'
+            assert call_args[0][1] == 'POST'
+
+    def test_initiate_search_download_token_too_short(self):
+        """Test that appropriate error is raised when token expires too soon."""
+        error_response = {
+            'error': 'JWT token expires too soon for download job',
+            'tokenExpiry': '2025-01-01T00:30:00Z',
+            'minRequiredLifetime': '6h0m0s'
+        }
+
+        with patch.object(Manager, '__init__', lambda self, **kwargs: None):
+            manager = Manager()
+            manager._oid = 'test-oid'
+            manager._jwt = 'test-jwt'
+            manager._search_url = None
+
+            manager._getSearchUrl = MagicMock(return_value='https://search.limacharlie.io/v1/search')
+            manager._restCall = MagicMock(return_value=(400, error_response))
+
+            with pytest.raises(LcApiException) as exc_info:
+                manager.initiateSearchDownload(
+                    query='*',
+                    start_time=1700000000,
+                    end_time=1700086400
+                )
+
+            assert 'token expires too soon' in str(exc_info.value).lower()
+
+    def test_get_search_download_status_success(self):
+        """Test getting download job status successfully."""
+        mock_status = {
+            'jobId': 'test-job-123',
+            'status': 'running',
+            'progress': {
+                'eventsProcessed': 5000,
+                'pagesProcessed': 10,
+                'bytesProcessed': 1024000
+            }
+        }
+
+        with patch.object(Manager, '__init__', lambda self, **kwargs: None):
+            manager = Manager()
+            manager._oid = 'test-oid'
+            manager._jwt = 'test-jwt'
+            manager._search_url = None
+
+            manager._getSearchUrl = MagicMock(return_value='https://search.limacharlie.io/v1/search')
+            manager._restCall = MagicMock(return_value=(200, mock_status))
+
+            result = manager.getSearchDownloadStatus('test-job-123')
+
+            assert result['status'] == 'running'
+            assert result['progress']['eventsProcessed'] == 5000
+
+    def test_get_search_download_status_not_found(self):
+        """Test getting status for non-existent job."""
+        with patch.object(Manager, '__init__', lambda self, **kwargs: None):
+            manager = Manager()
+            manager._oid = 'test-oid'
+            manager._jwt = 'test-jwt'
+            manager._search_url = None
+
+            manager._getSearchUrl = MagicMock(return_value='https://search.limacharlie.io/v1/search')
+            manager._restCall = MagicMock(return_value=(404, {'error': 'Job not found'}))
+
+            with pytest.raises(LcApiException) as exc_info:
+                manager.getSearchDownloadStatus('nonexistent-job')
+
+            assert 'not found' in str(exc_info.value).lower()
+
+    def test_list_search_downloads_success(self):
+        """Test listing download jobs successfully."""
+        mock_response = {
+            'jobs': [
+                {'jobId': 'job-1', 'status': 'completed'},
+                {'jobId': 'job-2', 'status': 'running'}
+            ]
+        }
+
+        with patch.object(Manager, '__init__', lambda self, **kwargs: None):
+            manager = Manager()
+            manager._oid = 'test-oid'
+            manager._jwt = 'test-jwt'
+            manager._search_url = None
+
+            manager._getSearchUrl = MagicMock(return_value='https://search.limacharlie.io/v1/search')
+            manager._restCall = MagicMock(return_value=(200, mock_response))
+
+            result = manager.listSearchDownloads(limit=10, offset=0)
+
+            assert len(result) == 2
+            assert result[0]['jobId'] == 'job-1'
+
+            # Verify query params
+            call_args = manager._restCall.call_args
+            query_params = call_args[1]['queryParams']
+            assert query_params['limit'] == '10'
+            assert query_params['offset'] == '0'
+
+    def test_cancel_search_download_success(self):
+        """Test canceling a download job successfully."""
+        with patch.object(Manager, '__init__', lambda self, **kwargs: None):
+            manager = Manager()
+            manager._oid = 'test-oid'
+            manager._jwt = 'test-jwt'
+            manager._search_url = None
+
+            manager._getSearchUrl = MagicMock(return_value='https://search.limacharlie.io/v1/search')
+            manager._restCall = MagicMock(return_value=(204, {}))
+
+            result = manager.cancelSearchDownload('test-job-123')
+
+            assert result is True
+            manager._restCall.assert_called_once()
+
+    def test_cancel_search_download_already_completed(self):
+        """Test canceling an already completed job."""
+        with patch.object(Manager, '__init__', lambda self, **kwargs: None):
+            manager = Manager()
+            manager._oid = 'test-oid'
+            manager._jwt = 'test-jwt'
+            manager._search_url = None
+
+            manager._getSearchUrl = MagicMock(return_value='https://search.limacharlie.io/v1/search')
+            manager._restCall = MagicMock(return_value=(409, {'error': 'Job already completed'}))
+
+            with pytest.raises(LcApiException) as exc_info:
+                manager.cancelSearchDownload('completed-job')
+
+            assert 'cannot cancel' in str(exc_info.value).lower()
+
+    def test_wait_for_search_download_completes(self):
+        """Test waiting for a download job to complete."""
+        status_sequence = [
+            {'status': 'running', 'progress': {'eventsProcessed': 100}},
+            {'status': 'running', 'progress': {'eventsProcessed': 500}},
+            {'status': 'merging', 'progress': {'eventsProcessed': 1000}},
+            {'status': 'completed', 'resultUrl': 'https://storage.example.com/result.zip'}
+        ]
+        call_count = [0]
+
+        def mock_get_status(job_id):
+            result = status_sequence[min(call_count[0], len(status_sequence) - 1)]
+            call_count[0] += 1
+            return result
+
+        with patch.object(Manager, '__init__', lambda self, **kwargs: None):
+            manager = Manager()
+            manager._oid = 'test-oid'
+            manager._jwt = 'test-jwt'
+
+            manager.getSearchDownloadStatus = MagicMock(side_effect=mock_get_status)
+
+            progress_calls = []
+
+            def track_progress(status):
+                progress_calls.append(status)
+
+            result = manager.waitForSearchDownload(
+                'test-job-123',
+                poll_interval=0.01,  # Fast polling for test
+                progress_callback=track_progress
+            )
+
+            assert result['status'] == 'completed'
+            assert result['resultUrl'] == 'https://storage.example.com/result.zip'
+            assert len(progress_calls) >= 3
+
+    def test_wait_for_search_download_fails(self):
+        """Test waiting for a job that fails."""
+        with patch.object(Manager, '__init__', lambda self, **kwargs: None):
+            manager = Manager()
+            manager._oid = 'test-oid'
+            manager._jwt = 'test-jwt'
+
+            manager.getSearchDownloadStatus = MagicMock(return_value={
+                'status': 'failed',
+                'error': 'Out of memory'
+            })
+
+            with pytest.raises(LcApiException) as exc_info:
+                manager.waitForSearchDownload('test-job-123', poll_interval=0.01)
+
+            assert 'failed' in str(exc_info.value).lower()
+            assert 'out of memory' in str(exc_info.value).lower()
+
+    def test_wait_for_search_download_timeout(self):
+        """Test that waiting times out correctly."""
+        with patch.object(Manager, '__init__', lambda self, **kwargs: None):
+            manager = Manager()
+            manager._oid = 'test-oid'
+            manager._jwt = 'test-jwt'
+
+            # Always return running status
+            manager.getSearchDownloadStatus = MagicMock(return_value={
+                'status': 'running',
+                'progress': {'eventsProcessed': 100}
+            })
+
+            with pytest.raises(LcApiException) as exc_info:
+                manager.waitForSearchDownload(
+                    'test-job-123',
+                    poll_interval=0.01,
+                    timeout=0.05  # Very short timeout
+                )
+
+            assert 'timeout' in str(exc_info.value).lower()
+
+
+class TestSearchDownloadCLI:
+    """Tests for the search-download CLI commands."""
+
+    def test_cli_start_basic(self, monkeypatch, capsys):
+        """Test the start command with basic options."""
+        mock_manager = MagicMock()
+        mock_manager._oid = 'test-oid'
+        mock_manager.getJWT.return_value = 'test-jwt'
+        mock_manager.initiateSearchDownload.return_value = {
+            'jobId': 'cli-job-123',
+            'estimatedStats': {'eventsMatched': 1000}
+        }
+
+        with patch('limacharlie.SearchDownload.Manager', return_value=mock_manager):
+            search_download_cli([
+                'start',
+                '-q', 'event_type = *',
+                '-s', 'now-1h',
+                '-e', 'now'
+            ])
+
+        captured = capsys.readouterr()
+        assert 'cli-job-123' in captured.out
+
+    def test_cli_start_json_output(self, monkeypatch, capsys):
+        """Test the start command with JSON output."""
+        mock_manager = MagicMock()
+        mock_manager._oid = 'test-oid'
+        mock_manager.getJWT.return_value = 'test-jwt'
+        mock_manager.initiateSearchDownload.return_value = {
+            'jobId': 'json-job-456',
+            'estimatedStats': {'eventsMatched': 500}
+        }
+
+        with patch('limacharlie.SearchDownload.Manager', return_value=mock_manager):
+            search_download_cli([
+                'start',
+                '-q', '*',
+                '-s', 'now-1h',
+                '-e', 'now',
+                '--json'
+            ])
+
+        captured = capsys.readouterr()
+        output = json.loads(captured.out)
+        assert output['jobId'] == 'json-job-456'
+
+    def test_cli_status_command(self, monkeypatch, capsys):
+        """Test the status command."""
+        mock_manager = MagicMock()
+        mock_manager.getSearchDownloadStatus.return_value = {
+            'jobId': 'status-job-789',
+            'status': 'running',
+            'progress': {'eventsProcessed': 5000}
+        }
+
+        with patch('limacharlie.SearchDownload.Manager', return_value=mock_manager):
+            search_download_cli(['status', 'status-job-789'])
+
+        captured = capsys.readouterr()
+        assert 'status-job-789' in captured.out
+        assert 'running' in captured.out.lower()
+
+    def test_cli_list_command(self, monkeypatch, capsys):
+        """Test the list command."""
+        mock_manager = MagicMock()
+        mock_manager.listSearchDownloads.return_value = [
+            {'jobId': 'list-job-1', 'status': 'completed'},
+            {'jobId': 'list-job-2', 'status': 'running'}
+        ]
+
+        with patch('limacharlie.SearchDownload.Manager', return_value=mock_manager):
+            search_download_cli(['list', '--limit', '10'])
+
+        captured = capsys.readouterr()
+        assert 'list-job-1' in captured.out
+        assert 'list-job-2' in captured.out
+
+    def test_cli_cancel_command(self, monkeypatch, capsys):
+        """Test the cancel command."""
+        mock_manager = MagicMock()
+        mock_manager.cancelSearchDownload.return_value = True
+
+        with patch('limacharlie.SearchDownload.Manager', return_value=mock_manager):
+            search_download_cli(['cancel', 'cancel-job-123'])
+
+        captured = capsys.readouterr()
+        assert 'cancelled' in captured.out.lower()
+
+    def test_cli_url_command_completed_job(self, monkeypatch, capsys):
+        """Test the url command for a completed job."""
+        mock_manager = MagicMock()
+        mock_manager.getSearchDownloadStatus.return_value = {
+            'jobId': 'url-job-123',
+            'status': 'completed',
+            'resultUrl': 'https://storage.example.com/results.zip'
+        }
+
+        with patch('limacharlie.SearchDownload.Manager', return_value=mock_manager):
+            search_download_cli(['url', 'url-job-123'])
+
+        captured = capsys.readouterr()
+        assert 'https://storage.example.com/results.zip' in captured.out
+
+    def test_cli_url_command_not_completed(self, monkeypatch, capsys):
+        """Test the url command for a job that's not completed."""
+        mock_manager = MagicMock()
+        mock_manager.getSearchDownloadStatus.return_value = {
+            'jobId': 'running-job-123',
+            'status': 'running'
+        }
+
+        with patch('limacharlie.SearchDownload.Manager', return_value=mock_manager):
+            with pytest.raises(SystemExit) as exc_info:
+                search_download_cli(['url', 'running-job-123'])
+
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert 'not completed' in captured.err.lower()
+
+    def test_cli_wait_command(self, monkeypatch, capsys):
+        """Test the wait command."""
+        status_sequence = [
+            {'status': 'running', 'progress': {'eventsProcessed': 100}},
+            {'status': 'completed', 'resultUrl': 'https://example.com/result.zip'}
+        ]
+        call_count = [0]
+
+        def mock_get_status(job_id):
+            result = status_sequence[min(call_count[0], len(status_sequence) - 1)]
+            call_count[0] += 1
+            return result
+
+        mock_manager = MagicMock()
+        mock_manager.getSearchDownloadStatus.side_effect = mock_get_status
+        mock_manager.waitForSearchDownload.return_value = status_sequence[-1]
+
+        with patch('limacharlie.SearchDownload.Manager', return_value=mock_manager):
+            search_download_cli(['wait', 'wait-job-123', '--quiet', '--poll-interval', '1'])
+
+        captured = capsys.readouterr()
+        # With --quiet, minimal output expected
+        assert 'completed' in captured.out.lower() or 'wait-job-123' in captured.out
+
+    def test_cli_start_with_metadata(self, monkeypatch, capsys):
+        """Test start command with custom metadata."""
+        mock_manager = MagicMock()
+        mock_manager._oid = 'test-oid'
+        mock_manager.getJWT.return_value = 'test-jwt'
+        mock_manager.initiateSearchDownload.return_value = {'jobId': 'meta-job-123'}
+
+        captured_metadata = None
+
+        def capture_init_call(**kwargs):
+            nonlocal captured_metadata
+            captured_metadata = kwargs.get('metadata')
+            return {'jobId': 'meta-job-123'}
+
+        mock_manager.initiateSearchDownload.side_effect = capture_init_call
+
+        with patch('limacharlie.SearchDownload.Manager', return_value=mock_manager):
+            search_download_cli([
+                'start',
+                '-q', '*',
+                '-s', 'now-1h',
+                '-e', 'now',
+                '--metadata', '{"purpose": "forensics", "ticket": "INC-123"}'
+            ])
+
+        assert captured_metadata == {'purpose': 'forensics', 'ticket': 'INC-123'}
+
+    def test_cli_start_invalid_metadata_json(self, monkeypatch, capsys):
+        """Test start command with invalid metadata JSON."""
+        mock_manager = MagicMock()
+
+        with patch('limacharlie.SearchDownload.Manager', return_value=mock_manager):
+            with pytest.raises(SystemExit):
+                search_download_cli([
+                    'start',
+                    '-q', '*',
+                    '-s', 'now-1h',
+                    '-e', 'now',
+                    '--metadata', 'not-valid-json'
+                ])
+
+        captured = capsys.readouterr()
+        assert 'error parsing metadata' in captured.err.lower()
+
+    def test_cli_start_with_wait(self, monkeypatch, capsys):
+        """Test start command with --wait flag waits for job completion."""
+        mock_manager = MagicMock()
+        mock_manager._oid = 'test-oid'
+        mock_manager.getJWT.return_value = 'test-jwt'
+        mock_manager.initiateSearchDownload.return_value = {
+            'jobId': 'wait-start-job-123',
+            'estimatedStats': {'eventsMatched': 1000}
+        }
+        mock_manager.waitForSearchDownload.return_value = {
+            'jobId': 'wait-start-job-123',
+            'status': 'completed',
+            'resultUrl': 'https://storage.example.com/results.zip',
+            'progress': {
+                'eventsProcessed': 1000,
+                'runtimeSeconds': 120
+            }
+        }
+
+        with patch('limacharlie.SearchDownload.Manager', return_value=mock_manager):
+            search_download_cli([
+                'start',
+                '-q', 'event_type = *',
+                '-s', 'now-1h',
+                '-e', 'now',
+                '--wait'
+            ])
+
+        # Verify waitForSearchDownload was called with the job ID
+        mock_manager.waitForSearchDownload.assert_called_once()
+        call_args = mock_manager.waitForSearchDownload.call_args
+        assert call_args[0][0] == 'wait-start-job-123'
+
+        captured = capsys.readouterr()
+        # Should show job started and final completed status
+        assert 'wait-start-job-123' in captured.out
+        assert 'completed' in captured.out.lower()
+
+    def test_cli_start_with_wait_json_output(self, monkeypatch, capsys):
+        """Test start command with --wait and --json outputs final status as JSON."""
+        mock_manager = MagicMock()
+        mock_manager._oid = 'test-oid'
+        mock_manager.getJWT.return_value = 'test-jwt'
+        mock_manager.initiateSearchDownload.return_value = {
+            'jobId': 'wait-json-job-456',
+            'estimatedStats': {'eventsMatched': 500}
+        }
+        final_status = {
+            'jobId': 'wait-json-job-456',
+            'status': 'completed',
+            'resultUrl': 'https://storage.example.com/final-results.zip',
+            'progress': {
+                'eventsProcessed': 500,
+                'bytesProcessed': 1024000
+            }
+        }
+        mock_manager.waitForSearchDownload.return_value = final_status
+
+        with patch('limacharlie.SearchDownload.Manager', return_value=mock_manager):
+            search_download_cli([
+                'start',
+                '-q', '*',
+                '-s', 'now-1h',
+                '-e', 'now',
+                '--wait',
+                '--json'
+            ])
+
+        captured = capsys.readouterr()
+        # With --json and --wait, the output should be the final status as JSON
+        # The output will have two JSON objects: initial response and final status
+        output_lines = captured.out.strip().split('\n')
+
+        # Parse the outputs - there should be two JSON blocks
+        json_blocks = []
+        current_block = []
+        for line in output_lines:
+            current_block.append(line)
+            try:
+                json_blocks.append(json.loads('\n'.join(current_block)))
+                current_block = []
+            except json.JSONDecodeError:
+                continue
+
+        # Should have at least the final status
+        assert len(json_blocks) >= 1
+        # The last JSON block should be the final status
+        last_block = json_blocks[-1]
+        assert last_block['status'] == 'completed'
+        assert last_block['resultUrl'] == 'https://storage.example.com/final-results.zip'
+
+    def test_cli_start_with_wait_job_fails(self, monkeypatch, capsys):
+        """Test start command with --wait when job fails."""
+        mock_manager = MagicMock()
+        mock_manager._oid = 'test-oid'
+        mock_manager.getJWT.return_value = 'test-jwt'
+        mock_manager.initiateSearchDownload.return_value = {
+            'jobId': 'fail-job-789'
+        }
+        # Simulate job failure during wait
+        mock_manager.waitForSearchDownload.side_effect = LcApiException(
+            'Download job failed: Query timeout exceeded'
+        )
+
+        with patch('limacharlie.SearchDownload.Manager', return_value=mock_manager):
+            with pytest.raises(SystemExit) as exc_info:
+                search_download_cli([
+                    'start',
+                    '-q', '*',
+                    '-s', 'now-1h',
+                    '-e', 'now',
+                    '--wait'
+                ])
+
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert 'error' in captured.err.lower()


### PR DESCRIPTION
## Description

This PR implements SDK methods and CLI commands for managing search downloads (WIP functionality which hasn't been released yet and it's under development).

## Changes

- Add SDK methods to `Manager.py` for all search download operations (initiate, status, list, cancel, wait)
- Create new `SearchDownload.py` CLI module with subcommands for managing download jobs
- Wire up `search-download` action in main CLI entry point
- Auto-generate long-lived JWT tokens (8 hours default) when starting download jobs

## SDK Methods

| Method | Description |
|--------|-------------|
| `getJWT(expiry_seconds)` | Generate JWT with custom expiry timestamp |
| `initiateSearchDownload()` | Start a new download job with query parameters |
| `getSearchDownloadStatus()` | Get detailed status of a job by ID |
| `listSearchDownloads()` | List all download jobs with pagination |
| `cancelSearchDownload()` | Cancel a running job |
| `waitForSearchDownload()` | Poll until completion with optional callback |

## CLI Usage

```bash
# Start a download job (auto-generates 8-hour token)
limacharlie search-download start -q "event_type:NEW_PROCESS" -s now-1h -e now

# Start and wait for completion
limacharlie search-download start -q "event_type:NEW_PROCESS" -s now-1h -e now --wait

# Custom token lifetime (10 hours)
limacharlie search-download start -q "*" -s now-6h -e now --token-hours 10

# Check job status
limacharlie search-download status <job-id>

# List all jobs
limacharlie search-download list --limit 10

# Wait for completion with progress
limacharlie search-download wait <job-id>

# Get download URL
limacharlie search-download url <job-id>

# Cancel a job
limacharlie search-download cancel <job-id>

# JSON output for scripting
limacharlie search-download start -q "*" -s now-1h -e now --json
limacharlie search-download status <job-id> --json
```

## Related PRs

- Changes for generating token with custom expiration time - https://github.com/refractionPOINT/python-limacharlie/pull/202