### PR TITLE
Add dr convert-rules CLI command for mass rule conversion

### DIFF
--- a/limacharlie/commands/_dr_convert.py
+++ b/limacharlie/commands/_dr_convert.py
@@ -1,0 +1,648 @@
+"""Core logic for mass rule conversion.
+
+Contains the GitHub crawler, local crawler, conversion pipeline,
+and progress display used by the ``dr convert-rules`` command.
+"""
+
+from __future__ import annotations
+
+import collections
+import json
+import os
+import re
+import shutil
+import ssl
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, TYPE_CHECKING
+from urllib.error import HTTPError
+from urllib.parse import quote as urlquote
+from urllib.request import Request, urlopen
+
+import click
+import yaml
+
+if TYPE_CHECKING:
+    from ..sdk.ai import AI
+    from ..sdk.organization import Organization
+
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+@dataclass
+class RuleFile:
+    """A source rule file to be converted."""
+
+    path: str       # Relative path from source root
+    content: str    # Raw file content
+    filename: str   # Basename
+
+
+@dataclass
+class ConversionResult:
+    """Result of converting a single rule."""
+
+    source_path: str
+    rule_key: str
+    success: bool
+    detect: dict[str, Any] | None = None
+    respond: list[dict[str, Any]] | Any | None = None
+    error: str | None = None
+    created_in_hive: bool = False
+
+
+# ---------------------------------------------------------------------------
+# File filtering
+# ---------------------------------------------------------------------------
+
+_RULE_EXTENSIONS = frozenset({
+    ".yml", ".yaml", ".json", ".sigma", ".spl", ".kql", ".toml",
+})
+
+_SKIP_BASENAMES = frozenset({
+    "readme.md", "license", "license.md", "license.txt",
+    "requirements.txt", "setup.py", "pyproject.toml", "setup.cfg",
+    ".gitignore", ".gitattributes",
+    "changelog.md", "changelog.txt", "changes.md",
+    "contributing.md", "code_of_conduct.md",
+    "makefile", "dockerfile", "docker-compose.yml", "docker-compose.yaml",
+    "tox.ini", "poetry.lock", "pipfile", "pipfile.lock",
+    "package.json", "package-lock.json", "tsconfig.json",
+    ".pre-commit-config.yaml", ".yamllint.yml", ".yamllint.yaml",
+    "mkdocs.yml", "mkdocs.yaml",
+})
+
+_SKIP_DIRS = frozenset({
+    ".github", ".git", ".gitlab", ".circleci",
+    "tests", "test", "testing", "ci", "scripts",
+    "docs", "doc", "documentation",
+    "__pycache__", "node_modules", ".vscode", ".idea",
+    "venv", ".venv", "env",
+    ".mypy_cache", ".pytest_cache", ".ruff_cache",
+})
+
+# When no explicit path is given for GitHub, prefer these directories.
+_RULE_DIRS = frozenset({
+    "rules", "detections", "sigma", "searches", "queries",
+    "detection-rules", "splunk", "detection_rules",
+})
+
+
+def is_rule_file(path: str) -> bool:
+    """Return True if *path* looks like a detection rule file."""
+    basename = os.path.basename(path).lower()
+    if basename in _SKIP_BASENAMES:
+        return False
+
+    parts = Path(path).parts
+    for part in parts:
+        if part.lower() in _SKIP_DIRS:
+            return False
+
+    _, ext = os.path.splitext(basename)
+    return ext in _RULE_EXTENSIONS
+
+
+def _has_rule_dir_ancestor(path: str) -> bool:
+    """Return True if any ancestor directory is a known rule directory."""
+    parts = Path(path).parts
+    for part in parts[:-1]:  # exclude filename
+        if part.lower() in _RULE_DIRS:
+            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# SSL helper (matches client.py)
+# ---------------------------------------------------------------------------
+
+def _create_ssl_context() -> ssl.SSLContext | None:
+    try:
+        ctx = ssl.create_default_context()
+        if hasattr(ssl, "OP_IGNORE_UNEXPECTED_EOF"):
+            ctx.options |= ssl.OP_IGNORE_UNEXPECTED_EOF
+        return ctx
+    except Exception:
+        return None
+
+
+_SSL_CTX = _create_ssl_context()
+
+
+def _urlopen(req: Request, timeout: int = 30) -> Any:
+    if _SSL_CTX is not None:
+        return urlopen(req, timeout=timeout, context=_SSL_CTX)
+    return urlopen(req, timeout=timeout)
+
+
+# ---------------------------------------------------------------------------
+# GitHub crawler
+# ---------------------------------------------------------------------------
+
+class GitHubCrawler:
+    """Crawl a GitHub repository for detection rule files."""
+
+    GITHUB_API = "https://api.github.com"
+
+    def __init__(
+        self,
+        repo: str,
+        path: str | None = None,
+        ref: str | None = None,
+        token: str | None = None,
+    ) -> None:
+        self._owner, self._repo = self._parse_repo(repo)
+        self._path = path.strip("/") if path else None
+        self._ref = ref
+        self._token = token
+
+    @property
+    def display_name(self) -> str:
+        parts = f"{self._owner}/{self._repo}"
+        if self._path:
+            parts += f"/{self._path}"
+        if self._ref:
+            parts += f" @ {self._ref}"
+        return parts
+
+    # -- URL parsing --------------------------------------------------------
+
+    @staticmethod
+    def _parse_repo(raw: str) -> tuple[str, str]:
+        """Parse ``owner/repo`` from various URL forms."""
+        raw = raw.strip().rstrip("/")
+        # Strip trailing .git
+        if raw.endswith(".git"):
+            raw = raw[:-4]
+        # Strip protocol and host
+        for prefix in ("https://github.com/", "http://github.com/", "github.com/"):
+            if raw.startswith(prefix):
+                raw = raw[len(prefix):]
+                break
+        parts = raw.split("/")
+        if len(parts) < 2:
+            raise ValueError(
+                f"Cannot parse GitHub repo from {raw!r}. "
+                "Expected owner/repo or https://github.com/owner/repo."
+            )
+        return parts[0], parts[1]
+
+    # -- HTTP helpers -------------------------------------------------------
+
+    def _api_get(self, endpoint: str, timeout: int = 30) -> Any:
+        """GET a GitHub API endpoint, returning parsed JSON."""
+        url = f"{self.GITHUB_API}{endpoint}"
+        headers = {
+            "Accept": "application/vnd.github.v3+json",
+            "User-Agent": "limacharlie-cli",
+        }
+        if self._token:
+            headers["Authorization"] = f"token {self._token}"
+        req = Request(url, headers=headers)
+        try:
+            resp = _urlopen(req, timeout=timeout)
+            try:
+                data = json.loads(resp.read().decode())
+            finally:
+                resp.close()
+            return data
+        except HTTPError as e:
+            body = e.read().decode() if hasattr(e, "read") else str(e)
+            if e.code == 403 and "rate limit" in body.lower():
+                raise RuntimeError(
+                    "GitHub API rate limit exceeded. "
+                    "Pass --github-token or set the GH_TOKEN environment variable."
+                ) from e
+            if e.code == 404:
+                raise RuntimeError(
+                    f"GitHub repo not found: {self._owner}/{self._repo}. "
+                    "If the repo is private, pass --github-token."
+                ) from e
+            raise RuntimeError(f"GitHub API error {e.code}: {body}") from e
+
+    def _fetch_raw(self, file_path: str, timeout: int = 30) -> str | None:
+        """Fetch file content from raw.githubusercontent.com."""
+        if self._ref is None:
+            raise RuntimeError("Cannot fetch raw content without a resolved ref")
+        # URL-encode the ref (branch names can contain /) and file path segments
+        encoded_ref = urlquote(self._ref, safe="")
+        encoded_path = "/".join(urlquote(seg, safe="") for seg in file_path.split("/"))
+        url = (
+            f"https://raw.githubusercontent.com/"
+            f"{urlquote(self._owner, safe='')}/{urlquote(self._repo, safe='')}/"
+            f"{encoded_ref}/{encoded_path}"
+        )
+        headers: dict[str, str] = {"User-Agent": "limacharlie-cli"}
+        if self._token:
+            headers["Authorization"] = f"token {self._token}"
+        req = Request(url, headers=headers)
+        try:
+            resp = _urlopen(req, timeout=timeout)
+            try:
+                content = resp.read()
+            finally:
+                resp.close()
+            # Skip binary files (contain null bytes)
+            if b"\x00" in content:
+                return None
+            return content.decode("utf-8", errors="replace")
+        except HTTPError:
+            return None
+
+    # -- Crawling -----------------------------------------------------------
+
+    def crawl(self, progress_echo: Callable[[str], None] | None = None) -> list[RuleFile]:
+        """Crawl the repository and return matching rule files.
+
+        Args:
+            progress_echo: Optional callable for status messages.
+        """
+        def _echo(msg: str) -> None:
+            if progress_echo:
+                progress_echo(msg)
+
+        # Resolve default branch if no ref given
+        if self._ref is None:
+            _echo("Resolving default branch...")
+            repo_info = self._api_get(f"/repos/{self._owner}/{self._repo}")
+            self._ref = repo_info["default_branch"]
+            _echo(f"Using branch: {self._ref}")
+
+        # Fetch the full recursive tree (single API call)
+        _echo("Fetching repository tree...")
+        encoded_ref = urlquote(self._ref, safe="")
+        tree_data = self._api_get(
+            f"/repos/{self._owner}/{self._repo}/git/trees/{encoded_ref}?recursive=1",
+            timeout=60,
+        )
+
+        if tree_data.get("truncated"):
+            _echo("Repository tree is very large, falling back to contents API...")
+            return self._crawl_contents_api(progress_echo=progress_echo)
+
+        # Filter to rule files
+        candidates: list[str] = []
+        for entry in tree_data.get("tree", []):
+            if entry.get("type") != "blob":
+                continue
+            path = entry["path"]
+            if self._path and not path.startswith(self._path + "/") and path != self._path:
+                continue
+            if is_rule_file(path):
+                candidates.append(path)
+
+        # When no explicit path given, try to narrow down to rule directories
+        if not self._path and candidates:
+            in_rule_dirs = [p for p in candidates if _has_rule_dir_ancestor(p)]
+            if in_rule_dirs:
+                candidates = in_rule_dirs
+
+        if not candidates:
+            return []
+
+        _echo(f"Found {len(candidates)} rule file(s), fetching content...")
+
+        # Fetch content in parallel
+        rule_files: list[RuleFile] = []
+        lock = threading.Lock()
+
+        def _fetch_one(path: str) -> RuleFile | None:
+            content = self._fetch_raw(path)
+            if content and content.strip():
+                return RuleFile(path=path, content=content, filename=os.path.basename(path))
+            return None
+
+        with ThreadPoolExecutor(max_workers=10) as pool:
+            futures = {pool.submit(_fetch_one, p): p for p in candidates}
+            for future in as_completed(futures):
+                result = future.result()
+                if result is not None:
+                    with lock:
+                        rule_files.append(result)
+
+        return rule_files
+
+    _MAX_CONTENTS_API_CALLS = 500  # safety limit to avoid runaway crawling
+
+    def _crawl_contents_api(self, progress_echo: Callable[[str], None] | None = None) -> list[RuleFile]:
+        """Fallback: crawl using the Contents API directory-by-directory."""
+        start_path = self._path or ""
+        rule_files: list[RuleFile] = []
+        dirs_to_visit: collections.deque[str] = collections.deque([start_path])
+        api_calls = 0
+
+        while dirs_to_visit and api_calls < self._MAX_CONTENTS_API_CALLS:
+            current = dirs_to_visit.popleft()
+            encoded_current = "/".join(
+                urlquote(seg, safe="") for seg in current.split("/")
+            ) if current else ""
+            endpoint = f"/repos/{self._owner}/{self._repo}/contents/{encoded_current}"
+            if self._ref:
+                endpoint += f"?ref={urlquote(self._ref, safe='')}"
+            api_calls += 1
+            try:
+                entries = self._api_get(endpoint)
+            except RuntimeError:
+                continue
+
+            if not isinstance(entries, list):
+                entries = [entries]
+
+            for entry in entries:
+                if entry["type"] == "dir":
+                    dir_name = os.path.basename(entry["path"]).lower()
+                    if dir_name not in _SKIP_DIRS:
+                        dirs_to_visit.append(entry["path"])
+                elif entry["type"] == "file":
+                    if is_rule_file(entry["path"]):
+                        content = self._fetch_raw(entry["path"])
+                        if content and content.strip():
+                            rule_files.append(
+                                RuleFile(
+                                    path=entry["path"],
+                                    content=content,
+                                    filename=entry["name"],
+                                )
+                            )
+
+        return rule_files
+
+
+# ---------------------------------------------------------------------------
+# Local crawler
+# ---------------------------------------------------------------------------
+
+class LocalCrawler:
+    """Crawl a local directory for detection rule files."""
+
+    def __init__(self, directory: str) -> None:
+        self._dir = Path(directory).resolve()
+
+    def crawl(self) -> list[RuleFile]:
+        rule_files: list[RuleFile] = []
+        for root, dirs, files in os.walk(self._dir):
+            # Prune skipped directories in-place
+            dirs[:] = [d for d in dirs if d.lower() not in _SKIP_DIRS and not d.startswith(".")]
+            for fname in files:
+                if fname.startswith("."):
+                    continue
+                full = os.path.join(root, fname)
+                rel = os.path.relpath(full, self._dir)
+                if not is_rule_file(rel):
+                    continue
+                try:
+                    with open(full, "r", encoding="utf-8", errors="replace") as f:
+                        content = f.read()
+                    if content.strip():
+                        rule_files.append(RuleFile(path=rel, content=content, filename=fname))
+                except OSError:
+                    continue
+        return rule_files
+
+
+# ---------------------------------------------------------------------------
+# Conversion pipeline
+# ---------------------------------------------------------------------------
+
+class ConversionPipeline:
+    """Convert rules using the LC AI API with parallel workers."""
+
+    def __init__(
+        self,
+        org: Organization,
+        parallel: int = 5,
+        prefix: str = "",
+    ) -> None:
+        from ..sdk.ai import AI
+        self._ai = AI(org)
+        self._parallel = parallel
+        self._prefix = prefix
+        self._lock = threading.Lock()
+        self._key_counts: dict[str, int] = {}
+
+    def convert_all(
+        self,
+        rule_files: list[RuleFile],
+        progress_callback: Callable[[int, int, int, str], None] | None = None,
+    ) -> list[ConversionResult]:
+        """Convert all rule files in parallel.
+
+        Args:
+            rule_files: List of source rules.
+            progress_callback: Called with (completed, total, failed, current_file)
+                after each rule finishes.
+
+        Returns:
+            list[ConversionResult]: Results for every input rule.
+        """
+        total = len(rule_files)
+        completed = 0
+        failed = 0
+        results: list[ConversionResult] = []
+
+        # Pre-allocate keys so that exception handlers don't double-allocate.
+        pre_keys = {id(rf): self._unique_key(rf.filename) for rf in rule_files}
+
+        interrupted = False
+        try:
+            with ThreadPoolExecutor(max_workers=self._parallel) as pool:
+                future_to_rule = {
+                    pool.submit(self._convert_one, rf, pre_keys[id(rf)]): rf
+                    for rf in rule_files
+                }
+                for future in as_completed(future_to_rule):
+                    rf = future_to_rule[future]
+                    try:
+                        result = future.result()
+                    except Exception as exc:
+                        result = ConversionResult(
+                            source_path=rf.path,
+                            rule_key=pre_keys[id(rf)],
+                            success=False,
+                            error=str(exc),
+                        )
+                    with self._lock:
+                        results.append(result)
+                        completed += 1
+                        if not result.success:
+                            failed += 1
+                    if progress_callback:
+                        progress_callback(completed, total, failed, rf.path)
+        except KeyboardInterrupt:
+            interrupted = True
+
+        if interrupted:
+            click.echo("\nInterrupted — returning partial results.", err=True)
+
+        return results
+
+    def _convert_one(self, rule_file: RuleFile, key: str | None = None) -> ConversionResult:
+        """Convert a single rule file.
+
+        Args:
+            rule_file: The source rule.
+            key: Pre-allocated hive key (from convert_all). Falls back to
+                generating one if not provided.
+        """
+        if key is None:
+            key = self._unique_key(rule_file.filename)
+
+        try:
+            # Detection prompt
+            detect_prompt = (
+                f"Convert this detection rule to LimaCharlie D&R detection format:\n\n"
+                f"{rule_file.content}"
+            )
+            detect_resp = self._ai.generate_detection(detect_prompt)
+            detect_data = self._parse_ai_response(detect_resp)
+
+            # Response prompt (includes detection for context)
+            detect_yaml_str = yaml.dump(detect_data, default_flow_style=False) if isinstance(detect_data, dict) else str(detect_data)
+            respond_prompt = (
+                f"Generate a LimaCharlie D&R response for this detection rule:\n\n"
+                f"{rule_file.content}\n\n"
+                f"The detection component is:\n{detect_yaml_str}"
+            )
+            respond_resp = self._ai.generate_response(respond_prompt)
+            respond_data = self._parse_ai_response(respond_resp)
+
+            # Normalize types
+            if isinstance(detect_data, str):
+                detect_data = yaml.safe_load(detect_data)
+            if isinstance(respond_data, str):
+                respond_data = yaml.safe_load(respond_data)
+            if isinstance(respond_data, dict):
+                respond_data = [respond_data]
+
+            # Validate detect_data is a dict (yaml.safe_load can return None or a scalar)
+            if not isinstance(detect_data, dict):
+                return ConversionResult(
+                    source_path=rule_file.path,
+                    rule_key=key,
+                    success=False,
+                    error=f"AI returned non-dict detection: {type(detect_data).__name__}",
+                )
+
+            return ConversionResult(
+                source_path=rule_file.path,
+                rule_key=key,
+                success=True,
+                detect=detect_data,
+                respond=respond_data,
+            )
+        except Exception as exc:
+            return ConversionResult(
+                source_path=rule_file.path,
+                rule_key=key,
+                success=False,
+                error=str(exc),
+            )
+
+    @staticmethod
+    def _parse_ai_response(resp: dict[str, Any]) -> Any:
+        """Extract the useful payload from an AI SDK response."""
+        if isinstance(resp, dict):
+            if "response" in resp:
+                return resp["response"]
+            for key in ("detection", "respond", "yaml", "content", "result"):
+                if key in resp:
+                    return resp[key]
+        return resp
+
+    def _unique_key(self, filename: str) -> str:
+        """Generate a unique hive key from a filename."""
+        base = self._sanitize_key(filename)
+        with self._lock:
+            count = self._key_counts.get(base, 0)
+            self._key_counts[base] = count + 1
+            if count == 0:
+                return base
+            return f"{base}-{count + 1}"
+
+    def _sanitize_key(self, filename: str) -> str:
+        """Convert a filename to a valid hive key name."""
+        name = os.path.splitext(filename)[0]
+        name = name.lower()
+        name = re.sub(r"[^a-z0-9]+", "-", name)
+        name = name.strip("-")
+        if not name:
+            name = "rule"
+        if self._prefix:
+            safe_prefix = re.sub(r"[^a-z0-9]+", "-", self._prefix.lower()).strip("-")
+            if safe_prefix:
+                name = f"{safe_prefix}-{name}"
+        return name
+
+
+# ---------------------------------------------------------------------------
+# Progress display
+# ---------------------------------------------------------------------------
+
+class ProgressDisplay:
+    """Terminal progress display for batch conversion."""
+
+    def __init__(self, total: int, quiet: bool = False) -> None:
+        self._total = total
+        self._quiet = quiet
+        self._start = time.monotonic()
+        self._lock = threading.Lock()
+
+    def update(self, completed: int, total: int, failed: int, current_file: str = "") -> None:
+        """Update the progress line in-place."""
+        if self._quiet:
+            return
+        with self._lock:
+            elapsed = time.monotonic() - self._start
+            eta = ""
+            if completed > 0:
+                remaining = (elapsed / completed) * (total - completed)
+                eta = f" | ETA: {self._fmt_duration(remaining)}"
+
+            line = f"\rConverting: [{completed}/{total}]"
+            if failed > 0:
+                line += f" {failed} failed"
+            line += eta
+
+            term_width = shutil.get_terminal_size((80, 24)).columns
+            # Pad to overwrite previous longer line, but stay within terminal
+            click.echo(line.ljust(term_width)[:term_width], nl=False)
+
+    def finish(self, results: list[ConversionResult]) -> None:
+        """Print the final summary after conversion."""
+        if self._quiet:
+            return
+
+        click.echo()  # end the progress line
+
+        elapsed = time.monotonic() - self._start
+        succeeded = [r for r in results if r.success]
+        failed = [r for r in results if not r.success]
+        hive_created = [r for r in results if r.created_in_hive]
+
+        click.echo(f"\nConversion complete ({self._fmt_duration(elapsed)})")
+        click.echo("-" * 40)
+        click.echo(f"  Total rules:       {len(results)}")
+        click.echo(f"  Converted:         {len(succeeded)}")
+        click.echo(f"  Failed:            {len(failed)}")
+        click.echo(f"  Created in hive:   {len(hive_created)}")
+
+        if failed:
+            click.echo(f"\nFailed rules:")
+            for r in failed:
+                click.echo(f"  {r.source_path}: {r.error}", err=True)
+
+    @staticmethod
+    def _fmt_duration(seconds: float) -> str:
+        s = int(seconds)
+        if s < 60:
+            return f"{s}s"
+        m, s = divmod(s, 60)
+        if m < 60:
+            return f"{m}m {s}s"
+        h, m = divmod(m, 60)
+        return f"{h}h {m}m"

--- a/limacharlie/commands/_dr_convert.py
+++ b/limacharlie/commands/_dr_convert.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import collections
 import json
 import os
+import random
 import re
 import shutil
 import ssl
@@ -156,9 +157,10 @@ class GitHubCrawler:
         ref: str | None = None,
         token: str | None = None,
     ) -> None:
-        self._owner, self._repo = self._parse_repo(repo)
-        self._path = path.strip("/") if path else None
-        self._ref = ref
+        self._owner, self._repo, url_ref, url_path = self._parse_repo(repo)
+        # Explicit CLI flags take priority over URL-derived values.
+        self._path = path.strip("/") if path else url_path
+        self._ref = ref if ref is not None else url_ref
         self._token = token
 
     @property
@@ -173,8 +175,17 @@ class GitHubCrawler:
     # -- URL parsing --------------------------------------------------------
 
     @staticmethod
-    def _parse_repo(raw: str) -> tuple[str, str]:
-        """Parse ``owner/repo`` from various URL forms."""
+    def _parse_repo(raw: str) -> tuple[str, str, str | None, str | None]:
+        """Parse ``owner/repo`` (and optional ref/path) from various URL forms.
+
+        Handles URLs like:
+            ``SigmaHQ/sigma``
+            ``https://github.com/SigmaHQ/sigma``
+            ``https://github.com/SigmaHQ/sigma/tree/master/rules/network``
+
+        Returns:
+            (owner, repo, ref_or_none, path_or_none)
+        """
         raw = raw.strip().rstrip("/")
         # Strip trailing .git
         if raw.endswith(".git"):
@@ -190,7 +201,17 @@ class GitHubCrawler:
                 f"Cannot parse GitHub repo from {raw!r}. "
                 "Expected owner/repo or https://github.com/owner/repo."
             )
-        return parts[0], parts[1]
+        owner, repo = parts[0], parts[1]
+        ref: str | None = None
+        path: str | None = None
+        # Remainder after owner/repo may be /tree/<ref>[/<path>]
+        # or /blob/<ref>[/<path>].
+        rest = parts[2:]
+        if rest and rest[0] in ("tree", "blob") and len(rest) >= 2:
+            ref = rest[1]
+            if len(rest) > 2:
+                path = "/".join(rest[2:])
+        return owner, repo, ref, path
 
     # -- HTTP helpers -------------------------------------------------------
 
@@ -415,7 +436,7 @@ class ConversionPipeline:
     def __init__(
         self,
         org: Organization,
-        parallel: int = 5,
+        parallel: int = 10,
         prefix: str = "",
     ) -> None:
         from ..sdk.ai import AI
@@ -445,6 +466,10 @@ class ConversionPipeline:
         failed = 0
         results: list[ConversionResult] = []
 
+        # Prime the JWT before spawning workers so that parallel threads
+        # don't all independently trigger an OAuth token refresh.
+        self._ai.client.refresh_jwt()
+
         # Pre-allocate keys so that exception handlers don't double-allocate.
         pre_keys = {id(rf): self._unique_key(rf.filename) for rf in rule_files}
 
@@ -452,7 +477,7 @@ class ConversionPipeline:
         try:
             with ThreadPoolExecutor(max_workers=self._parallel) as pool:
                 future_to_rule = {
-                    pool.submit(self._convert_one, rf, pre_keys[id(rf)]): rf
+                    pool.submit(self._convert_one_with_retry, rf, pre_keys[id(rf)]): rf
                     for rf in rule_files
                 }
                 for future in as_completed(future_to_rule):
@@ -480,6 +505,47 @@ class ConversionPipeline:
             click.echo("\nInterrupted — returning partial results.", err=True)
 
         return results
+
+    _TRANSIENT_RETRIES = 4
+    _TRANSIENT_BASE_WAIT = 15  # seconds
+
+    @staticmethod
+    def _is_transient_error(error: str) -> bool:
+        """Return True if the error looks transient and worth retrying."""
+        low = error.lower()
+        # Rate limits (429).
+        if "rate limit" in low:
+            return True
+        # Server-side failures (500): timeouts, processing errors, etc.
+        if "api error (500)" in low or "api error (502)" in low or "api error (503)" in low:
+            return True
+        return False
+
+    def _convert_one_with_retry(self, rule_file: RuleFile, key: str | None = None) -> ConversionResult:
+        """Call ``_convert_one`` with pipeline-level retries for transient errors.
+
+        The underlying ``Client.request`` already retries 429s and 504s a few
+        times, but with many parallel workers the thundering-herd effect can
+        exhaust those retries.  Server-side 500s (MCP timeouts, processing
+        failures) are also transient.  This wrapper adds additional backoff
+        with jitter at the pipeline level so that transient failures don't
+        become permanent.
+        """
+        last_result: ConversionResult | None = None
+        for attempt in range(1, self._TRANSIENT_RETRIES + 1):
+            result = self._convert_one(rule_file, key)
+            if result.success:
+                return result
+            last_result = result
+            if result.error and self._is_transient_error(result.error):
+                wait = self._TRANSIENT_BASE_WAIT * attempt + random.uniform(0, 5)
+                time.sleep(wait)
+                continue
+            # Non-transient failure — don't retry.
+            return result
+
+        # All retries exhausted — return the last failure.
+        return last_result  # type: ignore[return-value]
 
     def _convert_one(self, rule_file: RuleFile, key: str | None = None) -> ConversionResult:
         """Convert a single rule file.

--- a/limacharlie/commands/dr.py
+++ b/limacharlie/commands/dr.py
@@ -843,8 +843,8 @@ def import_rules(ctx, input_file, namespace, dry_run) -> None:
     help="Save converted rules as YAML files to this directory.",
 )
 @click.option(
-    "--parallel", type=click.IntRange(1, 20), default=5,
-    help="Number of parallel conversion workers (default: 5).",
+    "--parallel", type=click.IntRange(1, 20), default=10,
+    help="Number of parallel conversion workers (default: 10).",
 )
 @click.option("--prefix", default="", help="Prefix for rule key names in dr-general.")
 @click.option("--tag", "tags", multiple=True, help="Tags to add to all converted rules (repeatable).")

--- a/limacharlie/commands/dr.py
+++ b/limacharlie/commands/dr.py
@@ -9,6 +9,7 @@ and dr-service.
 from __future__ import annotations
 
 import json
+import os
 import sys
 from typing import Any
 
@@ -340,6 +341,32 @@ Examples:
   limacharlie dr import --input-file rules.yaml --namespace managed
 """
 
+_EXPLAIN_CONVERT_RULES = """\
+Mass-convert external detection rules to LimaCharlie D&R format using
+AI-powered translation.  Reads rules from a local directory or a GitHub
+repository, converts each to LC D&R format, and optionally creates
+them in the dr-general hive.
+
+The AI backend auto-detects the source format and platform — Sigma,
+Splunk SPL, Elastic KQL, CrowdStrike, and many more are supported
+without any format hint.
+
+The GitHub crawler intelligently identifies rule files by extension
+(.yml, .yaml, .json, .sigma, .spl, .kql, .toml) and filters out
+non-rule files (README, LICENSE, CI configs, etc.).
+
+Rules are created disabled by default for safety.  Use --enabled to
+create them enabled.  Use --dry-run to preview conversions without
+creating hive records.
+
+Examples:
+  limacharlie dr convert-rules --github SigmaHQ/sigma \\
+      --github-path rules/windows/process_creation
+  limacharlie dr convert-rules --input-dir ./splunk-rules --dry-run
+  limacharlie dr convert-rules --github elastic/detection-rules \\
+      --parallel 10 --tag migrated
+"""
+
 register_explain("dr.list", _EXPLAIN_LIST)
 register_explain("dr.get", _EXPLAIN_GET)
 register_explain("dr.set", _EXPLAIN_SET)
@@ -349,6 +376,7 @@ register_explain("dr.replay", _EXPLAIN_REPLAY)
 register_explain("dr.validate", _EXPLAIN_VALIDATE)
 register_explain("dr.export", _EXPLAIN_EXPORT)
 register_explain("dr.import", _EXPLAIN_IMPORT)
+register_explain("dr.convert-rules", _EXPLAIN_CONVERT_RULES)
 
 
 # ---------------------------------------------------------------------------
@@ -782,3 +810,160 @@ def import_rules(ctx, input_file, namespace, dry_run) -> None:
                 click.echo(err, err=True)
     if errors:
         ctx.exit(min(len(errors), 125))
+
+
+# ---------------------------------------------------------------------------
+# convert-rules
+# ---------------------------------------------------------------------------
+
+@group.command("convert-rules")
+@click.option(
+    "--input-dir", type=click.Path(exists=True, file_okay=False), default=None,
+    help="Local directory containing detection rule files.",
+)
+@click.option(
+    "--github", "github_repo", default=None,
+    help="GitHub repo to crawl (owner/repo or full URL).",
+)
+@click.option(
+    "--github-path", default=None,
+    help="Subdirectory within the GitHub repo to search.",
+)
+@click.option(
+    "--github-ref", default=None,
+    help="Branch or tag to use (default: repo default branch).",
+)
+@click.option(
+    "--github-token", default=None, envvar="GH_TOKEN",
+    help="GitHub token for private repos (or set GH_TOKEN env var).",
+)
+@click.option("--dry-run", is_flag=True, default=False, help="Convert without creating hive records.")
+@click.option(
+    "--output-dir", type=click.Path(file_okay=False), default=None,
+    help="Save converted rules as YAML files to this directory.",
+)
+@click.option(
+    "--parallel", type=click.IntRange(1, 20), default=5,
+    help="Number of parallel conversion workers (default: 5).",
+)
+@click.option("--prefix", default="", help="Prefix for rule key names in dr-general.")
+@click.option("--tag", "tags", multiple=True, help="Tags to add to all converted rules (repeatable).")
+@click.option("--enabled/--disabled", default=False, help="Whether rules start enabled (default: disabled).")
+@pass_context
+def convert_rules(ctx, input_dir, github_repo, github_path, github_ref,
+                  github_token, dry_run, output_dir, parallel, prefix,
+                  tags, enabled) -> None:
+    """Mass-convert external detection rules to LC D&R format.
+
+    Converts rules from local files or a GitHub repository using
+    AI-powered translation, then creates them in dr-general.
+
+    The AI auto-detects the source format (Sigma, Splunk, Elastic, etc.).
+
+    Examples:
+        limacharlie dr convert-rules --github SigmaHQ/sigma \\
+            --github-path rules/windows/process_creation
+
+        limacharlie dr convert-rules --input-dir ./my-rules --dry-run
+
+        limacharlie dr convert-rules --github elastic/detection-rules \\
+            --parallel 10 --tag migrated --disabled
+    """
+    from ._dr_convert import (
+        GitHubCrawler, LocalCrawler, ConversionPipeline, ProgressDisplay,
+    )
+
+    # -- Validate inputs ---------------------------------------------------
+    if not input_dir and not github_repo:
+        raise click.UsageError("Provide --input-dir or --github.")
+    if input_dir and github_repo:
+        raise click.UsageError("Provide --input-dir or --github, not both.")
+
+    quiet = ctx.obj.quiet
+
+    def echo(msg: str) -> None:
+        if not quiet:
+            click.echo(msg)
+
+    # -- Collect rule files ------------------------------------------------
+    if github_repo:
+        crawler = GitHubCrawler(github_repo, path=github_path, ref=github_ref, token=github_token)
+        echo(f"Crawling GitHub repo: {crawler.display_name}...")
+        rule_files = crawler.crawl(progress_echo=echo)
+    else:
+        echo(f"Scanning directory: {input_dir}")
+        rule_files = LocalCrawler(input_dir).crawl()
+
+    if not rule_files:
+        click.echo("No rule files found.", err=True)
+        ctx.exit(1)
+        return
+
+    echo(f"Found {len(rule_files)} rule file(s).\n")
+
+    # -- Run conversion pipeline -------------------------------------------
+    client = Client(oid=ctx.obj.oid, environment=ctx.obj.environment, is_retry_quota_errors=True)
+    org = Organization(client)
+
+    pipeline = ConversionPipeline(org, parallel=parallel, prefix=prefix)
+    progress = ProgressDisplay(len(rule_files), quiet=quiet)
+    results = pipeline.convert_all(rule_files, progress_callback=progress.update)
+
+    # -- Create in hive (unless dry-run) -----------------------------------
+    if not dry_run:
+        hive = Hive(org, "dr-general")
+        for r in results:
+            if not r.success:
+                continue
+            try:
+                record = HiveRecord(
+                    name=r.rule_key,
+                    data={"detect": r.detect, "respond": r.respond},
+                    enabled=enabled,
+                    tags=list(tags) if tags else None,
+                    comment=f"Converted from: {r.source_path}",
+                )
+                hive.set(record)
+                r.created_in_hive = True
+            except Exception as exc:
+                # Don't mark conversion as failed — it succeeded, only the
+                # hive write failed.  Track the error separately.
+                r.error = f"Hive write failed: {exc}"
+
+    # -- Save to files (optional) ------------------------------------------
+    if output_dir:
+        os.makedirs(output_dir, exist_ok=True)
+        for r in results:
+            if r.success:
+                out_path = os.path.join(output_dir, f"{r.rule_key}.yaml")
+                with open(out_path, "w") as f:
+                    yaml.dump(
+                        {"detect": r.detect, "respond": r.respond},
+                        f, default_flow_style=False, sort_keys=False,
+                    )
+
+    # -- Summary -----------------------------------------------------------
+    progress.finish(results)
+
+    # -- Structured output -------------------------------------------------
+    output_data = {
+        "total": len(results),
+        "converted": sum(1 for r in results if r.success),
+        "failed": sum(1 for r in results if not r.success),
+        "created_in_hive": sum(1 for r in results if r.created_in_hive),
+        "rules": [
+            {
+                "source": r.source_path,
+                "key": r.rule_key,
+                "success": r.success,
+                "error": r.error,
+                "created_in_hive": r.created_in_hive,
+            }
+            for r in results
+        ],
+    }
+    _output(ctx, output_data)
+
+    # -- Exit code ---------------------------------------------------------
+    if results and all(not r.success for r in results):
+        ctx.exit(1)

--- a/limacharlie/discovery.py
+++ b/limacharlie/discovery.py
@@ -31,6 +31,7 @@ PROFILES = {
             "fp list", "fp get", "fp create", "fp delete",
             "replay run",
             "ai generate-rule", "ai generate-detection", "ai generate-response",
+            "dr convert-rules",
         ],
     },
     "historical_data": {

--- a/tests/unit/test_dr_convert.py
+++ b/tests/unit/test_dr_convert.py
@@ -1,0 +1,571 @@
+"""Tests for the dr convert-rules command and supporting classes."""
+
+import json
+import os
+import textwrap
+from unittest.mock import MagicMock, patch, call
+
+import pytest
+
+from limacharlie.commands._dr_convert import (
+    ConversionPipeline,
+    ConversionResult,
+    GitHubCrawler,
+    LocalCrawler,
+    ProgressDisplay,
+    RuleFile,
+    is_rule_file,
+    _has_rule_dir_ancestor,
+)
+
+
+# ---------------------------------------------------------------------------
+# is_rule_file
+# ---------------------------------------------------------------------------
+
+class TestIsRuleFile:
+    def test_yaml_accepted(self):
+        assert is_rule_file("rules/my_rule.yml") is True
+        assert is_rule_file("detections/proc.yaml") is True
+
+    def test_json_accepted(self):
+        assert is_rule_file("searches/query.json") is True
+
+    def test_sigma_accepted(self):
+        assert is_rule_file("rules/sigma_rule.sigma") is True
+
+    def test_spl_accepted(self):
+        assert is_rule_file("rules/splunk_search.spl") is True
+
+    def test_kql_accepted(self):
+        assert is_rule_file("rules/azure.kql") is True
+
+    def test_toml_accepted(self):
+        assert is_rule_file("rules/elastic_rule.toml") is True
+
+    def test_readme_rejected(self):
+        assert is_rule_file("rules/README.md") is False
+
+    def test_license_rejected(self):
+        assert is_rule_file("LICENSE") is False
+
+    def test_gitignore_rejected(self):
+        assert is_rule_file(".gitignore") is False
+
+    def test_requirements_rejected(self):
+        assert is_rule_file("requirements.txt") is False
+
+    def test_pyproject_rejected(self):
+        assert is_rule_file("pyproject.toml") is False
+
+    def test_docker_compose_rejected(self):
+        assert is_rule_file("docker-compose.yml") is False
+
+    def test_github_dir_rejected(self):
+        assert is_rule_file(".github/workflows/ci.yml") is False
+
+    def test_tests_dir_rejected(self):
+        assert is_rule_file("tests/test_rule.yaml") is False
+
+    def test_docs_dir_rejected(self):
+        assert is_rule_file("docs/examples/rule.yaml") is False
+
+    def test_txt_extension_rejected(self):
+        assert is_rule_file("notes.txt") is False
+
+    def test_py_extension_rejected(self):
+        assert is_rule_file("convert.py") is False
+
+    def test_nested_rule_file(self):
+        assert is_rule_file("rules/windows/process_creation/mimikatz.yml") is True
+
+    def test_pre_commit_config_rejected(self):
+        assert is_rule_file(".pre-commit-config.yaml") is False
+
+    def test_mkdocs_rejected(self):
+        assert is_rule_file("mkdocs.yml") is False
+
+    def test_yamllint_rejected(self):
+        assert is_rule_file(".yamllint.yml") is False
+
+
+class TestHasRuleDirAncestor:
+    def test_rules_dir(self):
+        assert _has_rule_dir_ancestor("rules/my_rule.yml") is True
+
+    def test_detections_dir(self):
+        assert _has_rule_dir_ancestor("detections/proc.yaml") is True
+
+    def test_sigma_dir(self):
+        assert _has_rule_dir_ancestor("sigma/windows/rule.yml") is True
+
+    def test_no_rule_dir(self):
+        assert _has_rule_dir_ancestor("misc/something.yml") is False
+
+    def test_file_at_root(self):
+        assert _has_rule_dir_ancestor("rule.yml") is False
+
+    def test_nested_rule_dir(self):
+        assert _has_rule_dir_ancestor("project/rules/windows/rule.yml") is True
+
+
+# ---------------------------------------------------------------------------
+# GitHubCrawler URL parsing
+# ---------------------------------------------------------------------------
+
+class TestGitHubCrawlerParseRepo:
+    def test_short_form(self):
+        owner, repo = GitHubCrawler._parse_repo("SigmaHQ/sigma")
+        assert owner == "SigmaHQ"
+        assert repo == "sigma"
+
+    def test_https_url(self):
+        owner, repo = GitHubCrawler._parse_repo("https://github.com/SigmaHQ/sigma")
+        assert owner == "SigmaHQ"
+        assert repo == "sigma"
+
+    def test_https_url_with_git(self):
+        owner, repo = GitHubCrawler._parse_repo("https://github.com/elastic/detection-rules.git")
+        assert owner == "elastic"
+        assert repo == "detection-rules"
+
+    def test_http_url(self):
+        owner, repo = GitHubCrawler._parse_repo("http://github.com/owner/repo")
+        assert owner == "owner"
+        assert repo == "repo"
+
+    def test_bare_domain(self):
+        owner, repo = GitHubCrawler._parse_repo("github.com/owner/repo")
+        assert owner == "owner"
+        assert repo == "repo"
+
+    def test_trailing_slash(self):
+        owner, repo = GitHubCrawler._parse_repo("SigmaHQ/sigma/")
+        assert owner == "SigmaHQ"
+        assert repo == "sigma"
+
+    def test_invalid_raises(self):
+        with pytest.raises(ValueError, match="Cannot parse"):
+            GitHubCrawler._parse_repo("just-a-name")
+
+    def test_url_with_extra_path(self):
+        owner, repo = GitHubCrawler._parse_repo("https://github.com/owner/repo/tree/main/rules")
+        assert owner == "owner"
+        assert repo == "repo"
+
+
+class TestGitHubCrawlerDisplayName:
+    def test_basic(self):
+        crawler = GitHubCrawler.__new__(GitHubCrawler)
+        crawler._owner = "SigmaHQ"
+        crawler._repo = "sigma"
+        crawler._path = None
+        crawler._ref = None
+        assert crawler.display_name == "SigmaHQ/sigma"
+
+    def test_with_path_and_ref(self):
+        crawler = GitHubCrawler.__new__(GitHubCrawler)
+        crawler._owner = "SigmaHQ"
+        crawler._repo = "sigma"
+        crawler._path = "rules/windows"
+        crawler._ref = "main"
+        assert crawler.display_name == "SigmaHQ/sigma/rules/windows @ main"
+
+
+# ---------------------------------------------------------------------------
+# LocalCrawler
+# ---------------------------------------------------------------------------
+
+class TestLocalCrawler:
+    def test_finds_yaml_files(self, tmp_path):
+        (tmp_path / "rule1.yml").write_text("title: rule1")
+        (tmp_path / "rule2.yaml").write_text("title: rule2")
+        (tmp_path / "README.md").write_text("# readme")
+
+        results = LocalCrawler(str(tmp_path)).crawl()
+        filenames = {r.filename for r in results}
+        assert "rule1.yml" in filenames
+        assert "rule2.yaml" in filenames
+        assert "README.md" not in filenames
+
+    def test_skips_hidden_files(self, tmp_path):
+        (tmp_path / ".hidden.yml").write_text("title: hidden")
+        (tmp_path / "visible.yml").write_text("title: visible")
+
+        results = LocalCrawler(str(tmp_path)).crawl()
+        filenames = {r.filename for r in results}
+        assert ".hidden.yml" not in filenames
+        assert "visible.yml" in filenames
+
+    def test_skips_hidden_dirs(self, tmp_path):
+        hidden = tmp_path / ".git"
+        hidden.mkdir()
+        (hidden / "config.yml").write_text("something")
+        (tmp_path / "rule.yml").write_text("title: rule")
+
+        results = LocalCrawler(str(tmp_path)).crawl()
+        assert len(results) == 1
+        assert results[0].filename == "rule.yml"
+
+    def test_skips_empty_files(self, tmp_path):
+        (tmp_path / "empty.yml").write_text("")
+        (tmp_path / "whitespace.yml").write_text("   \n  ")
+        (tmp_path / "real.yml").write_text("title: real")
+
+        results = LocalCrawler(str(tmp_path)).crawl()
+        assert len(results) == 1
+        assert results[0].filename == "real.yml"
+
+    def test_recursive(self, tmp_path):
+        sub = tmp_path / "rules" / "windows"
+        sub.mkdir(parents=True)
+        (sub / "proc.yml").write_text("title: proc")
+        (tmp_path / "root.yaml").write_text("title: root")
+
+        results = LocalCrawler(str(tmp_path)).crawl()
+        filenames = {r.filename for r in results}
+        assert "proc.yml" in filenames
+        assert "root.yaml" in filenames
+
+    def test_skips_test_dirs(self, tmp_path):
+        tests = tmp_path / "tests"
+        tests.mkdir()
+        (tests / "test_rule.yml").write_text("title: test")
+        (tmp_path / "rule.yml").write_text("title: rule")
+
+        results = LocalCrawler(str(tmp_path)).crawl()
+        assert len(results) == 1
+
+
+# ---------------------------------------------------------------------------
+# ConversionPipeline
+# ---------------------------------------------------------------------------
+
+class TestConversionPipelineSanitizeKey:
+    def _make_pipeline(self):
+        org = MagicMock()
+        return ConversionPipeline(org, prefix="")
+
+    def test_basic(self):
+        p = self._make_pipeline()
+        assert p._sanitize_key("My Cool Rule.yml") == "my-cool-rule"
+
+    def test_special_chars(self):
+        p = self._make_pipeline()
+        assert p._sanitize_key("rule (v2) [final].yaml") == "rule-v2-final"
+
+    def test_with_prefix(self):
+        org = MagicMock()
+        p = ConversionPipeline(org, prefix="sigma")
+        assert p._sanitize_key("mimikatz.yml") == "sigma-mimikatz"
+
+    def test_empty_name(self):
+        p = self._make_pipeline()
+        assert p._sanitize_key("!!!.yml") == "rule"
+
+    def test_preserves_numbers(self):
+        p = self._make_pipeline()
+        assert p._sanitize_key("rule_123_v2.yml") == "rule-123-v2"
+
+    def test_prefix_sanitized(self):
+        """Prefix with special chars gets sanitized to safe hive key."""
+        org = MagicMock()
+        p = ConversionPipeline(org, prefix="My Prefix!!")
+        assert p._sanitize_key("rule.yml") == "my-prefix-rule"
+
+    def test_prefix_path_traversal_sanitized(self):
+        """Prefix containing path traversal components gets sanitized."""
+        org = MagicMock()
+        p = ConversionPipeline(org, prefix="../../etc")
+        assert p._sanitize_key("rule.yml") == "etc-rule"
+
+
+class TestConversionPipelineUniqueKey:
+    def test_first_call_no_suffix(self):
+        org = MagicMock()
+        p = ConversionPipeline(org)
+        assert p._unique_key("rule.yml") == "rule"
+
+    def test_duplicate_gets_suffix(self):
+        org = MagicMock()
+        p = ConversionPipeline(org)
+        assert p._unique_key("rule.yml") == "rule"
+        assert p._unique_key("rule.yml") == "rule-2"
+        assert p._unique_key("rule.yml") == "rule-3"
+
+    def test_different_names_no_collision(self):
+        org = MagicMock()
+        p = ConversionPipeline(org)
+        assert p._unique_key("alpha.yml") == "alpha"
+        assert p._unique_key("beta.yml") == "beta"
+
+
+class TestConversionPipelineParseResponse:
+    def test_extracts_response_key(self):
+        resp = {"response": {"event": "NEW_PROCESS"}}
+        assert ConversionPipeline._parse_ai_response(resp) == {"event": "NEW_PROCESS"}
+
+    def test_extracts_detection_key(self):
+        resp = {"detection": {"op": "is"}}
+        assert ConversionPipeline._parse_ai_response(resp) == {"op": "is"}
+
+    def test_returns_raw_if_no_known_key(self):
+        resp = {"something": "else"}
+        assert ConversionPipeline._parse_ai_response(resp) == resp
+
+    def test_returns_non_dict_as_is(self):
+        assert ConversionPipeline._parse_ai_response("raw string") == "raw string"
+
+
+class TestConversionPipelineConvertOne:
+    def test_success(self):
+        org = MagicMock()
+        p = ConversionPipeline(org)
+
+        detect_data = {"event": "NEW_PROCESS", "op": "contains", "path": "event/COMMAND_LINE", "value": "mimikatz"}
+        respond_data = [{"action": "report", "name": "mimikatz-detected"}]
+
+        p._ai = MagicMock()
+        p._ai.generate_detection.return_value = {"response": detect_data}
+        p._ai.generate_response.return_value = {"response": respond_data}
+
+        rf = RuleFile(path="rules/mimikatz.yml", content="title: Mimikatz", filename="mimikatz.yml")
+        result = p._convert_one(rf)
+
+        assert result.success is True
+        assert result.detect == detect_data
+        assert result.respond == respond_data
+        assert p._ai.generate_detection.called
+        assert p._ai.generate_response.called
+
+    def test_detection_failure(self):
+        org = MagicMock()
+        p = ConversionPipeline(org)
+
+        p._ai = MagicMock()
+        p._ai.generate_detection.side_effect = Exception("AI error")
+
+        rf = RuleFile(path="rules/bad.yml", content="garbage", filename="bad.yml")
+        result = p._convert_one(rf)
+
+        assert result.success is False
+        assert "AI error" in result.error
+
+    def test_response_failure(self):
+        org = MagicMock()
+        p = ConversionPipeline(org)
+
+        p._ai = MagicMock()
+        p._ai.generate_detection.return_value = {"response": {"event": "X"}}
+        p._ai.generate_response.side_effect = Exception("Response error")
+
+        rf = RuleFile(path="rules/partial.yml", content="title: Partial", filename="partial.yml")
+        result = p._convert_one(rf)
+
+        assert result.success is False
+        assert "Response error" in result.error
+
+    def test_non_dict_detect_fails(self):
+        """AI returning a non-dict detect (e.g. None from yaml parse) is a failure."""
+        org = MagicMock()
+        p = ConversionPipeline(org)
+
+        p._ai = MagicMock()
+        # Return a string that yaml.safe_load turns into None
+        p._ai.generate_detection.return_value = {"response": "null"}
+        p._ai.generate_response.return_value = {"response": [{"action": "report", "name": "x"}]}
+
+        rf = RuleFile(path="rules/bad.yml", content="title: Bad", filename="bad.yml")
+        result = p._convert_one(rf)
+
+        assert result.success is False
+        assert "non-dict" in result.error
+
+
+class TestConversionPipelineConvertAll:
+    def test_parallel_execution(self):
+        org = MagicMock()
+        p = ConversionPipeline(org, parallel=2)
+
+        p._ai = MagicMock()
+        p._ai.generate_detection.return_value = {"response": {"event": "X"}}
+        p._ai.generate_response.return_value = {"response": [{"action": "report", "name": "x"}]}
+
+        rule_files = [
+            RuleFile(path=f"r{i}.yml", content=f"rule {i}", filename=f"r{i}.yml")
+            for i in range(5)
+        ]
+
+        results = p.convert_all(rule_files)
+        assert len(results) == 5
+        assert all(r.success for r in results)
+
+    def test_mixed_success_and_failure(self):
+        org = MagicMock()
+        p = ConversionPipeline(org, parallel=1)
+
+        call_count = 0
+        def mock_detect(query):
+            nonlocal call_count
+            call_count += 1
+            if call_count % 2 == 0:
+                raise Exception("fail")
+            return {"response": {"event": "X"}}
+
+        p._ai = MagicMock()
+        p._ai.generate_detection.side_effect = mock_detect
+        p._ai.generate_response.return_value = {"response": [{"action": "report", "name": "x"}]}
+
+        rule_files = [
+            RuleFile(path=f"r{i}.yml", content=f"rule {i}", filename=f"r{i}.yml")
+            for i in range(4)
+        ]
+
+        results = p.convert_all(rule_files)
+        succeeded = [r for r in results if r.success]
+        failed = [r for r in results if not r.success]
+        assert len(succeeded) == 2
+        assert len(failed) == 2
+
+    def test_progress_callback_called(self):
+        org = MagicMock()
+        p = ConversionPipeline(org, parallel=1)
+
+        p._ai = MagicMock()
+        p._ai.generate_detection.return_value = {"response": {"event": "X"}}
+        p._ai.generate_response.return_value = {"response": [{"action": "report", "name": "x"}]}
+
+        calls = []
+        def cb(completed, total, failed, current):
+            calls.append((completed, total, failed))
+
+        rule_files = [RuleFile(path="r.yml", content="rule", filename="r.yml")]
+        p.convert_all(rule_files, progress_callback=cb)
+
+        assert len(calls) == 1
+        assert calls[0] == (1, 1, 0)
+
+
+# ---------------------------------------------------------------------------
+# ProgressDisplay
+# ---------------------------------------------------------------------------
+
+class TestProgressDisplay:
+    def test_quiet_mode_no_output(self, capsys):
+        pd = ProgressDisplay(10, quiet=True)
+        pd.update(5, 10, 1, "file.yml")
+        pd.finish([])
+        out = capsys.readouterr()
+        assert out.out == ""
+
+    def test_fmt_duration_seconds(self):
+        assert ProgressDisplay._fmt_duration(45) == "45s"
+
+    def test_fmt_duration_minutes(self):
+        assert ProgressDisplay._fmt_duration(125) == "2m 5s"
+
+    def test_fmt_duration_hours(self):
+        assert ProgressDisplay._fmt_duration(3665) == "1h 1m"
+
+    def test_finish_shows_summary(self, capsys):
+        pd = ProgressDisplay(2, quiet=False)
+        results = [
+            ConversionResult("a.yml", "a", True, {"event": "X"}, [{"action": "report"}], created_in_hive=True),
+            ConversionResult("b.yml", "b", False, error="boom"),
+        ]
+        pd.finish(results)
+        out = capsys.readouterr().out
+        assert "Total rules:" in out
+        assert "Converted:" in out
+        assert "Failed:" in out
+
+    def test_finish_shows_failed_rules(self, capsys):
+        pd = ProgressDisplay(1, quiet=False)
+        results = [
+            ConversionResult("bad.yml", "bad", False, error="AI timeout"),
+        ]
+        pd.finish(results)
+        combined = capsys.readouterr()
+        assert "bad.yml" in combined.err
+        assert "AI timeout" in combined.err
+
+
+# ---------------------------------------------------------------------------
+# CLI integration (Click CliRunner)
+# ---------------------------------------------------------------------------
+
+class TestConvertRulesCommand:
+    def _invoke(self, args, **kwargs):
+        from click.testing import CliRunner
+        from limacharlie.cli import cli
+        return CliRunner().invoke(cli, ["dr", "convert-rules"] + args, catch_exceptions=False, **kwargs)
+
+    def test_help(self):
+        result = self._invoke(["--help"])
+        assert result.exit_code == 0
+        assert "Mass-convert" in result.output
+        assert "--github" in result.output
+        assert "--input-dir" in result.output
+
+    def test_no_input_source_error(self):
+        from click.testing import CliRunner
+        from limacharlie.cli import cli
+        result = CliRunner().invoke(cli, ["dr", "convert-rules"])
+        assert result.exit_code != 0
+        assert "Provide --input-dir or --github" in result.output
+
+    def test_both_input_sources_error(self):
+        from click.testing import CliRunner
+        from limacharlie.cli import cli
+        result = CliRunner().invoke(cli, ["dr", "convert-rules", "--input-dir", "/tmp", "--github", "owner/repo"])
+        assert result.exit_code != 0
+        assert "not both" in result.output
+
+    def test_dry_run_local_dir(self, tmp_path):
+        (tmp_path / "rule.yml").write_text("title: Test Rule\nstatus: test")
+
+        with patch("limacharlie.commands.dr.Client") as MockClient, \
+             patch("limacharlie.commands.dr.Organization") as MockOrg, \
+             patch("limacharlie.commands._dr_convert.ConversionPipeline.convert_all") as mock_convert:
+            mock_convert.return_value = [
+                ConversionResult(
+                    source_path="rule.yml",
+                    rule_key="rule",
+                    success=True,
+                    detect={"event": "NEW_PROCESS"},
+                    respond=[{"action": "report", "name": "test"}],
+                ),
+            ]
+            result = self._invoke([
+                "--input-dir", str(tmp_path),
+                "--dry-run",
+            ])
+
+        assert result.exit_code == 0
+
+    def test_output_dir_created(self, tmp_path):
+        input_dir = tmp_path / "input"
+        input_dir.mkdir()
+        (input_dir / "rule.yml").write_text("title: Test")
+        output_dir = tmp_path / "output"
+
+        with patch("limacharlie.commands.dr.Client"), \
+             patch("limacharlie.commands.dr.Organization"), \
+             patch("limacharlie.commands._dr_convert.ConversionPipeline.convert_all") as mock_convert:
+            mock_convert.return_value = [
+                ConversionResult(
+                    source_path="rule.yml",
+                    rule_key="rule",
+                    success=True,
+                    detect={"event": "NEW_PROCESS"},
+                    respond=[{"action": "report", "name": "test"}],
+                ),
+            ]
+            self._invoke([
+                "--input-dir", str(input_dir),
+                "--dry-run",
+                "--output-dir", str(output_dir),
+            ])
+
+        assert output_dir.exists()
+        assert (output_dir / "rule.yaml").exists()

--- a/tests/unit/test_dr_convert.py
+++ b/tests/unit/test_dr_convert.py
@@ -115,32 +115,38 @@ class TestHasRuleDirAncestor:
 
 class TestGitHubCrawlerParseRepo:
     def test_short_form(self):
-        owner, repo = GitHubCrawler._parse_repo("SigmaHQ/sigma")
+        owner, repo, ref, path = GitHubCrawler._parse_repo("SigmaHQ/sigma")
         assert owner == "SigmaHQ"
         assert repo == "sigma"
+        assert ref is None
+        assert path is None
 
     def test_https_url(self):
-        owner, repo = GitHubCrawler._parse_repo("https://github.com/SigmaHQ/sigma")
+        owner, repo, ref, path = GitHubCrawler._parse_repo("https://github.com/SigmaHQ/sigma")
         assert owner == "SigmaHQ"
         assert repo == "sigma"
+        assert ref is None
+        assert path is None
 
     def test_https_url_with_git(self):
-        owner, repo = GitHubCrawler._parse_repo("https://github.com/elastic/detection-rules.git")
+        owner, repo, ref, path = GitHubCrawler._parse_repo("https://github.com/elastic/detection-rules.git")
         assert owner == "elastic"
         assert repo == "detection-rules"
+        assert ref is None
+        assert path is None
 
     def test_http_url(self):
-        owner, repo = GitHubCrawler._parse_repo("http://github.com/owner/repo")
+        owner, repo, ref, path = GitHubCrawler._parse_repo("http://github.com/owner/repo")
         assert owner == "owner"
         assert repo == "repo"
 
     def test_bare_domain(self):
-        owner, repo = GitHubCrawler._parse_repo("github.com/owner/repo")
+        owner, repo, ref, path = GitHubCrawler._parse_repo("github.com/owner/repo")
         assert owner == "owner"
         assert repo == "repo"
 
     def test_trailing_slash(self):
-        owner, repo = GitHubCrawler._parse_repo("SigmaHQ/sigma/")
+        owner, repo, ref, path = GitHubCrawler._parse_repo("SigmaHQ/sigma/")
         assert owner == "SigmaHQ"
         assert repo == "sigma"
 
@@ -148,10 +154,76 @@ class TestGitHubCrawlerParseRepo:
         with pytest.raises(ValueError, match="Cannot parse"):
             GitHubCrawler._parse_repo("just-a-name")
 
-    def test_url_with_extra_path(self):
-        owner, repo = GitHubCrawler._parse_repo("https://github.com/owner/repo/tree/main/rules")
+    def test_tree_url_extracts_ref_and_path(self):
+        owner, repo, ref, path = GitHubCrawler._parse_repo(
+            "https://github.com/SigmaHQ/sigma/tree/master/rules/network/cisco"
+        )
+        assert owner == "SigmaHQ"
+        assert repo == "sigma"
+        assert ref == "master"
+        assert path == "rules/network/cisco"
+
+    def test_tree_url_ref_only(self):
+        owner, repo, ref, path = GitHubCrawler._parse_repo(
+            "https://github.com/owner/repo/tree/main"
+        )
         assert owner == "owner"
         assert repo == "repo"
+        assert ref == "main"
+        assert path is None
+
+    def test_blob_url_extracts_ref_and_path(self):
+        owner, repo, ref, path = GitHubCrawler._parse_repo(
+            "https://github.com/owner/repo/blob/develop/src/rule.yml"
+        )
+        assert owner == "owner"
+        assert repo == "repo"
+        assert ref == "develop"
+        assert path == "src/rule.yml"
+
+    def test_tree_url_trailing_slash(self):
+        owner, repo, ref, path = GitHubCrawler._parse_repo(
+            "https://github.com/SigmaHQ/sigma/tree/master/rules/"
+        )
+        assert owner == "SigmaHQ"
+        assert repo == "sigma"
+        assert ref == "master"
+        assert path == "rules"
+
+    def test_non_tree_extra_path_ignored(self):
+        """Extra path segments that aren't tree/blob are ignored."""
+        owner, repo, ref, path = GitHubCrawler._parse_repo(
+            "https://github.com/owner/repo/issues/123"
+        )
+        assert owner == "owner"
+        assert repo == "repo"
+        assert ref is None
+        assert path is None
+
+
+class TestGitHubCrawlerInitFromURL:
+    """Verify __init__ uses URL-derived ref/path as defaults."""
+
+    def test_url_populates_path_and_ref(self):
+        c = GitHubCrawler("https://github.com/SigmaHQ/sigma/tree/master/rules/network/cisco")
+        assert c._owner == "SigmaHQ"
+        assert c._repo == "sigma"
+        assert c._ref == "master"
+        assert c._path == "rules/network/cisco"
+
+    def test_explicit_flags_override_url(self):
+        c = GitHubCrawler(
+            "https://github.com/SigmaHQ/sigma/tree/master/rules/network/cisco",
+            path="rules/windows",
+            ref="develop",
+        )
+        assert c._ref == "develop"
+        assert c._path == "rules/windows"
+
+    def test_plain_repo_no_defaults(self):
+        c = GitHubCrawler("SigmaHQ/sigma")
+        assert c._ref is None
+        assert c._path is None
 
 
 class TestGitHubCrawlerDisplayName:
@@ -380,6 +452,127 @@ class TestConversionPipelineConvertOne:
 
         assert result.success is False
         assert "non-dict" in result.error
+
+
+class TestConversionPipelineTransientRetry:
+    def test_retries_on_rate_limit_then_succeeds(self):
+        from limacharlie.errors import RateLimitError
+
+        org = MagicMock()
+        p = ConversionPipeline(org)
+
+        call_count = 0
+        def mock_detect(query):
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 2:
+                raise RateLimitError("Rate limit exceeded: {'error': 'rate limit exceeded'}")
+            return {"response": {"event": "X"}}
+
+        p._ai = MagicMock()
+        p._ai.generate_detection.side_effect = mock_detect
+        p._ai.generate_response.return_value = {"response": [{"action": "report", "name": "x"}]}
+
+        rf = RuleFile(path="rules/rule.yml", content="title: Test", filename="rule.yml")
+        with patch("limacharlie.commands._dr_convert.time.sleep"):
+            result = p._convert_one_with_retry(rf, "rule")
+
+        assert result.success is True
+        assert call_count == 3
+
+    def test_retries_on_server_500_then_succeeds(self):
+        from limacharlie.errors import ApiError
+
+        org = MagicMock()
+        p = ConversionPipeline(org)
+
+        call_count = 0
+        def mock_detect(query):
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 2:
+                raise ApiError("API error (500): {'error': 'failed to process response'}", status_code=500)
+            return {"response": {"event": "X"}}
+
+        p._ai = MagicMock()
+        p._ai.generate_detection.side_effect = mock_detect
+        p._ai.generate_response.return_value = {"response": [{"action": "report", "name": "x"}]}
+
+        rf = RuleFile(path="rules/rule.yml", content="title: Test", filename="rule.yml")
+        with patch("limacharlie.commands._dr_convert.time.sleep"):
+            result = p._convert_one_with_retry(rf, "rule")
+
+        assert result.success is True
+        assert call_count == 3
+
+    def test_retries_on_mcp_timeout_then_succeeds(self):
+        from limacharlie.errors import ApiError
+
+        org = MagicMock()
+        p = ConversionPipeline(org)
+
+        call_count = 0
+        def mock_detect(query):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise ApiError(
+                    'API error (500): {\'error\': \'AI generation failed: MCP tool call failed: '
+                    'transport error: context deadline exceeded\'}',
+                    status_code=500,
+                )
+            return {"response": {"event": "X"}}
+
+        p._ai = MagicMock()
+        p._ai.generate_detection.side_effect = mock_detect
+        p._ai.generate_response.return_value = {"response": [{"action": "report", "name": "x"}]}
+
+        rf = RuleFile(path="rules/rule.yml", content="title: Test", filename="rule.yml")
+        with patch("limacharlie.commands._dr_convert.time.sleep"):
+            result = p._convert_one_with_retry(rf, "rule")
+
+        assert result.success is True
+        assert call_count == 2
+
+    def test_gives_up_after_max_retries(self):
+        from limacharlie.errors import RateLimitError
+
+        org = MagicMock()
+        p = ConversionPipeline(org)
+
+        p._ai = MagicMock()
+        p._ai.generate_detection.side_effect = RateLimitError("Rate limit exceeded: {'error': 'rate limit exceeded'}")
+
+        rf = RuleFile(path="rules/rule.yml", content="title: Test", filename="rule.yml")
+        with patch("limacharlie.commands._dr_convert.time.sleep"):
+            result = p._convert_one_with_retry(rf, "rule")
+
+        assert result.success is False
+        assert "rate limit" in result.error.lower()
+
+    def test_non_transient_error_not_retried(self):
+        org = MagicMock()
+        p = ConversionPipeline(org)
+
+        p._ai = MagicMock()
+        p._ai.generate_detection.side_effect = Exception("Some other error")
+
+        rf = RuleFile(path="rules/rule.yml", content="title: Test", filename="rule.yml")
+        result = p._convert_one_with_retry(rf, "rule")
+
+        assert result.success is False
+        assert "Some other error" in result.error
+        # Should only have been called once (no retry).
+        assert p._ai.generate_detection.call_count == 1
+
+    def test_is_transient_error_coverage(self):
+        check = ConversionPipeline._is_transient_error
+        assert check("Rate limit exceeded: blah") is True
+        assert check("API error (500): {'error': 'failed'}") is True
+        assert check("API error (502): bad gateway") is True
+        assert check("API error (503): unavailable") is True
+        assert check("API error (404): not found") is False
+        assert check("Some random error") is False
 
 
 class TestConversionPipelineConvertAll:


### PR DESCRIPTION
## Summary

- Adds `limacharlie dr convert-rules` command that mass-converts external detection rules (Sigma, Splunk SPL, Elastic KQL, CrowdStrike, etc.) to LimaCharlie D&R format using the AI API
- Supports crawling **GitHub repositories** or **local directories**
- Full GitHub URL support: `--github https://github.com/SigmaHQ/sigma/tree/master/rules/network/cisco` auto-extracts the branch and subdirectory path
- Creates converted rules directly in the org's `dr-general` hive with configurable prefix, tags, and enabled/disabled state
- Parallel conversion workers (default 10) with live progress display and ETA
- Pipeline-level retry with jitter for transient errors (429 rate limits, 500/502/503 server errors, MCP timeouts)
- Pre-primes JWT before spawning workers to avoid redundant OAuth refreshes
- Dry-run mode and YAML file output

### Usage examples

```bash
# From a full GitHub URL (auto-extracts ref + path)
limacharlie dr convert-rules \
    --github https://github.com/SigmaHQ/sigma/tree/master/rules/windows/process_creation

# From a GitHub repo with explicit path
limacharlie dr convert-rules --github SigmaHQ/sigma \
    --github-path rules/windows/process_creation

# From a local directory (dry run)
limacharlie dr convert-rules --input-dir ./splunk-rules --dry-run

# With options
limacharlie dr convert-rules --github elastic/detection-rules \
    --parallel 10 --tag migrated --prefix sigma --disabled
```

### New files
- `limacharlie/commands/_dr_convert.py` — Core logic: `GitHubCrawler`, `LocalCrawler`, `ConversionPipeline`, `ProgressDisplay`
- `tests/unit/test_dr_convert.py` — 88 unit tests

### Modified files
- `limacharlie/commands/dr.py` — Added `convert-rules` Click subcommand + explain text
- `limacharlie/discovery.py` — Added to `detection_engineering` profile

## Test plan

- [x] 88 unit tests pass (`pytest tests/unit/test_dr_convert.py`)
- [x] Manual test: `--github` with full GitHub tree URL scopes to correct subdirectory
- [x] Manual test: transient 500s and rate limits are retried automatically
- [ ] Manual test: end-to-end with hive creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)