### PR TITLE
Add --sid filter to ticket list

### DIFF
--- a/limacharlie/commands/ticket.py
+++ b/limacharlie/commands/ticket.py
@@ -41,6 +41,7 @@ Filters (all repeatable/comma-separated):
   --classification  pending, true_positive, false_positive
   --assignee  filter by assignee email
   --search    full-text search in detection_cat and hostname
+  --sid       filter to tickets with any detection from this sensor ID
   --tag       filter by tag (repeat for AND logic)
 
 Sorting:
@@ -594,6 +595,7 @@ def create(ctx, detection_id, detection_cat, severity, detection_source,
 @click.option("--classification", multiple=True, type=_CLASSIFICATION_CHOICES, help="Filter by classification (repeatable).")
 @click.option("--assignee", default=None, help="Filter by assignee email.")
 @click.option("--search", default=None, help="Full-text search (detection_cat, hostname).")
+@click.option("--sid", default=None, help="Filter to tickets with any detection from this sensor ID.")
 @click.option("--tag", multiple=True, help="Filter by tag (repeat for AND logic).")
 @click.option("--sort", default=None, type=_SORT_CHOICES, help="Sort field (default: created_at).")
 @click.option("--order", default=None, type=_ORDER_CHOICES, help="Sort order (default: desc).")
@@ -601,7 +603,7 @@ def create(ctx, detection_id, detection_cat, severity, detection_source,
 @click.option("--cursor", default=None, help="Page token for next page.")
 @pass_context
 def list_tickets(ctx, status, severity, classification, assignee, search,
-                 tag, sort, order, limit, cursor) -> None:
+                 sid, tag, sort, order, limit, cursor) -> None:
     """List tickets.
 
     Examples:
@@ -610,6 +612,7 @@ def list_tickets(ctx, status, severity, classification, assignee, search,
         limacharlie ticket list --severity critical --severity high
         limacharlie ticket list --search "mimikatz" --limit 20
         limacharlie ticket list --tag phishing --tag urgent
+        limacharlie ticket list --sid 8f4b1c2e-...
     """
     t = _get_ticketing(ctx)
     data = t.list_tickets(
@@ -618,6 +621,7 @@ def list_tickets(ctx, status, severity, classification, assignee, search,
         classification=list(classification) or None,
         assignee=assignee,
         search=search,
+        sensor_id=sid,
         tag=list(tag) or None,
         sort=sort,
         order=order,

--- a/limacharlie/sdk/ticketing.py
+++ b/limacharlie/sdk/ticketing.py
@@ -108,6 +108,7 @@ class Ticketing:
         classification: list[str] | None = None,
         assignee: str | None = None,
         search: str | None = None,
+        sensor_id: str | None = None,
         tag: list[str] | None = None,
         sort: str | None = None,
         order: str | None = None,
@@ -126,6 +127,8 @@ class Ticketing:
             qp["assignee"] = assignee
         if search:
             qp["search"] = search
+        if sensor_id:
+            qp["sensor_id"] = sensor_id
         if tag:
             qp["tag"] = ",".join(tag)
         if sort:

--- a/tests/unit/test_cli_ticket.py
+++ b/tests/unit/test_cli_ticket.py
@@ -1181,6 +1181,50 @@ class TestTicketListTag:
 
 
 # ---------------------------------------------------------------------------
+# ticket list --sid
+# ---------------------------------------------------------------------------
+
+
+class TestTicketListSid:
+    def test_list_with_sid(self):
+        p1, p2, p3 = _patch_ticketing()
+        with p1, p2, p3 as mock_t_cls:
+            result, mock_t = _invoke(
+                ["ticket", "list", "--sid", "abc-sensor-123"],
+                mock_t_cls,
+                return_value={"tickets": [], "total_counts": {}},
+            )
+            assert result.exit_code == 0
+            call_kwargs = mock_t.list_tickets.call_args[1]
+            assert call_kwargs["sensor_id"] == "abc-sensor-123"
+
+    def test_list_without_sid(self):
+        p1, p2, p3 = _patch_ticketing()
+        with p1, p2, p3 as mock_t_cls:
+            result, mock_t = _invoke(
+                ["ticket", "list"],
+                mock_t_cls,
+                return_value={"tickets": [], "total_counts": {}},
+            )
+            assert result.exit_code == 0
+            call_kwargs = mock_t.list_tickets.call_args[1]
+            assert call_kwargs["sensor_id"] is None
+
+    def test_list_sid_combined_with_status(self):
+        p1, p2, p3 = _patch_ticketing()
+        with p1, p2, p3 as mock_t_cls:
+            result, mock_t = _invoke(
+                ["ticket", "list", "--sid", "abc-sensor-123", "--status", "new"],
+                mock_t_cls,
+                return_value={"tickets": [], "total_counts": {}},
+            )
+            assert result.exit_code == 0
+            call_kwargs = mock_t.list_tickets.call_args[1]
+            assert call_kwargs["sensor_id"] == "abc-sensor-123"
+            assert call_kwargs["status"] == ["new"]
+
+
+# ---------------------------------------------------------------------------
 # ticket update --tag
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_sdk_ticketing.py
+++ b/tests/unit/test_sdk_ticketing.py
@@ -164,6 +164,20 @@ class TestListTickets:
         assert "status" not in qp
         assert "severity" not in qp
 
+    def test_sensor_id_filter(self, ticketing, mock_org):
+        mock_org.client.request.return_value = {"tickets": []}
+        ticketing.list_tickets(sensor_id="abc-sensor-123")
+        _, kwargs = _extract_call(mock_org)
+        qp = kwargs["query_params"]
+        assert qp["sensor_id"] == "abc-sensor-123"
+
+    def test_sensor_id_none_omitted(self, ticketing, mock_org):
+        mock_org.client.request.return_value = {"tickets": []}
+        ticketing.list_tickets(sensor_id=None)
+        _, kwargs = _extract_call(mock_org)
+        qp = kwargs["query_params"]
+        assert "sensor_id" not in qp
+
 
 class TestGetTicket:
     def test_path_and_query(self, ticketing, mock_org):


### PR DESCRIPTION
## Summary
- Adds `--sid` option to `ticket list` CLI command to find tickets where ANY detection came from a given sensor ID
- Adds `sensor_id` parameter to `Ticketing.list_tickets()` SDK method
- Backed by a new Spanner index (`idx_ticket_detections_sensor_id`) and EXISTS subquery in ext-ticketing (pushed to `claude` branch)

## How it works
The ext-ticketing API now accepts a `sensor_id` query parameter on `GET /api/v1/tickets`. Under the hood, a `NULL_FILTERED INDEX` on `ticket_detections(oid, sensor_id, ticket_id)` makes the lookup efficient. The query uses an `EXISTS` subquery that hits this index to find tickets where any linked detection came from the given sensor, without a full table scan.

## Usage
```bash
limacharlie ticket list --sid <sensor-id>
limacharlie ticket list --sid <sensor-id> --status new --severity critical
```

## Test plan
- [x] SDK tests: `test_sensor_id_filter`, `test_sensor_id_none_omitted`
- [x] CLI tests: `test_list_with_sid`, `test_list_without_sid`, `test_list_sid_combined_with_status`
- [x] All 146 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)