### PR TITLE
Show web app URL after org create

### DIFF
--- a/limacharlie/commands/org.py
+++ b/limacharlie/commands/org.py
@@ -390,6 +390,20 @@ def create(ctx: click.Context, name: str, location: str, template: str | None) -
     data = Organization.create_org(client, name, location, template)
     _output(ctx, data)
 
+    # Show the web app URL for the new org on success.
+    oid = None
+    inner = data.get("data") if isinstance(data, dict) else None
+    if isinstance(inner, dict):
+        oid = inner.get("oid")
+    elif isinstance(inner, str):
+        try:
+            import json
+            oid = json.loads(inner).get("oid")
+        except (ValueError, AttributeError):
+            pass
+    if oid and not ctx.obj.quiet:
+        click.echo(f"\nOrganization URL: https://app.limacharlie.io/orgs/{oid}")
+
 
 # ---------------------------------------------------------------------------
 # delete

--- a/tests/unit/test_cli_commands.py
+++ b/tests/unit/test_cli_commands.py
@@ -166,6 +166,35 @@ class TestOrgCommands:
 
     @patch("limacharlie.commands.org.Client")
     @patch("limacharlie.commands.org.Organization")
+    def test_org_create_shows_url(self, mock_org_cls, mock_client_cls):
+        oid = "d379729c-ab8c-492b-808e-5be1bb09774f"
+        mock_org_cls.create_org.return_value = {
+            "success": True,
+            "data": {"code": "e3d54874270322f0", "loc": "usa", "oid": oid},
+        }
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--output", "json", "org", "create", "--name", "test-org"])
+        assert result.exit_code == 0
+        assert f"https://app.limacharlie.io/orgs/{oid}" in result.output
+        mock_org_cls.create_org.assert_called_once()
+
+    @patch("limacharlie.commands.org.Client")
+    @patch("limacharlie.commands.org.Organization")
+    def test_org_create_quiet_no_url(self, mock_org_cls, mock_client_cls):
+        oid = "d379729c-ab8c-492b-808e-5be1bb09774f"
+        mock_org_cls.create_org.return_value = {
+            "success": True,
+            "data": {"code": "abc", "loc": "usa", "oid": oid},
+        }
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--quiet", "org", "create", "--name", "test-org"])
+        assert result.exit_code == 0
+        assert "app.limacharlie.io" not in result.output
+
+    @patch("limacharlie.commands.org.Client")
+    @patch("limacharlie.commands.org.Organization")
     def test_org_errors(self, mock_org_cls, mock_client_cls):
         mock_org = MagicMock()
         mock_org.get_errors.return_value = [{"component": "output-s3", "error": "access denied"}]


### PR DESCRIPTION
## Summary
- After `limacharlie org create` succeeds, prints the web app URL (`https://app.limacharlie.io/orgs/<oid>`) so users can quickly open the new org in the browser
- Handles the `data` field as either a dict or JSON string for robustness
- Suppressed in `--quiet` mode
- Adds two unit tests covering normal and quiet output

## Test plan
- [x] `test_org_create_shows_url` — verifies URL appears in output
- [x] `test_org_create_quiet_no_url` — verifies URL is suppressed with `--quiet`
- [ ] Manual: `limacharlie org create --name test-org` and verify URL is printed

🤖 Generated with [Claude Code](https://claude.com/claude-code)