### PR TITLE
Fix AI SDK form encoding and add ticketing target alias

### DIFF
--- a/limacharlie/commands/api_cmd.py
+++ b/limacharlie/commands/api_cmd.py
@@ -30,6 +30,7 @@ _TARGETS = {
     "jwt": "https://jwt.limacharlie.io",
     "stream": "https://stream-tmp.limacharlie.io",
     "downloads": "https://downloads.limacharlie.io",
+    "ticketing": "https://ticketing.limacharlie.io",
 }
 
 
@@ -54,7 +55,7 @@ Use --json to send a JSON body instead.  -F coerces bools, ints, and supports
 @file for reading values from files.  Alternatively, use --input to send
 a raw body from a file or stdin.
 
-Target aliases: api (default), billing, jwt, stream, downloads.
+Target aliases: api (default), billing, jwt, stream, downloads, ticketing.
 Any other value is treated as a raw https:// URL.
 
 Non-200 responses are NOT errors: the raw response body is printed and the
@@ -170,7 +171,7 @@ def _exit_code_for_status(status: int) -> int:
 @click.option("--json", "use_json", is_flag=True, help="Send fields as JSON body instead of form-encoded.")
 @click.option("--input", "input_file", default=None, help="Request body from file (use '-' for stdin).")
 @click.option("--content-type", "content_type_override", default=None, help="Content-Type for --input body (default: auto-detect).")
-@click.option("--target", default="api", help="API host alias or URL (aliases: api, billing, jwt, stream, downloads).")
+@click.option("--target", default="api", help="API host alias or URL (aliases: api, billing, jwt, stream, downloads, ticketing).")
 @click.option("-i", "--include", "include_status", is_flag=True, help="Show HTTP status code in output.")
 @click.option("--silent", is_flag=True, help="Suppress response body.")
 @click.option("--no-auth", is_flag=True, help="Skip authentication.")

--- a/limacharlie/sdk/ai.py
+++ b/limacharlie/sdk/ai.py
@@ -27,8 +27,7 @@ class AI:
             description: Natural language description of the desired rule.
         """
         return self.client.request("POST", "ai/dr",
-                                   raw_body=json.dumps({"query": description}).encode(),
-                                   content_type="application/json")
+                                   params={"query": description})
 
     def generate_detection(self, description: str) -> dict[str, Any]:
         """Generate a detection component from a natural language description.
@@ -37,8 +36,7 @@ class AI:
             description: Natural language description of the detection logic.
         """
         return self.client.request("POST", "ai/detection",
-                                   raw_body=json.dumps({"query": description}).encode(),
-                                   content_type="application/json")
+                                   params={"query": description})
 
     def generate_response(self, description: str) -> dict[str, Any]:
         """Generate a response component from a natural language description.
@@ -47,8 +45,7 @@ class AI:
             description: Natural language description of the response action.
         """
         return self.client.request("POST", "ai/response",
-                                   raw_body=json.dumps({"query": description}).encode(),
-                                   content_type="application/json")
+                                   params={"query": description})
 
     def generate_lcql(self, description: str) -> dict[str, Any]:
         """Generate an LCQL query from a natural language description.
@@ -57,8 +54,7 @@ class AI:
             description: Natural language description of the query.
         """
         return self.client.request("POST", "ai/lcql",
-                                   raw_body=json.dumps({"query": description}).encode(),
-                                   content_type="application/json")
+                                   params={"query": description})
 
     def generate_sensor_selector(self, description: str) -> dict[str, Any]:
         """Generate a sensor selector from a natural language description.
@@ -67,8 +63,7 @@ class AI:
             description: Natural language description of the target sensors.
         """
         return self.client.request("POST", "ai/sensor_selector",
-                                   raw_body=json.dumps({"query": description}).encode(),
-                                   content_type="application/json")
+                                   params={"query": description})
 
     def generate_playbook(self, description: str) -> dict[str, Any]:
         """Generate a Python playbook from a natural language description.
@@ -77,8 +72,7 @@ class AI:
             description: Natural language description of the playbook logic.
         """
         return self.client.request("POST", "ai/playbook/python",
-                                   raw_body=json.dumps({"query": description}).encode(),
-                                   content_type="application/json")
+                                   params={"query": description})
 
     def summarize_detection(self, detection_data: dict[str, Any]) -> dict[str, Any]:
         """Generate a human-readable summary of a detection.
@@ -87,5 +81,4 @@ class AI:
             detection_data: Detection data dict to summarize.
         """
         return self.client.request("POST", "ai/det_summary",
-                                   raw_body=json.dumps({"query": json.dumps(detection_data)}).encode(),
-                                   content_type="application/json")
+                                   params={"query": json.dumps(detection_data)})

--- a/tests/unit/test_api_cmd.py
+++ b/tests/unit/test_api_cmd.py
@@ -106,6 +106,14 @@ class TestTargetResolution:
             _, kwargs = mock_cls.return_value.raw_request.call_args
             assert kwargs["alt_root"] == "https://billing.limacharlie.io"
 
+    def test_ticketing_target(self):
+        with _patch_client() as mock_cls:
+            runner = CliRunner()
+            result = runner.invoke(cli, ["api", "--target", "ticketing", "api/v1/tickets"])
+            assert result.exit_code == 0
+            _, kwargs = mock_cls.return_value.raw_request.call_args
+            assert kwargs["alt_root"] == "https://ticketing.limacharlie.io"
+
     def test_raw_url_target(self):
         with _patch_client() as mock_cls:
             runner = CliRunner()

--- a/tests/unit/test_sdk_ai.py
+++ b/tests/unit/test_sdk_ai.py
@@ -26,10 +26,9 @@ class TestAIGenerateDrRule:
         ai.generate_dr_rule("detect mimikatz")
         call_args = mock_org.client.request.call_args
         assert call_args[0] == ("POST", "ai/dr")
-        body = json.loads(call_args[1]["raw_body"])
-        assert body["query"] == "detect mimikatz"
-        assert "description" not in body
-        assert call_args[1]["content_type"] == "application/json"
+        assert call_args[1]["params"] == {"query": "detect mimikatz"}
+        assert "raw_body" not in call_args[1]
+        assert "content_type" not in call_args[1]
         assert "test-oid" not in call_args[0][1]
 
 
@@ -39,10 +38,9 @@ class TestAIGenerateDetection:
         ai.generate_detection("lateral movement")
         call_args = mock_org.client.request.call_args
         assert call_args[0] == ("POST", "ai/detection")
-        body = json.loads(call_args[1]["raw_body"])
-        assert body["query"] == "lateral movement"
-        assert "description" not in body
-        assert call_args[1]["content_type"] == "application/json"
+        assert call_args[1]["params"] == {"query": "lateral movement"}
+        assert "raw_body" not in call_args[1]
+        assert "content_type" not in call_args[1]
 
 
 class TestAIGenerateResponse:
@@ -51,9 +49,9 @@ class TestAIGenerateResponse:
         ai.generate_response("isolate sensor")
         call_args = mock_org.client.request.call_args
         assert call_args[0] == ("POST", "ai/response")
-        body = json.loads(call_args[1]["raw_body"])
-        assert body["query"] == "isolate sensor"
-        assert call_args[1]["content_type"] == "application/json"
+        assert call_args[1]["params"] == {"query": "isolate sensor"}
+        assert "raw_body" not in call_args[1]
+        assert "content_type" not in call_args[1]
 
 
 class TestAIGenerateLcql:
@@ -62,9 +60,9 @@ class TestAIGenerateLcql:
         ai.generate_lcql("find all DNS events")
         call_args = mock_org.client.request.call_args
         assert call_args[0] == ("POST", "ai/lcql")
-        body = json.loads(call_args[1]["raw_body"])
-        assert body["query"] == "find all DNS events"
-        assert call_args[1]["content_type"] == "application/json"
+        assert call_args[1]["params"] == {"query": "find all DNS events"}
+        assert "raw_body" not in call_args[1]
+        assert "content_type" not in call_args[1]
 
 
 class TestAIGenerateSensorSelector:
@@ -73,9 +71,9 @@ class TestAIGenerateSensorSelector:
         ai.generate_sensor_selector("all windows servers")
         call_args = mock_org.client.request.call_args
         assert call_args[0] == ("POST", "ai/sensor_selector")
-        body = json.loads(call_args[1]["raw_body"])
-        assert body["query"] == "all windows servers"
-        assert call_args[1]["content_type"] == "application/json"
+        assert call_args[1]["params"] == {"query": "all windows servers"}
+        assert "raw_body" not in call_args[1]
+        assert "content_type" not in call_args[1]
 
 
 class TestAIGeneratePlaybook:
@@ -84,9 +82,9 @@ class TestAIGeneratePlaybook:
         ai.generate_playbook("respond to ransomware")
         call_args = mock_org.client.request.call_args
         assert call_args[0] == ("POST", "ai/playbook/python")
-        body = json.loads(call_args[1]["raw_body"])
-        assert body["query"] == "respond to ransomware"
-        assert call_args[1]["content_type"] == "application/json"
+        assert call_args[1]["params"] == {"query": "respond to ransomware"}
+        assert "raw_body" not in call_args[1]
+        assert "content_type" not in call_args[1]
 
 
 class TestAISummarizeDetection:
@@ -96,6 +94,6 @@ class TestAISummarizeDetection:
         ai.summarize_detection(detection)
         call_args = mock_org.client.request.call_args
         assert call_args[0] == ("POST", "ai/det_summary")
-        body = json.loads(call_args[1]["raw_body"])
-        assert body["query"] == json.dumps(detection)
-        assert call_args[1]["content_type"] == "application/json"
+        assert call_args[1]["params"] == {"query": json.dumps(detection)}
+        assert "raw_body" not in call_args[1]
+        assert "content_type" not in call_args[1]


### PR DESCRIPTION
## Summary

- **Fix all `ai` commands returning `{'error': 'query is required'}`**: The AI SDK was sending requests with `Content-Type: application/json` (`raw_body` + `content_type`), but the LC API backend (`lc_api-go/service/input.go`) only parses form-encoded bodies (`application/x-www-form-urlencoded`). The JSON body was silently ignored, causing the backend to see an empty `query` parameter. Switched all AI methods to use `params=` for proper form encoding.
- **Add `ticketing` target alias to `limacharlie api`**: Added `"ticketing": "https://ticketing.limacharlie.io"` so users can write `--target ticketing` instead of `--target "https://ticketing.limacharlie.io"`. Updated `--ai-help` text and `--target` help string.

## Affected commands

All `ai` subcommands: `generate-query`, `generate-detection`, `generate-response`, `generate-rule`, `generate-selector`, `generate-playbook`, `summarize-detection`

## Test plan

- [x] Unit tests updated and passing (713 passed)
- [ ] Manual test: `limacharlie ai generate-query --prompt "find DNS events" --oid <oid>` returns a valid LCQL query
- [ ] Manual test: `limacharlie api --target ticketing "api/v1/tickets?oids={oid}" --oid <oid>` returns tickets

> **Note**: `ai generate-rule` (which calls `/ai/dr`) will still fail with `"invalid AI configuration"` because the backend `aiConfigs` map has no `"dr"` entry — that's a separate backend fix in `lc_api-go`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)