### PR TITLE
Add enable/disable commands for Hive records

### DIFF
--- a/limacharlie/commands/_hive_shortcut.py
+++ b/limacharlie/commands/_hive_shortcut.py
@@ -125,10 +125,32 @@ def make_hive_group(group_name: str, hive_name: str, noun_singular: str, noun_pl
         result = hive.delete(key)
         _output(ctx, result)
 
+    @grp.command("enable", help=f"Enable {article} {noun_singular}.")
+    @click.option("--key", required=True, help="Record key name.")
+    @pass_context
+    def enable_cmd(ctx, key) -> None:
+        org = _get_org(ctx)
+        hive = Hive(org, hive_name)
+        record = HiveRecord(key, enabled=True)
+        result = hive.set(record)
+        _output(ctx, result)
+
+    @grp.command("disable", help=f"Disable {article} {noun_singular}.")
+    @click.option("--key", required=True, help="Record key name.")
+    @pass_context
+    def disable_cmd(ctx, key) -> None:
+        org = _get_org(ctx)
+        hive = Hive(org, hive_name)
+        record = HiveRecord(key, enabled=False)
+        result = hive.set(record)
+        _output(ctx, result)
+
     # Register explain texts.
     register_explain(f"{group_name}.list", explain_list)
     register_explain(f"{group_name}.get", explain_get)
     register_explain(f"{group_name}.set", explain_set)
     register_explain(f"{group_name}.delete", explain_delete)
+    register_explain(f"{group_name}.enable", f"Enable {article} {noun_singular} by key (sets usr_mtd.enabled to true).")
+    register_explain(f"{group_name}.disable", f"Disable {article} {noun_singular} by key (sets usr_mtd.enabled to false).")
 
     return grp

--- a/limacharlie/commands/hive.py
+++ b/limacharlie/commands/hive.py
@@ -301,6 +301,57 @@ def delete(ctx, hive_name, key, confirm) -> None:
 
 
 # ---------------------------------------------------------------------------
+# enable / disable
+# ---------------------------------------------------------------------------
+
+_EXPLAIN_ENABLE = """\
+Enable a hive record by setting its usr_mtd.enabled flag to true.
+Only the metadata is updated; the record data is left unchanged.
+
+This is a shortcut for:
+  echo '{"usr_mtd": {"enabled": true}}' | limacharlie hive set ...
+"""
+register_explain("hive.enable", _EXPLAIN_ENABLE)
+
+_EXPLAIN_DISABLE = """\
+Disable a hive record by setting its usr_mtd.enabled flag to false.
+Only the metadata is updated; the record data is left unchanged.
+
+This is a shortcut for:
+  echo '{"usr_mtd": {"enabled": false}}' | limacharlie hive set ...
+"""
+register_explain("hive.disable", _EXPLAIN_DISABLE)
+
+
+def _set_enabled(ctx: click.Context, hive_name: str, key: str, enabled: bool) -> None:
+    """Toggle the enabled flag on a hive record."""
+    org = _get_org(ctx)
+    hive = Hive(org, hive_name)
+    record = HiveRecord(key, enabled=enabled)
+    result = hive.set(record)
+    state = "enabled" if enabled else "disabled"
+    if not ctx.obj.quiet:
+        click.echo(f"Record '{key}' {state} in hive '{hive_name}'.")
+    _output(ctx, result)
+
+
+@group.command()
+@click.option("--hive-name", required=True, help="Hive name.")
+@click.option("--key", required=True, help="Record key.")
+@pass_context
+def enable(ctx, hive_name, key) -> None:
+    _set_enabled(ctx, hive_name, key, True)
+
+
+@group.command()
+@click.option("--hive-name", required=True, help="Hive name.")
+@click.option("--key", required=True, help="Record key.")
+@pass_context
+def disable(ctx, hive_name, key) -> None:
+    _set_enabled(ctx, hive_name, key, False)
+
+
+# ---------------------------------------------------------------------------
 # validate
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_cli_commands.py
+++ b/tests/unit/test_cli_commands.py
@@ -267,3 +267,63 @@ class TestDRCommands:
         mock_hive.list.assert_called_once()
 
 
+class TestHiveEnableDisable:
+    @patch("limacharlie.commands.hive.Client")
+    @patch("limacharlie.commands.hive.Organization")
+    @patch("limacharlie.commands.hive.Hive")
+    def test_hive_enable(self, mock_hive_cls, mock_org_cls, mock_client_cls):
+        mock_hive = MagicMock()
+        mock_hive.set.return_value = {"etag": "new"}
+        mock_hive_cls.return_value = mock_hive
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["hive", "enable", "--hive-name", "dr-general", "--key", "my-rule"])
+        assert result.exit_code == 0
+        record = mock_hive.set.call_args[0][0]
+        assert record.enabled is True
+        assert record.data is None  # only metadata update
+
+    @patch("limacharlie.commands.hive.Client")
+    @patch("limacharlie.commands.hive.Organization")
+    @patch("limacharlie.commands.hive.Hive")
+    def test_hive_disable(self, mock_hive_cls, mock_org_cls, mock_client_cls):
+        mock_hive = MagicMock()
+        mock_hive.set.return_value = {"etag": "new"}
+        mock_hive_cls.return_value = mock_hive
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["hive", "disable", "--hive-name", "dr-general", "--key", "my-rule"])
+        assert result.exit_code == 0
+        record = mock_hive.set.call_args[0][0]
+        assert record.enabled is False
+        assert record.data is None
+
+    @patch("limacharlie.commands._hive_shortcut.Client")
+    @patch("limacharlie.commands._hive_shortcut.Organization")
+    @patch("limacharlie.commands._hive_shortcut.Hive")
+    def test_shortcut_enable(self, mock_hive_cls, mock_org_cls, mock_client_cls):
+        mock_hive = MagicMock()
+        mock_hive.set.return_value = {"etag": "new"}
+        mock_hive_cls.return_value = mock_hive
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["secret", "enable", "--key", "my-secret"])
+        assert result.exit_code == 0
+        record = mock_hive.set.call_args[0][0]
+        assert record.enabled is True
+
+    @patch("limacharlie.commands._hive_shortcut.Client")
+    @patch("limacharlie.commands._hive_shortcut.Organization")
+    @patch("limacharlie.commands._hive_shortcut.Hive")
+    def test_shortcut_disable(self, mock_hive_cls, mock_org_cls, mock_client_cls):
+        mock_hive = MagicMock()
+        mock_hive.set.return_value = {"etag": "new"}
+        mock_hive_cls.return_value = mock_hive
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["secret", "disable", "--key", "my-secret"])
+        assert result.exit_code == 0
+        record = mock_hive.set.call_args[0][0]
+        assert record.enabled is False
+
+


### PR DESCRIPTION
## Summary
- Adds `hive enable` and `hive disable` subcommands that toggle `usr_mtd.enabled` without touching record data
- Adds the same `enable`/`disable` commands to all hive shortcut groups (secret, lookup, fp, playbook, etc.)
- Shortcut for the clunky `echo '{"usr_mtd": {"enabled": false}}' | limacharlie hive set ...` pattern

## Usage
```bash
# Direct hive commands
limacharlie hive disable --hive-name dr-general --key my-rule
limacharlie hive enable --hive-name dr-general --key my-rule

# Via shortcut groups
limacharlie secret disable --key my-secret
limacharlie lookup enable --key my-lookup
```

## Test plan
- [x] Unit tests for `hive enable` and `hive disable`
- [x] Unit tests for shortcut group `enable`/`disable` (via `secret`)
- [x] All 959 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)