### PR TITLE
Add `limacharlie usp validate` CLI command for testing adapter parsing

### DIFF
--- a/limacharlie/USP.py
+++ b/limacharlie/USP.py
@@ -187,6 +187,20 @@ def do_validate(args):
         if results:
             print(f'Partially parsed {len(results)} event(s) before failure.')
         sys.exit(1)
+    elif len(results) == 0:
+        # No events parsed - this likely indicates misconfigured parsing rules
+        print('VALIDATION FAILED\n')
+        print('WARNING: No events were parsed from the sample data.\n')
+        print('This usually indicates one of the following issues:')
+        print('  - The parsing_re regex does not match the input format')
+        print('  - The platform type does not match the data format')
+        print('  - The sample data is empty or contains only whitespace')
+        print('')
+        print('Suggestions:')
+        print('  - Verify your parsing_re regex matches the sample data')
+        print('  - Check that the platform matches your data format (text, json, cef, etc.)')
+        print('  - Ensure the sample file contains valid log data')
+        sys.exit(1)
     else:
         print('VALIDATION SUCCESSFUL\n')
         print(f'Parsed {len(results)} event(s):\n')

--- a/limacharlie/USP.py
+++ b/limacharlie/USP.py
@@ -1,0 +1,338 @@
+# Copyright 2024 Refraction Point, Inc.
+# Licensed under the Apache License, Version 2.0
+
+"""
+USP (Universal Sensor Protocol) CLI module for LimaCharlie.
+
+Provides commands for validating USP adapter configurations before deployment.
+"""
+
+from limacharlie import Manager
+import yaml
+import json
+import sys
+
+
+def printData(data):
+    """
+    Print data in a human-readable format.
+
+    Parameters:
+        data: The data to print (str, dict, or list).
+
+    Return:
+        None
+    """
+    if isinstance(data, str):
+        print(data)
+    else:
+        print(yaml.safe_dump(data, default_flow_style=False))
+
+
+def reportError(msg):
+    """
+    Report an error message to stderr and exit with code 1.
+
+    Parameters:
+        msg (str): The error message to display.
+
+    Return:
+        None (exits the program)
+    """
+    sys.stderr.write(msg + '\n')
+    sys.exit(1)
+
+
+def _load_file_content(file_path, as_json=False):
+    """
+    Load content from a file.
+
+    Parameters:
+        file_path (str): Path to the file to load.
+        as_json (bool): If True, parse as JSON. If False, return raw text.
+
+    Return:
+        The file content (parsed JSON or raw string).
+    """
+    try:
+        with open(file_path, 'rb') as f:
+            content = f.read().decode('utf-8')
+            if as_json:
+                return json.loads(content)
+            return content
+    except FileNotFoundError:
+        reportError(f'File not found: {file_path}')
+    except json.JSONDecodeError as e:
+        reportError(f'Invalid JSON in file {file_path}: {e}')
+    except Exception as e:
+        reportError(f'Error reading file {file_path}: {e}')
+
+
+def _load_mapping(args):
+    """
+    Load mapping configuration from file or inline argument.
+
+    Parameters:
+        args: Parsed arguments containing mapping or mapping_file.
+
+    Return:
+        dict: The mapping configuration, or None if not provided.
+    """
+    if args.mapping_file:
+        try:
+            with open(args.mapping_file, 'rb') as f:
+                content = f.read()
+                # Try YAML first (also handles JSON)
+                return yaml.safe_load(content)
+        except Exception as e:
+            reportError(f'Error loading mapping file: {e}')
+    elif args.mapping:
+        try:
+            return json.loads(args.mapping)
+        except json.JSONDecodeError as e:
+            reportError(f'Invalid JSON in mapping argument: {e}')
+    return None
+
+
+def do_validate(args):
+    """
+    Validate a USP adapter configuration against sample data.
+
+    Tests parsing rules by sending sample data through the parsing engine
+    and returning the parsed events or error messages. This allows verification
+    of parsing configurations before deploying adapters to production.
+
+    Parameters:
+        args: Parsed arguments containing platform, mapping, and input data.
+
+    Return:
+        None (prints validation results to stdout)
+    """
+    # Platforms with built-in parsers that don't require custom mapping
+    builtin_parser_platforms = ['cef', 'wel', 'gcp', 'aws', '1password', 'duo', 'slack']
+
+    # Load mapping configuration
+    mapping = _load_mapping(args)
+    if mapping is None and args.mappings_file is None:
+        # Only require mapping for platforms that need custom parsing rules
+        if args.platform not in builtin_parser_platforms:
+            reportError(f'Platform "{args.platform}" requires a mapping configuration.\n'
+                       f'Use --mapping, --mapping-file, or --mappings-file to provide one.\n'
+                       f'Platforms with built-in parsers (no mapping required): {", ".join(builtin_parser_platforms)}')
+
+    # Load mappings array if provided
+    mappings = None
+    if args.mappings_file:
+        mappings = _load_file_content(args.mappings_file, as_json=True)
+        if not isinstance(mappings, list):
+            reportError('--mappings-file must contain a JSON array of mapping descriptors')
+
+    # Load input data
+    text_input = None
+    json_input = None
+
+    if args.input_file:
+        if args.json_input:
+            json_input = _load_file_content(args.input_file, as_json=True)
+            if not isinstance(json_input, list):
+                reportError('JSON input must be an array of objects')
+        else:
+            text_input = _load_file_content(args.input_file, as_json=False)
+    elif args.input:
+        if args.json_input:
+            try:
+                json_input = json.loads(args.input)
+                if not isinstance(json_input, list):
+                    reportError('JSON input must be an array of objects')
+            except json.JSONDecodeError as e:
+                reportError(f'Invalid JSON in input argument: {e}')
+        else:
+            text_input = args.input
+
+    if text_input is None and json_input is None:
+        reportError('Either --input or --input-file is required')
+
+    # Load indexing rules if provided
+    indexing = None
+    if args.indexing_file:
+        indexing = _load_file_content(args.indexing_file, as_json=True)
+        if not isinstance(indexing, list):
+            reportError('--indexing-file must contain a JSON array of indexing rules')
+
+    # Call the validation API
+    man = Manager(None, None)
+    try:
+        result = man.validateUSP(
+            platform=args.platform,
+            hostname=args.hostname,
+            mapping=mapping,
+            mappings=mappings,
+            indexing=indexing,
+            text_input=text_input,
+            json_input=json_input,
+        )
+    except Exception as e:
+        reportError(f'API error: {e}')
+
+    # Format and display results
+    errors = result.get('errors', [])
+    results = result.get('results', [])
+
+    if errors:
+        print('VALIDATION FAILED\n')
+        print('Errors:')
+        for err in errors:
+            print(f'  - {err}')
+        print('')
+        if results:
+            print(f'Partially parsed {len(results)} event(s) before failure.')
+        sys.exit(1)
+    else:
+        print('VALIDATION SUCCESSFUL\n')
+        print(f'Parsed {len(results)} event(s):\n')
+
+        if args.output_format == 'json':
+            print(json.dumps(results, indent=2))
+        elif args.output_format == 'yaml':
+            print(yaml.safe_dump(results, default_flow_style=False))
+        else:
+            # Default: summary format
+            for i, event in enumerate(results, 1):
+                print(f'Event {i}:')
+                # Show routing info if present
+                routing = event.get('routing', {})
+                if routing:
+                    hostname = routing.get('hostname', routing.get('this', {}).get('hostname', ''))
+                    if hostname:
+                        print(f'  hostname: {hostname}')
+                # Show event data
+                evt = event.get('event', event)
+                for key, value in evt.items():
+                    if key != 'routing':
+                        print(f'  {key}: {value}')
+                print('')
+
+
+def main(sourceArgs=None):
+    """
+    Main entry point for the USP CLI.
+
+    Parameters:
+        sourceArgs (list): Optional list of CLI arguments. If None, uses sys.argv.
+
+    Return:
+        None
+    """
+    import argparse
+
+    actions = {
+        'validate': do_validate,
+    }
+
+    parser = argparse.ArgumentParser(
+        prog='limacharlie usp',
+        description='USP (Universal Sensor Protocol) adapter management and validation.'
+    )
+    parser.add_argument(
+        'action',
+        type=str,
+        help='the action to take, one of: %s' % (', '.join(actions.keys()))
+    )
+
+    # Platform selection
+    parser.add_argument(
+        '-p', '--platform',
+        type=str,
+        required=False,
+        default='text',
+        dest='platform',
+        choices=['text', 'json', 'cef', 'gcp', 'aws'],
+        help='parser platform type (default: text)'
+    )
+
+    # Mapping configuration (mutually exclusive options)
+    parser.add_argument(
+        '-m', '--mapping',
+        type=str,
+        required=False,
+        default=None,
+        dest='mapping',
+        help='inline JSON mapping configuration'
+    )
+    parser.add_argument(
+        '-f', '--mapping-file',
+        type=str,
+        required=False,
+        default=None,
+        dest='mapping_file',
+        help='path to YAML/JSON file containing mapping configuration'
+    )
+    parser.add_argument(
+        '--mappings-file',
+        type=str,
+        required=False,
+        default=None,
+        dest='mappings_file',
+        help='path to JSON file containing array of mapping descriptors (for multi-mapping selection)'
+    )
+
+    # Input data
+    parser.add_argument(
+        '-i', '--input',
+        type=str,
+        required=False,
+        default=None,
+        dest='input',
+        help='inline sample data to validate (text or JSON depending on --json-input)'
+    )
+    parser.add_argument(
+        '--input-file',
+        type=str,
+        required=False,
+        default=None,
+        dest='input_file',
+        help='path to file containing sample data to validate'
+    )
+    parser.add_argument(
+        '--json-input',
+        action='store_true',
+        default=False,
+        dest='json_input',
+        help='treat input as JSON array instead of newline-separated text'
+    )
+
+    # Optional parameters
+    parser.add_argument(
+        '--hostname',
+        type=str,
+        required=False,
+        default=None,
+        dest='hostname',
+        help='default hostname for sensors (defaults to "validation-test")'
+    )
+    parser.add_argument(
+        '--indexing-file',
+        type=str,
+        required=False,
+        default=None,
+        dest='indexing_file',
+        help='path to JSON file containing indexing rules'
+    )
+
+    # Output format
+    parser.add_argument(
+        '-o', '--output-format',
+        type=str,
+        required=False,
+        default='summary',
+        dest='output_format',
+        choices=['summary', 'json', 'yaml'],
+        help='output format for parsed events (default: summary)'
+    )
+
+    args = parser.parse_args(sourceArgs)
+    actions[args.action.lower()](args)
+
+
+if '__main__' == __name__:
+    main()

--- a/limacharlie/__main__.py
+++ b/limacharlie/__main__.py
@@ -54,7 +54,7 @@ def cli(args):
     parser = argparse.ArgumentParser( prog = 'limacharlie' )
     parser.add_argument( 'action',
                          type = str,
-                         help = 'management action, currently supported "login" (store credentials), "use" (use specific credentials), "set-oid" (change organization ID), "get-arl" (outputs data returned from ARLs), "dr" (manage Detection & Response rules), "search" (search for Indicators of Compromise), "search-api" (execute Search API queries), "replay" (replay D&R rules on data), "sync" (synchronize configurations from/to an org), "who" get current SDK authentication in effect, "detections" (download detections), "events" (download events), "artifacts" (get or upload artifacts), "users" (manage and invite users)' )
+                         help = 'management action, currently supported "login" (store credentials), "use" (use specific credentials), "set-oid" (change organization ID), "get-arl" (outputs data returned from ARLs), "dr" (manage Detection & Response rules), "search" (search for Indicators of Compromise), "search-api" (execute Search API queries), "replay" (replay D&R rules on data), "sync" (synchronize configurations from/to an org), "who" get current SDK authentication in effect, "detections" (download detections), "events" (download events), "artifacts" (get or upload artifacts), "users" (manage and invite users), "usp" (validate USP adapter configurations)' )
     parser.add_argument( 'opt_arg',
                          type = str,
                          nargs = "?",
@@ -557,6 +557,9 @@ def cli(args):
         print(json.dumps(Manager().getMITREReport(), indent = 2))
     elif args.action.lower() == 'users':
         from .User import main as cmdMain
+        cmdMain( actionArgs )
+    elif args.action.lower() == 'usp':
+        from .USP import main as cmdMain
         cmdMain( actionArgs )
     else:
         raise Exception( 'invalid action: %s' % (args.action.lower()) )

--- a/tests/unit/test_cli_sanity.py
+++ b/tests/unit/test_cli_sanity.py
@@ -38,6 +38,7 @@ AVAILABLE_ACTIONS_WITH_ARGUMENTS = [
     "sensors_with_ip",
     "mitre-report",
     "users",
+    "usp",
 ]
 
 

--- a/tests/unit/test_usp.py
+++ b/tests/unit/test_usp.py
@@ -284,15 +284,22 @@ class TestValidateAction:
 class TestValidateEmptyResults:
     """Tests for empty results handling in validation."""
 
-    def test_empty_results_exits_with_error(self, capsys, mocker):
+    def test_empty_results_exits_with_error(self, capsys, monkeypatch):
         """Test that empty parsing results cause exit with error code 1."""
-        # Mock the Manager.validateUSP to return empty results
-        mock_manager = mocker.patch('limacharlie.USP.Manager')
-        mock_instance = mock_manager.return_value
-        mock_instance.validateUSP.return_value = {
-            'errors': [],
-            'results': []  # Empty results
-        }
+        # Create a mock Manager class that returns empty results
+        class MockManager:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def validateUSP(self, **kwargs):
+                return {
+                    'errors': [],
+                    'results': []  # Empty results
+                }
+
+        # Patch the Manager class in the USP module
+        import limacharlie.USP as usp_module
+        monkeypatch.setattr(usp_module, 'Manager', MockManager)
 
         with pytest.raises(SystemExit) as exc_info:
             main([
@@ -302,14 +309,20 @@ class TestValidateEmptyResults:
             ])
         assert exc_info.value.code == 1
 
-    def test_empty_results_shows_warning_message(self, capsys, mocker):
+    def test_empty_results_shows_warning_message(self, capsys, monkeypatch):
         """Test that empty results display helpful warning message."""
-        mock_manager = mocker.patch('limacharlie.USP.Manager')
-        mock_instance = mock_manager.return_value
-        mock_instance.validateUSP.return_value = {
-            'errors': [],
-            'results': []
-        }
+        class MockManager:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def validateUSP(self, **kwargs):
+                return {
+                    'errors': [],
+                    'results': []
+                }
+
+        import limacharlie.USP as usp_module
+        monkeypatch.setattr(usp_module, 'Manager', MockManager)
 
         with pytest.raises(SystemExit):
             main([
@@ -323,14 +336,20 @@ class TestValidateEmptyResults:
         assert "No events were parsed" in captured.out
         assert "VALIDATION FAILED" in captured.out
 
-    def test_empty_results_shows_suggestions(self, capsys, mocker):
+    def test_empty_results_shows_suggestions(self, capsys, monkeypatch):
         """Test that empty results show troubleshooting suggestions."""
-        mock_manager = mocker.patch('limacharlie.USP.Manager')
-        mock_instance = mock_manager.return_value
-        mock_instance.validateUSP.return_value = {
-            'errors': [],
-            'results': []
-        }
+        class MockManager:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def validateUSP(self, **kwargs):
+                return {
+                    'errors': [],
+                    'results': []
+                }
+
+        import limacharlie.USP as usp_module
+        monkeypatch.setattr(usp_module, 'Manager', MockManager)
 
         with pytest.raises(SystemExit):
             main([
@@ -344,14 +363,20 @@ class TestValidateEmptyResults:
         assert "parsing_re" in captured.out.lower() or "regex" in captured.out.lower()
         assert "platform" in captured.out.lower()
 
-    def test_non_empty_results_succeeds(self, capsys, mocker):
+    def test_non_empty_results_succeeds(self, capsys, monkeypatch):
         """Test that non-empty results succeed without error."""
-        mock_manager = mocker.patch('limacharlie.USP.Manager')
-        mock_instance = mock_manager.return_value
-        mock_instance.validateUSP.return_value = {
-            'errors': [],
-            'results': [{'event_type': 'test', 'data': 'parsed'}]
-        }
+        class MockManager:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def validateUSP(self, **kwargs):
+                return {
+                    'errors': [],
+                    'results': [{'event_type': 'test', 'data': 'parsed'}]
+                }
+
+        import limacharlie.USP as usp_module
+        monkeypatch.setattr(usp_module, 'Manager', MockManager)
 
         # Should not raise SystemExit
         main([

--- a/tests/unit/test_usp.py
+++ b/tests/unit/test_usp.py
@@ -279,3 +279,87 @@ class TestValidateAction:
         assert exc_info.value.code == 1
         captured = capsys.readouterr()
         assert "array" in captured.err.lower()
+
+
+class TestValidateEmptyResults:
+    """Tests for empty results handling in validation."""
+
+    def test_empty_results_exits_with_error(self, capsys, mocker):
+        """Test that empty parsing results cause exit with error code 1."""
+        # Mock the Manager.validateUSP to return empty results
+        mock_manager = mocker.patch('limacharlie.USP.Manager')
+        mock_instance = mock_manager.return_value
+        mock_instance.validateUSP.return_value = {
+            'errors': [],
+            'results': []  # Empty results
+        }
+
+        with pytest.raises(SystemExit) as exc_info:
+            main([
+                "validate",
+                "--platform", "cef",  # Built-in parser, no mapping needed
+                "--input", "test data"
+            ])
+        assert exc_info.value.code == 1
+
+    def test_empty_results_shows_warning_message(self, capsys, mocker):
+        """Test that empty results display helpful warning message."""
+        mock_manager = mocker.patch('limacharlie.USP.Manager')
+        mock_instance = mock_manager.return_value
+        mock_instance.validateUSP.return_value = {
+            'errors': [],
+            'results': []
+        }
+
+        with pytest.raises(SystemExit):
+            main([
+                "validate",
+                "--platform", "cef",
+                "--input", "test data"
+            ])
+
+        captured = capsys.readouterr()
+        # Check that warning message is displayed
+        assert "No events were parsed" in captured.out
+        assert "VALIDATION FAILED" in captured.out
+
+    def test_empty_results_shows_suggestions(self, capsys, mocker):
+        """Test that empty results show troubleshooting suggestions."""
+        mock_manager = mocker.patch('limacharlie.USP.Manager')
+        mock_instance = mock_manager.return_value
+        mock_instance.validateUSP.return_value = {
+            'errors': [],
+            'results': []
+        }
+
+        with pytest.raises(SystemExit):
+            main([
+                "validate",
+                "--platform", "cef",
+                "--input", "test data"
+            ])
+
+        captured = capsys.readouterr()
+        # Check that suggestions are displayed
+        assert "parsing_re" in captured.out.lower() or "regex" in captured.out.lower()
+        assert "platform" in captured.out.lower()
+
+    def test_non_empty_results_succeeds(self, capsys, mocker):
+        """Test that non-empty results succeed without error."""
+        mock_manager = mocker.patch('limacharlie.USP.Manager')
+        mock_instance = mock_manager.return_value
+        mock_instance.validateUSP.return_value = {
+            'errors': [],
+            'results': [{'event_type': 'test', 'data': 'parsed'}]
+        }
+
+        # Should not raise SystemExit
+        main([
+            "validate",
+            "--platform", "cef",
+            "--input", "test data"
+        ])
+
+        captured = capsys.readouterr()
+        assert "VALIDATION SUCCESSFUL" in captured.out
+        assert "Parsed 1 event(s)" in captured.out

--- a/tests/unit/test_usp.py
+++ b/tests/unit/test_usp.py
@@ -1,0 +1,281 @@
+"""
+Unit tests for the USP (Universal Sensor Protocol) CLI module.
+
+Tests the USP validation CLI functionality including argument parsing,
+file loading, and error handling.
+"""
+
+import json
+import os
+import sys
+import tempfile
+import pytest
+import yaml
+
+from limacharlie.USP import (
+    _load_file_content,
+    _load_mapping,
+    main,
+    printData,
+    reportError,
+)
+
+
+class TestLoadFileContent:
+    """Tests for the _load_file_content helper function."""
+
+    def test_load_text_file(self, tmp_path):
+        """Test loading a plain text file."""
+        test_content = "line1\nline2\nline3"
+        test_file = tmp_path / "test.txt"
+        test_file.write_text(test_content)
+
+        result = _load_file_content(str(test_file), as_json=False)
+        assert result == test_content
+
+    def test_load_json_file(self, tmp_path):
+        """Test loading a JSON file."""
+        test_data = [{"key": "value"}, {"key2": "value2"}]
+        test_file = tmp_path / "test.json"
+        test_file.write_text(json.dumps(test_data))
+
+        result = _load_file_content(str(test_file), as_json=True)
+        assert result == test_data
+
+    def test_load_nonexistent_file(self):
+        """Test that loading a nonexistent file exits with error."""
+        with pytest.raises(SystemExit) as exc_info:
+            _load_file_content("/nonexistent/path/file.txt", as_json=False)
+        assert exc_info.value.code == 1
+
+    def test_load_invalid_json(self, tmp_path):
+        """Test that loading invalid JSON exits with error."""
+        test_file = tmp_path / "invalid.json"
+        test_file.write_text("not valid json {{{")
+
+        with pytest.raises(SystemExit) as exc_info:
+            _load_file_content(str(test_file), as_json=True)
+        assert exc_info.value.code == 1
+
+
+class TestLoadMapping:
+    """Tests for the _load_mapping helper function."""
+
+    def test_load_mapping_from_yaml_file(self, tmp_path):
+        """Test loading mapping from a YAML file."""
+        mapping_data = {
+            "parsing_re": r"(?P<timestamp>\S+) (?P<msg>.*)",
+            "event_type_path": "event_type"
+        }
+        yaml_file = tmp_path / "mapping.yaml"
+        yaml_file.write_text(yaml.dump(mapping_data))
+
+        # Use object instance to avoid class-scope variable access issues
+        class Args:
+            pass
+        args = Args()
+        args.mapping_file = str(yaml_file)
+        args.mapping = None
+
+        result = _load_mapping(args)
+        assert result == mapping_data
+
+    def test_load_mapping_from_json_file(self, tmp_path):
+        """Test loading mapping from a JSON file."""
+        mapping_data = {
+            "parsing_re": r"(?P<timestamp>\S+) (?P<msg>.*)",
+        }
+        json_file = tmp_path / "mapping.json"
+        json_file.write_text(json.dumps(mapping_data))
+
+        # Use object instance to avoid class-scope variable access issues
+        class Args:
+            pass
+        args = Args()
+        args.mapping_file = str(json_file)
+        args.mapping = None
+
+        result = _load_mapping(args)
+        assert result == mapping_data
+
+    def test_load_mapping_from_inline_json(self):
+        """Test loading mapping from inline JSON argument."""
+        mapping_json = '{"parsing_re": "(?P<ts>\\\\S+)"}'
+
+        class Args:
+            mapping_file = None
+            mapping = mapping_json
+
+        result = _load_mapping(Args())
+        assert result == {"parsing_re": r"(?P<ts>\S+)"}
+
+    def test_load_mapping_invalid_inline_json(self):
+        """Test that invalid inline JSON exits with error."""
+        class Args:
+            mapping_file = None
+            mapping = "not valid json"
+
+        with pytest.raises(SystemExit) as exc_info:
+            _load_mapping(Args())
+        assert exc_info.value.code == 1
+
+    def test_load_mapping_returns_none_if_not_provided(self):
+        """Test that no mapping returns None."""
+        class Args:
+            mapping_file = None
+            mapping = None
+
+        result = _load_mapping(Args())
+        assert result is None
+
+
+class TestPrintData:
+    """Tests for the printData helper function."""
+
+    def test_print_string(self, capsys):
+        """Test printing a plain string."""
+        printData("test message")
+        captured = capsys.readouterr()
+        assert "test message" in captured.out
+
+    def test_print_dict(self, capsys):
+        """Test printing a dictionary (as YAML)."""
+        printData({"key": "value"})
+        captured = capsys.readouterr()
+        assert "key: value" in captured.out
+
+
+class TestReportError:
+    """Tests for the reportError helper function."""
+
+    def test_report_error_exits(self):
+        """Test that reportError exits with code 1."""
+        with pytest.raises(SystemExit) as exc_info:
+            reportError("test error")
+        assert exc_info.value.code == 1
+
+    def test_report_error_writes_to_stderr(self, capsys):
+        """Test that reportError writes to stderr."""
+        with pytest.raises(SystemExit):
+            reportError("error message")
+        captured = capsys.readouterr()
+        assert "error message" in captured.err
+
+
+class TestMainArgParsing:
+    """Tests for the main CLI argument parsing."""
+
+    def test_main_shows_help(self, capsys):
+        """Test that --help works."""
+        with pytest.raises(SystemExit) as exc_info:
+            main(["validate", "--help"])
+        # argparse exits with 0 on --help
+        assert exc_info.value.code == 0
+
+    def test_main_requires_action(self, capsys):
+        """Test that missing action shows error."""
+        with pytest.raises(SystemExit) as exc_info:
+            main([])
+        assert exc_info.value.code == 2  # argparse error code
+
+    def test_main_validates_platform_choices(self, capsys):
+        """Test that invalid platform shows error."""
+        with pytest.raises(SystemExit) as exc_info:
+            main(["validate", "--platform", "invalid_platform"])
+        assert exc_info.value.code == 2  # argparse error code
+
+    def test_main_accepts_valid_platforms(self, capsys):
+        """Test that valid platforms are accepted."""
+        valid_platforms = ["text", "json", "cef", "gcp", "aws"]
+        for platform in valid_platforms:
+            # This will fail due to missing input, but platform should be accepted
+            with pytest.raises(SystemExit) as exc_info:
+                main(["validate", "--platform", platform])
+            # Exit code 1 means it got past argument parsing (missing input error)
+            assert exc_info.value.code == 1
+
+    def test_main_accepts_output_formats(self, capsys):
+        """Test that output format choices are valid."""
+        valid_formats = ["summary", "json", "yaml"]
+        for fmt in valid_formats:
+            with pytest.raises(SystemExit) as exc_info:
+                main(["validate", "--output-format", fmt])
+            # Exit code 1 means it got past argument parsing
+            assert exc_info.value.code == 1
+
+
+class TestValidateAction:
+    """Tests for the validate action end-to-end."""
+
+    def test_validate_requires_mapping_or_mappings(self, capsys):
+        """Test that validation fails without mapping."""
+        with pytest.raises(SystemExit) as exc_info:
+            main(["validate", "--input", "test data"])
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert "mapping" in captured.err.lower()
+
+    def test_validate_requires_input(self, capsys, tmp_path):
+        """Test that validation fails without input."""
+        mapping_file = tmp_path / "mapping.yaml"
+        mapping_file.write_text(yaml.dump({"parsing_re": ".*"}))
+
+        with pytest.raises(SystemExit) as exc_info:
+            main(["validate", "--mapping-file", str(mapping_file)])
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert "input" in captured.err.lower()
+
+    def test_validate_json_input_must_be_array(self, capsys, tmp_path):
+        """Test that JSON input must be an array."""
+        mapping_file = tmp_path / "mapping.yaml"
+        mapping_file.write_text(yaml.dump({"parsing_re": ".*"}))
+
+        # Create a JSON file with an object instead of array
+        input_file = tmp_path / "input.json"
+        input_file.write_text('{"key": "value"}')
+
+        with pytest.raises(SystemExit) as exc_info:
+            main([
+                "validate",
+                "--mapping-file", str(mapping_file),
+                "--input-file", str(input_file),
+                "--json-input"
+            ])
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert "array" in captured.err.lower()
+
+    def test_validate_mappings_file_must_be_array(self, capsys, tmp_path):
+        """Test that mappings file must contain an array."""
+        mappings_file = tmp_path / "mappings.json"
+        mappings_file.write_text('{"not": "array"}')
+
+        with pytest.raises(SystemExit) as exc_info:
+            main([
+                "validate",
+                "--mappings-file", str(mappings_file),
+                "--input", "test"
+            ])
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert "array" in captured.err.lower()
+
+    def test_validate_indexing_file_must_be_array(self, capsys, tmp_path):
+        """Test that indexing file must contain an array."""
+        mapping_file = tmp_path / "mapping.yaml"
+        mapping_file.write_text(yaml.dump({"parsing_re": ".*"}))
+
+        indexing_file = tmp_path / "indexing.json"
+        indexing_file.write_text('{"not": "array"}')
+
+        with pytest.raises(SystemExit) as exc_info:
+            main([
+                "validate",
+                "--mapping-file", str(mapping_file),
+                "--input", "test",
+                "--indexing-file", str(indexing_file)
+            ])
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert "array" in captured.err.lower()


### PR DESCRIPTION
## Description

Add `limacharlie usp validate` CLI command for testing USP adapter parsing configurations against sample data before deployment.

This allows users to verify their parsing rules work correctly without deploying an adapter.

- New `USP.py` module with validation logic
- Calls LimaCharlie validation API (`POST /usp/validate/{oid}`)
- Built-in parser platforms (cef, wel, gcp, aws, 1password, duo, slack) don't require custom mapping
- Multiple input methods: inline text, file, JSON array
- Output formats: summary, json, yaml

## Usage

```bash
# Text platform with custom mapping
limacharlie usp validate \
  --platform text \
  --mapping-file mapping.yaml \
  --input-file sample.log \
  --output-format json

# CEF platform (built-in parser, no mapping required)
limacharlie usp validate \
  --platform cef \
  --input-file cef-sample.log

# JSON platform with field mapping
limacharlie usp validate \
  --platform json \
  --mapping-file json-mapping.yaml \
  --input-file data.json \
  --json-input \
  --output-format json
```

## Example Output

```
=== Testing Text Platform Parsing ===
Platform 'text' requires a custom mapping
VALIDATION SUCCESSFUL

Parsed 3 event(s):

[
  {
    "event_time": 0,
    "event_type": "INFO",
    "hostname": "server01",
    "index_records": null,
    "investigation_id": "",
    "json_payload": {
      "hostname": "server01",
      "level": "INFO",
      "message": "User login successful",
      "timestamp": "2024-01-01T12:00:00Z"
    },
    "sensor_key": "",
    "sid_ccs": null
  },
  {
    "event_time": 0,
    "event_type": "WARN",
    "hostname": "server01",
    "index_records": null,
    "investigation_id": "",
    "json_payload": {
      "hostname": "server01",
      "level": "WARN",
      "message": "High memory usage detected",
      "timestamp": "2024-01-01T12:00:05Z"
    },
    "sensor_key": "",
    "sid_ccs": null
  },
  {
    "event_time": 0,
    "event_type": "ERROR",
    "hostname": "server02",
    "index_records": null,
    "investigation_id": "",
    "json_payload": {
      "hostname": "server02",
      "level": "ERROR",
      "message": "Database connection failed",
      "timestamp": "2024-01-01T12:00:10Z"
    },
    "sensor_key": "",
    "sid_ccs": null
  }
]
```

## Test plan

- [x] Run `limacharlie usp validate --help` to verify CLI registration
- [x] Test text platform with custom mapping file
- [x] Test JSON platform with `--json-input` flag
- [x] Test built-in parser platform (cef) without mapping
- [x] Verify error handling for missing required arguments
- [x] Verify non-zero exit code on validation failure

## Links

- Tracking ticket - https://github.com/refractionPOINT/python-limacharlie/pull/207
- Support ticket - https://app.suptask.com/tickets/67