### PR TITLE
Remove model hive from infrastructure-as-code

### DIFF
--- a/limacharlie/Configs.py
+++ b/limacharlie/Configs.py
@@ -987,12 +987,6 @@ def main( sourceArgs = None ):
                          action = 'store_true',
                          dest = 'isHivePlaybook',
                          help = 'if specified, apply playbooks in hive from operations' )
-    parser.add_argument( '--hive-model',
-                         required = False,
-                         default = False,
-                         action = 'store_true',
-                         dest = 'isHiveModel',
-                         help = 'if specified, apply models in hive from operations' )
     parser.add_argument( '--hive-ai-agent',
                          required = False,
                          default = False,
@@ -1067,7 +1061,6 @@ def main( sourceArgs = None ):
         'isHiveSecret',
         'isHiveQuery',
         'isHivePlaybook',
-        'isHiveModel',
         'isHiveAiAgent',
         'isHiveExternalAdapter',
     ]
@@ -1084,7 +1077,6 @@ def main( sourceArgs = None ):
         'secret': True,
         'query': True,
         'playbook': True,
-        'model': True,
         'ai_agent': True,
         'external_adapter': True,
     }
@@ -1127,8 +1119,6 @@ def main( sourceArgs = None ):
         hives['query'] = True
     if args.isHivePlaybook:
         hives['playbook'] = True
-    if args.isHiveModel:
-        hives['model'] = True
     if args.isHiveAiAgent:
         hives['ai_agent'] = True
     if args.isHiveExternalAdapter:

--- a/limacharlie/__init__.py
+++ b/limacharlie/__init__.py
@@ -1,6 +1,6 @@
 """limacharlie API for limacharlie.io"""
 
-__version__ = "4.11.2"
+__version__ = "4.11.3"
 __author__ = "Maxime Lamothe-Brassard ( Refraction Point, Inc )"
 __author_email__ = "maxime@refractionpoint.com"
 __license__ = "Apache v2"

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-__version__ = "4.11.2"
+__version__ = "4.11.3"
 __author__ = "Maxime Lamothe-Brassard ( Refraction Point, Inc )"
 __author_email__ = "maxime@refractionpoint.com"
 __license__ = "Apache v2"

--- a/tests/unit/test_configs.py
+++ b/tests/unit/test_configs.py
@@ -139,7 +139,6 @@ class TestConfigsAllFlag:
             'secret',
             'query',
             'playbook',
-            'model',
             'ai_agent',
             'external_adapter',
         }


### PR DESCRIPTION
## Summary
- Remove the `model` hive from IaC code since the feature is not released yet
- Keep the `limacharlie model` CLI command and Model.py available for direct use
- Bump version to 4.11.3

## Changes
- `limacharlie/Configs.py`: Remove `--hive-model` flag, remove from `resTypes` and `allHives`
- `tests/unit/test_configs.py`: Remove `model` from expected hives
- Version bump in `setup.py` and `__init__.py`

## Test plan
- [ ] Run unit tests
- [ ] Verify `limacharlie model` CLI command still works
- [ ] Verify `limacharlie configs --all` no longer includes model hive

🤖 Generated with [Claude Code](https://claude.com/claude-code)