### PR TITLE
Update cloudbuild-pr image

### DIFF
--- a/cloudbuild_pr.yaml
+++ b/cloudbuild_pr.yaml
@@ -1,6 +1,6 @@
 steps:
 - id: "Run Unit Tests"
-  name: "python:3.15"
+  name: "python:3.14"
   entrypoint: "bash"
   args:
     - "-c"
@@ -13,7 +13,7 @@ steps:
   waitFor: ["-"]  # Run in parallel with other steps.
 
 - id: "Run Integration Tests"
-  name: "python:3.15"
+  name: "python:3.14"
   entrypoint: "bash"
   args:
     - "-c"
@@ -27,7 +27,7 @@ steps:
   waitFor: ["-"]  # Run in parallel with other steps.
 
 - id: "Run wheel Sanity Checks"
-  name: 'python:3.15'
+  name: 'python:3.14'
   entrypoint: "bash"
   args:
     - '-c'
@@ -52,7 +52,7 @@ steps:
   waitFor: ["-"]  # Run in parallel with other steps.
 
 - id: "Run sdist Sanity Checks"
-  name: 'python:3.15'
+  name: 'python:3.14'
   entrypoint: "bash"
   args:
     - '-c'

--- a/cloudbuild_pr.yaml
+++ b/cloudbuild_pr.yaml
@@ -1,6 +1,6 @@
 steps:
 - id: "Run Unit Tests"
-  name: "python:3.11-slim"
+  name: "python:3.15"
   entrypoint: "bash"
   args:
     - "-c"
@@ -13,7 +13,7 @@ steps:
   waitFor: ["-"]  # Run in parallel with other steps.
 
 - id: "Run Integration Tests"
-  name: "python:3.11-slim"
+  name: "python:3.15"
   entrypoint: "bash"
   args:
     - "-c"
@@ -27,7 +27,7 @@ steps:
   waitFor: ["-"]  # Run in parallel with other steps.
 
 - id: "Run wheel Sanity Checks"
-  name: 'python:3.9-slim'
+  name: 'python:3.15'
   entrypoint: "bash"
   args:
     - '-c'
@@ -52,7 +52,7 @@ steps:
   waitFor: ["-"]  # Run in parallel with other steps.
 
 - id: "Run sdist Sanity Checks"
-  name: 'python:3.9-slim'
+  name: 'python:3.15'
   entrypoint: "bash"
   args:
     - '-c'


### PR DESCRIPTION
As 
For CLI-v2, I [made a hange](https://github.com/refractionPOINT/python-limacharlie/pull/214) that needs git during cloud build.

[Current cloud-build](https://github.com/refractionPOINT/python-limacharlie/blob/cli-v2/cloudbuild_pr.yaml#L3) uses python:3.11-slim image that doesn't have git installed. Now builds will fail as `setuptools-scm` requires git. 

Adding  apt install git to all steps doesn't make sense, so let's use the full image in the cloud build for now, and switch to using GHA by release of v5.



PS. Using the full image didn't changed the build time much: it has been between 2:30 and 3:50 min on average and now 3:24/ 