### PR TITLE
Add --use flag to org create

### DIFF
--- a/limacharlie/commands/installation_key.py
+++ b/limacharlie/commands/installation_key.py
@@ -155,14 +155,16 @@ def get_key(ctx, iid) -> None:
 @group.command()
 @click.option("--description", required=True, help="Key description.")
 @click.option("--tags", default=None, help="Comma-separated tags to apply to enrolled sensors.")
+@click.option("--get", "get_after", is_flag=True, default=False, help="Fetch the full key details after creation.")
 @pass_context
-def create(ctx, description, tags) -> None:
+def create(ctx, description, tags, get_after) -> None:
     """Create a new installation key.
 
     Examples:
         limacharlie installation-key create --description "production linux"
         limacharlie installation-key create --description "staging" \\
             --tags "env:staging,os:windows"
+        limacharlie installation-key create --description "prod" --get
     """
     tag_list = None
     if tags:
@@ -173,6 +175,12 @@ def create(ctx, description, tags) -> None:
     data = keys.create(description, tags=tag_list)
     if not ctx.obj.quiet:
         click.echo("Installation key created.")
+
+    if get_after:
+        iid = data.get("iid") if isinstance(data, dict) else None
+        if iid:
+            data = keys.get(iid)
+
     _output(ctx, data)
 
 

--- a/limacharlie/commands/org.py
+++ b/limacharlie/commands/org.py
@@ -12,6 +12,7 @@ import click
 
 from ..cli import pass_context
 from ..client import Client
+from ..config import load_config, save_config
 from ..sdk.organization import Organization
 from ..output import format_output, detect_output_format
 from ..discovery import register_explain
@@ -378,13 +379,15 @@ def urls(ctx: click.Context) -> None:
 @click.option("--name", required=True, help="Name for the new organization.")
 @click.option("--location", default="auto", help="Data center location (usa, canada, europe, uk, india, australia, auto). Defaults to auto.")
 @click.option("--template", default=None, help="Optional template name to bootstrap the organization.")
+@click.option("--use", is_flag=True, default=False, help="Set the new organization as the default for subsequent commands.")
 @pass_context
-def create(ctx: click.Context, name: str, location: str, template: str | None) -> None:
+def create(ctx: click.Context, name: str, location: str, template: str | None, use: bool) -> None:
     """Create a new organization.
 
     Example:
         limacharlie org create --name my-org --location usa
         limacharlie org create --name my-org --location europe --template default
+        limacharlie org create --name my-org --use
     """
     client = _get_client(ctx)
     data = Organization.create_org(client, name, location, template)
@@ -403,6 +406,19 @@ def create(ctx: click.Context, name: str, location: str, template: str | None) -
             pass
     if oid and not ctx.obj.quiet:
         click.echo(f"\nOrganization URL: https://app.limacharlie.io/orgs/{oid}")
+
+    if use and oid:
+        env_name = ctx.obj.environment or "default"
+        config = load_config() or {}
+        if env_name == "default":
+            config["oid"] = oid
+        else:
+            config.setdefault("env", {})
+            config["env"].setdefault(env_name, {})
+            config["env"][env_name]["oid"] = oid
+        save_config(config)
+        if not ctx.obj.quiet:
+            click.echo(f"Default organization set to {oid} (environment '{env_name}').")
 
 
 # ---------------------------------------------------------------------------

--- a/limacharlie/commands/org.py
+++ b/limacharlie/commands/org.py
@@ -389,7 +389,7 @@ def create(ctx: click.Context, name: str, location: str, template: str | None, u
         limacharlie org create --name my-org --location europe --template default
         limacharlie org create --name my-org --use
     """
-    client = _get_client(ctx)
+    client = Client(oid="-", environment=ctx.obj.environment)
     data = Organization.create_org(client, name, location, template)
     _output(ctx, data)
 


### PR DESCRIPTION
## Summary
- Adds `--use` flag to `limacharlie org create` that automatically sets the newly created organization as the default OID for subsequent commands, saving an extra `limacharlie auth use-org <OID>` call
- Adds `--get` flag to `limacharlie installation-key create` that fetches the full key details after creation, equivalent to a follow-up `limacharlie installation-key get --iid <IID>`
- Fixes `org create` to use an OID-less (`-`) client so it doesn't fail when the previously saved default org has been deleted

## Test plan
- [ ] Run `limacharlie org create --name test-org --use` and verify the OID is saved to `~/.limacharlie`
- [ ] Run `limacharlie org create --name test-org` (without `--use`) and verify it still works unchanged
- [ ] Verify `--use` with `--env` saves to the correct environment section
- [ ] Delete the default org, then run `limacharlie org create --name new-org` and verify it no longer fails with a stale OID error
- [ ] Run `limacharlie installation-key create --description "test" --get` and verify full key details are returned
- [ ] Run `limacharlie installation-key create --description "test"` (without `--get`) and verify it still works unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)