### PR TITLE
feat: Add AI session creation via ai_agent Hive definitions

### DIFF
--- a/limacharlie/commands/ai.py
+++ b/limacharlie/commands/ai.py
@@ -256,3 +256,40 @@ def summarize_detection(ctx, detection_id) -> None:
     sdk = AISDK(org)
     data = sdk.summarize_detection(detection_data)
     _output(ctx, data)
+
+
+# ---------------------------------------------------------------------------
+# start-session
+# ---------------------------------------------------------------------------
+
+_EXPLAIN_START_SESSION = """\
+Start an AI session using an ai_agent Hive definition.  The definition
+contains the full session configuration including prompt, model,
+credentials (as hive://secret/ references), tool permissions, and
+MCP server configs.
+
+All hive://secret/ references in the definition are resolved
+automatically before the session is created.
+
+Example:
+  limacharlie ai start-session --definition my-security-analyst
+
+  limacharlie ai start-session --definition my-agent \\
+    --prompt "Investigate this specific alert" \\
+    --name "Alert investigation"
+"""
+register_explain("ai.start-session", _EXPLAIN_START_SESSION)
+
+
+@group.command("start-session")
+@click.option("--definition", required=True, help="Name of the ai_agent hive record to use.")
+@click.option("--prompt", default=None, help="Override the prompt from the definition.")
+@click.option("--name", default=None, help="Override the session name.")
+@click.option("--idempotent-key", default=None, help="Deduplication key for the session.")
+@pass_context
+def start_session(ctx, definition, prompt, name, idempotent_key) -> None:
+    org = _get_org(ctx)
+    sdk = AISDK(org)
+    data = sdk.start_session(definition, prompt=prompt, name=name,
+                             idempotent_key=idempotent_key)
+    _output(ctx, data)

--- a/limacharlie/sdk/ai.py
+++ b/limacharlie/sdk/ai.py
@@ -110,16 +110,28 @@ class AI:
         if profile:
             request_body["profile"] = profile
 
+        extra = {"X-LC-OID": self.client._oid}
+
+        # Use the raw API key when available (works with current and future
+        # ai-sessions deployments).  Fall back to JWT auth for OAuth users
+        # (requires OrgDualAuthMiddleware on the server side).
+        if self.client._api_key is not None:
+            extra["Authorization"] = f"Bearer {self.client._api_key}"
+            return self.client.request(
+                "POST", "v1/api/sessions",
+                raw_body=json.dumps(request_body).encode(),
+                content_type="application/json",
+                is_no_auth=True,
+                alt_root=_AI_SESSIONS_URL,
+                extra_headers=extra,
+            )
+
         return self.client.request(
             "POST", "v1/api/sessions",
             raw_body=json.dumps(request_body).encode(),
             content_type="application/json",
-            is_no_auth=True,
             alt_root=_AI_SESSIONS_URL,
-            extra_headers={
-                "Authorization": f"Bearer {self.client._api_key}",
-                "X-LC-OID": self.client._oid,
-            },
+            extra_headers=extra,
         )
 
     def generate_dr_rule(self, description: str) -> dict[str, Any]:

--- a/limacharlie/sdk/ai.py
+++ b/limacharlie/sdk/ai.py
@@ -8,6 +8,9 @@ from typing import Any, TYPE_CHECKING
 if TYPE_CHECKING:
     from .organization import Organization
 
+_HIVE_SECRET_PREFIX = "hive://secret/"
+_AI_SESSIONS_URL = "https://ai.limacharlie.io"
+
 
 class AI:
     """AI-powered generation of rules, queries, selectors, and playbooks."""
@@ -19,6 +22,105 @@ class AI:
     def client(self) -> Any:
         """The underlying API client."""
         return self._org.client
+
+    def _resolve_secret(self, value: str) -> str:
+        """Resolve a value that may be a hive://secret/ reference."""
+        if not value or not value.startswith(_HIVE_SECRET_PREFIX):
+            return value
+        secret_name = value[len(_HIVE_SECRET_PREFIX):]
+        if not secret_name:
+            raise ValueError("empty secret name in hive://secret/ reference")
+        from .hive import Hive
+        record = Hive(self._org, "secret").get(secret_name)
+        return record.data["secret"]
+
+    def _resolve_map_secrets(self, m: dict[str, str] | None) -> dict[str, str] | None:
+        """Resolve hive://secret/ references in all values of a string map."""
+        if not m:
+            return m
+        return {k: self._resolve_secret(v) for k, v in m.items()}
+
+    def start_session(self, definition_name: str, prompt: str | None = None,
+                      name: str | None = None,
+                      idempotent_key: str | None = None) -> dict[str, Any]:
+        """Start an AI session using an ai_agent Hive definition.
+
+        Args:
+            definition_name: Name of the ai_agent hive record.
+            prompt: Override the prompt from the definition.
+            name: Override the session name.
+            idempotent_key: Optional deduplication key.
+
+        Returns:
+            dict: Session creation response with session_id and status.
+        """
+        from .hive import Hive
+
+        # Fetch the ai_agent definition.
+        record = Hive(self._org, "ai_agent").get(definition_name)
+        defn = record.data or {}
+
+        # Resolve credential secrets.
+        anthropic_key = self._resolve_secret(defn.get("anthropic_secret", ""))
+        lc_api_key = self._resolve_secret(defn.get("lc_api_key_secret", ""))
+        lc_uid = self._resolve_secret(defn.get("lc_uid_secret", ""))
+
+        # Fall back to the caller's own API key if none specified.
+        if not lc_api_key:
+            lc_api_key = self.client._api_key
+
+        # Build the profile section.
+        profile: dict[str, Any] = {}
+        for field in ("allowed_tools", "denied_tools", "permission_mode",
+                       "model", "max_turns", "max_budget_usd",
+                       "ttl_seconds", "one_shot"):
+            if field in defn:
+                profile[field] = defn[field]
+
+        # Resolve secrets in environment values.
+        if defn.get("environment"):
+            profile["environment"] = self._resolve_map_secrets(defn["environment"])
+
+        # Resolve secrets in MCP server configs.
+        if defn.get("mcp_servers"):
+            resolved_servers: dict[str, Any] = {}
+            for srv_name, srv_cfg in defn["mcp_servers"].items():
+                srv = dict(srv_cfg)
+                if srv.get("headers"):
+                    srv["headers"] = self._resolve_map_secrets(srv["headers"])
+                if srv.get("env"):
+                    srv["env"] = self._resolve_map_secrets(srv["env"])
+                resolved_servers[srv_name] = srv
+            profile["mcp_servers"] = resolved_servers
+
+        # Build the request body.
+        request_body: dict[str, Any] = {
+            "prompt": prompt or defn.get("prompt", ""),
+            "anthropic_key": anthropic_key,
+            "trigger_source": "cli",
+        }
+        if lc_api_key:
+            request_body["lc_api_key"] = lc_api_key
+        if lc_uid:
+            request_body["lc_uid"] = lc_uid
+        if name or defn.get("name"):
+            request_body["name"] = name or defn["name"]
+        if idempotent_key:
+            request_body["idempotent_key"] = idempotent_key
+        if profile:
+            request_body["profile"] = profile
+
+        return self.client.request(
+            "POST", "v1/api/sessions",
+            raw_body=json.dumps(request_body).encode(),
+            content_type="application/json",
+            is_no_auth=True,
+            alt_root=_AI_SESSIONS_URL,
+            extra_headers={
+                "Authorization": f"Bearer {self.client._api_key}",
+                "X-LC-OID": self.client._oid,
+            },
+        )
 
     def generate_dr_rule(self, description: str) -> dict[str, Any]:
         """Generate a complete D&R rule from a natural language description.

--- a/tests/unit/test_sdk_ai_sessions.py
+++ b/tests/unit/test_sdk_ai_sessions.py
@@ -1,0 +1,255 @@
+"""Tests for AI.start_session in limacharlie.sdk.ai."""
+
+import json
+from unittest.mock import MagicMock, patch, call
+
+import pytest
+
+from limacharlie.sdk.ai import AI, _AI_SESSIONS_URL
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def mock_org():
+    org = MagicMock()
+    org.oid = "test-oid"
+    org.client = MagicMock()
+    org.client._api_key = "test-api-key"
+    org.client._oid = "test-oid"
+    return org
+
+
+@pytest.fixture
+def ai(mock_org):
+    return AI(mock_org)
+
+
+def _make_hive_record(data):
+    """Return a mock HiveRecord with the given data dict."""
+    record = MagicMock()
+    record.data = data
+    return record
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestStartSessionBasic:
+    """Minimal definition with inline credentials (no hive://secret/ refs)."""
+
+    def test_sends_correct_request(self, ai, mock_org):
+        defn = {
+            "prompt": "Analyze this event",
+            "anthropic_secret": "sk-ant-literal",
+            "lc_api_key_secret": "lc-key-literal",
+            "model": "claude-sonnet-4-6",
+            "max_turns": 10,
+        }
+
+        with patch("limacharlie.sdk.hive.Hive") as MockHive:
+            hive_instance = MagicMock()
+            MockHive.return_value = hive_instance
+            hive_instance.get.return_value = _make_hive_record(defn)
+            mock_org.client.request.return_value = {
+                "session_id": "sess-123",
+                "status": "pending",
+            }
+
+            result = ai.start_session("my-agent")
+
+        # Verify hive was queried for the ai_agent record.
+        MockHive.assert_called_with(mock_org, "ai_agent")
+        hive_instance.get.assert_called_with("my-agent")
+
+        # Verify the POST call.
+        call_args = mock_org.client.request.call_args
+        assert call_args[0] == ("POST", "v1/api/sessions")
+        assert call_args[1]["content_type"] == "application/json"
+        assert call_args[1]["is_no_auth"] is True
+        assert call_args[1]["alt_root"] == _AI_SESSIONS_URL
+        assert call_args[1]["extra_headers"]["Authorization"] == "Bearer test-api-key"
+        assert call_args[1]["extra_headers"]["X-LC-OID"] == "test-oid"
+
+        body = json.loads(call_args[1]["raw_body"])
+        assert body["prompt"] == "Analyze this event"
+        assert body["anthropic_key"] == "sk-ant-literal"
+        assert body["lc_api_key"] == "lc-key-literal"
+        assert body["trigger_source"] == "cli"
+        assert body["profile"]["model"] == "claude-sonnet-4-6"
+        assert body["profile"]["max_turns"] == 10
+
+        assert result == {"session_id": "sess-123", "status": "pending"}
+
+
+class TestStartSessionSecretResolution:
+    """Credentials that use hive://secret/ references get resolved."""
+
+    def test_resolves_secrets(self, ai, mock_org):
+        defn = {
+            "prompt": "investigate",
+            "anthropic_secret": "hive://secret/anthropic-key",
+            "lc_api_key_secret": "hive://secret/lc-key",
+            "lc_uid_secret": "hive://secret/lc-uid",
+        }
+
+        with patch("limacharlie.sdk.hive.Hive") as MockHive:
+            hive_instance = MagicMock()
+            MockHive.return_value = hive_instance
+
+            def get_side_effect(name):
+                records = {
+                    "my-agent": _make_hive_record(defn),
+                    "anthropic-key": _make_hive_record({"secret": "sk-resolved"}),
+                    "lc-key": _make_hive_record({"secret": "lc-resolved"}),
+                    "lc-uid": _make_hive_record({"secret": "uid-resolved"}),
+                }
+                return records[name]
+
+            hive_instance.get.side_effect = get_side_effect
+            mock_org.client.request.return_value = {"session_id": "s1"}
+
+            ai.start_session("my-agent")
+
+        body = json.loads(mock_org.client.request.call_args[1]["raw_body"])
+        assert body["anthropic_key"] == "sk-resolved"
+        assert body["lc_api_key"] == "lc-resolved"
+        assert body["lc_uid"] == "uid-resolved"
+
+
+class TestStartSessionLcApiKeyFallback:
+    """When lc_api_key_secret is not in the definition, falls back to client key."""
+
+    def test_uses_client_api_key(self, ai, mock_org):
+        defn = {
+            "prompt": "analyze",
+            "anthropic_secret": "sk-ant",
+        }
+
+        with patch("limacharlie.sdk.hive.Hive") as MockHive:
+            hive_instance = MagicMock()
+            MockHive.return_value = hive_instance
+            hive_instance.get.return_value = _make_hive_record(defn)
+            mock_org.client.request.return_value = {"session_id": "s1"}
+
+            ai.start_session("agent")
+
+        body = json.loads(mock_org.client.request.call_args[1]["raw_body"])
+        assert body["lc_api_key"] == "test-api-key"
+
+
+class TestStartSessionOverrides:
+    """Prompt and name can be overridden from CLI parameters."""
+
+    def test_overrides_prompt_and_name(self, ai, mock_org):
+        defn = {
+            "prompt": "original prompt",
+            "name": "original name",
+            "anthropic_secret": "sk-ant",
+            "lc_api_key_secret": "lc-key",
+        }
+
+        with patch("limacharlie.sdk.hive.Hive") as MockHive:
+            hive_instance = MagicMock()
+            MockHive.return_value = hive_instance
+            hive_instance.get.return_value = _make_hive_record(defn)
+            mock_org.client.request.return_value = {"session_id": "s1"}
+
+            ai.start_session("agent", prompt="override prompt",
+                             name="override name", idempotent_key="dedup-1")
+
+        body = json.loads(mock_org.client.request.call_args[1]["raw_body"])
+        assert body["prompt"] == "override prompt"
+        assert body["name"] == "override name"
+        assert body["idempotent_key"] == "dedup-1"
+
+
+class TestStartSessionMCPServers:
+    """MCP server configs have their secrets resolved."""
+
+    def test_resolves_mcp_server_secrets(self, ai, mock_org):
+        defn = {
+            "prompt": "do things",
+            "anthropic_secret": "sk-ant",
+            "lc_api_key_secret": "lc-key",
+            "mcp_servers": {
+                "github": {
+                    "type": "http",
+                    "url": "https://api.github.com",
+                    "headers": {
+                        "Authorization": "hive://secret/gh-token",
+                        "Accept": "application/json",
+                    },
+                },
+                "local": {
+                    "type": "stdio",
+                    "command": "/usr/bin/tool",
+                    "env": {
+                        "API_KEY": "hive://secret/tool-key",
+                        "DEBUG": "false",
+                    },
+                },
+            },
+        }
+
+        with patch("limacharlie.sdk.hive.Hive") as MockHive:
+            hive_instance = MagicMock()
+            MockHive.return_value = hive_instance
+
+            def get_side_effect(name):
+                records = {
+                    "agent": _make_hive_record(defn),
+                    "gh-token": _make_hive_record({"secret": "ghp_resolved"}),
+                    "tool-key": _make_hive_record({"secret": "tool-resolved"}),
+                }
+                return records[name]
+
+            hive_instance.get.side_effect = get_side_effect
+            mock_org.client.request.return_value = {"session_id": "s1"}
+
+            ai.start_session("agent")
+
+        body = json.loads(mock_org.client.request.call_args[1]["raw_body"])
+        mcp = body["profile"]["mcp_servers"]
+        assert mcp["github"]["headers"]["Authorization"] == "ghp_resolved"
+        assert mcp["github"]["headers"]["Accept"] == "application/json"
+        assert mcp["local"]["env"]["API_KEY"] == "tool-resolved"
+        assert mcp["local"]["env"]["DEBUG"] == "false"
+
+
+class TestStartSessionEnvironmentSecrets:
+    """Environment map values with hive://secret/ are resolved."""
+
+    def test_resolves_environment_secrets(self, ai, mock_org):
+        defn = {
+            "prompt": "go",
+            "anthropic_secret": "sk-ant",
+            "lc_api_key_secret": "lc-key",
+            "environment": {
+                "EXTERNAL_KEY": "hive://secret/ext-key",
+                "PLAIN": "plain-value",
+            },
+        }
+
+        with patch("limacharlie.sdk.hive.Hive") as MockHive:
+            hive_instance = MagicMock()
+            MockHive.return_value = hive_instance
+
+            def get_side_effect(name):
+                records = {
+                    "agent": _make_hive_record(defn),
+                    "ext-key": _make_hive_record({"secret": "ext-resolved"}),
+                }
+                return records[name]
+
+            hive_instance.get.side_effect = get_side_effect
+            mock_org.client.request.return_value = {"session_id": "s1"}
+
+            ai.start_session("agent")
+
+        body = json.loads(mock_org.client.request.call_args[1]["raw_body"])
+        assert body["profile"]["environment"]["EXTERNAL_KEY"] == "ext-resolved"
+        assert body["profile"]["environment"]["PLAIN"] == "plain-value"


### PR DESCRIPTION
## Summary
- Add `limacharlie ai start-session --definition <name>` CLI command to start AI sessions using `ai_agent` Hive definitions
- Resolves all `hive://secret/` references in credentials, environment variables, and MCP server configs
- Falls back to the caller's own API key when `lc_api_key_secret` is not specified in the definition
- Posts to `https://ai.limacharlie.io/v1/api/sessions` with raw API key auth

## Test plan
- [x] Unit tests added (6 tests covering basic flow, secret resolution, API key fallback, overrides, MCP server secrets, environment secrets)
- [x] All existing unit tests still pass
- [ ] Manual test against staging: `limacharlie ai start-session --definition <test-agent>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)