### PR TITLE
Fix hive enable/disable to preserve existing metadata

### DIFF
--- a/limacharlie/commands/_hive_shortcut.py
+++ b/limacharlie/commands/_hive_shortcut.py
@@ -131,7 +131,8 @@ def make_hive_group(group_name: str, hive_name: str, noun_singular: str, noun_pl
     def enable_cmd(ctx, key) -> None:
         org = _get_org(ctx)
         hive = Hive(org, hive_name)
-        record = HiveRecord(key, enabled=True)
+        record = hive.get_metadata(key)
+        record.enabled = True
         result = hive.set(record)
         _output(ctx, result)
 
@@ -141,7 +142,8 @@ def make_hive_group(group_name: str, hive_name: str, noun_singular: str, noun_pl
     def disable_cmd(ctx, key) -> None:
         org = _get_org(ctx)
         hive = Hive(org, hive_name)
-        record = HiveRecord(key, enabled=False)
+        record = hive.get_metadata(key)
+        record.enabled = False
         result = hive.set(record)
         _output(ctx, result)
 

--- a/limacharlie/commands/hive.py
+++ b/limacharlie/commands/hive.py
@@ -306,28 +306,29 @@ def delete(ctx, hive_name, key, confirm) -> None:
 
 _EXPLAIN_ENABLE = """\
 Enable a hive record by setting its usr_mtd.enabled flag to true.
-Only the metadata is updated; the record data is left unchanged.
-
-This is a shortcut for:
-  echo '{"usr_mtd": {"enabled": true}}' | limacharlie hive set ...
+Only the enabled flag is changed; all other metadata (tags, expiry,
+comment) and record data are preserved.
 """
 register_explain("hive.enable", _EXPLAIN_ENABLE)
 
 _EXPLAIN_DISABLE = """\
 Disable a hive record by setting its usr_mtd.enabled flag to false.
-Only the metadata is updated; the record data is left unchanged.
-
-This is a shortcut for:
-  echo '{"usr_mtd": {"enabled": false}}' | limacharlie hive set ...
+Only the enabled flag is changed; all other metadata (tags, expiry,
+comment) and record data are preserved.
 """
 register_explain("hive.disable", _EXPLAIN_DISABLE)
 
 
 def _set_enabled(ctx: click.Context, hive_name: str, key: str, enabled: bool) -> None:
-    """Toggle the enabled flag on a hive record."""
+    """Toggle the enabled flag on a hive record.
+
+    Reads the current metadata first so that tags, expiry, and comment
+    are preserved (the API replaces usr_mtd wholesale).
+    """
     org = _get_org(ctx)
     hive = Hive(org, hive_name)
-    record = HiveRecord(key, enabled=enabled)
+    record = hive.get_metadata(key)
+    record.enabled = enabled
     result = hive.set(record)
     state = "enabled" if enabled else "disabled"
     if not ctx.obj.quiet:

--- a/tests/unit/test_cli_commands.py
+++ b/tests/unit/test_cli_commands.py
@@ -268,11 +268,22 @@ class TestDRCommands:
 
 
 class TestHiveEnableDisable:
+    @staticmethod
+    def _existing_record(name="my-rule", enabled=True):
+        """Return an HiveRecord simulating existing metadata."""
+        from limacharlie.sdk.hive import HiveRecord
+        return HiveRecord(
+            name=name, enabled=enabled,
+            tags=["keep-me"], expiry=1234, comment="preserve this",
+            etag="old-etag",
+        )
+
     @patch("limacharlie.commands.hive.Client")
     @patch("limacharlie.commands.hive.Organization")
     @patch("limacharlie.commands.hive.Hive")
     def test_hive_enable(self, mock_hive_cls, mock_org_cls, mock_client_cls):
         mock_hive = MagicMock()
+        mock_hive.get_metadata.return_value = self._existing_record(enabled=False)
         mock_hive.set.return_value = {"etag": "new"}
         mock_hive_cls.return_value = mock_hive
 
@@ -282,12 +293,16 @@ class TestHiveEnableDisable:
         record = mock_hive.set.call_args[0][0]
         assert record.enabled is True
         assert record.data is None  # only metadata update
+        assert record.tags == ["keep-me"]
+        assert record.expiry == 1234
+        assert record.comment == "preserve this"
 
     @patch("limacharlie.commands.hive.Client")
     @patch("limacharlie.commands.hive.Organization")
     @patch("limacharlie.commands.hive.Hive")
     def test_hive_disable(self, mock_hive_cls, mock_org_cls, mock_client_cls):
         mock_hive = MagicMock()
+        mock_hive.get_metadata.return_value = self._existing_record(enabled=True)
         mock_hive.set.return_value = {"etag": "new"}
         mock_hive_cls.return_value = mock_hive
 
@@ -297,12 +312,14 @@ class TestHiveEnableDisable:
         record = mock_hive.set.call_args[0][0]
         assert record.enabled is False
         assert record.data is None
+        assert record.tags == ["keep-me"]
 
     @patch("limacharlie.commands._hive_shortcut.Client")
     @patch("limacharlie.commands._hive_shortcut.Organization")
     @patch("limacharlie.commands._hive_shortcut.Hive")
     def test_shortcut_enable(self, mock_hive_cls, mock_org_cls, mock_client_cls):
         mock_hive = MagicMock()
+        mock_hive.get_metadata.return_value = self._existing_record("my-secret", enabled=False)
         mock_hive.set.return_value = {"etag": "new"}
         mock_hive_cls.return_value = mock_hive
 
@@ -311,12 +328,14 @@ class TestHiveEnableDisable:
         assert result.exit_code == 0
         record = mock_hive.set.call_args[0][0]
         assert record.enabled is True
+        assert record.tags == ["keep-me"]
 
     @patch("limacharlie.commands._hive_shortcut.Client")
     @patch("limacharlie.commands._hive_shortcut.Organization")
     @patch("limacharlie.commands._hive_shortcut.Hive")
     def test_shortcut_disable(self, mock_hive_cls, mock_org_cls, mock_client_cls):
         mock_hive = MagicMock()
+        mock_hive.get_metadata.return_value = self._existing_record("my-secret", enabled=True)
         mock_hive.set.return_value = {"etag": "new"}
         mock_hive_cls.return_value = mock_hive
 
@@ -325,5 +344,6 @@ class TestHiveEnableDisable:
         assert result.exit_code == 0
         record = mock_hive.set.call_args[0][0]
         assert record.enabled is False
+        assert record.tags == ["keep-me"]
 
 


### PR DESCRIPTION
## Summary
- The hive API **replaces** `usr_mtd` wholesale (not merge), so the original enable/disable implementation would wipe tags, expiry, and comment
- Now does a read-modify-write: `get_metadata()` → set `enabled` → `set()` with full metadata preserved
- Fixed in both the `hive` group commands and all shortcut groups (`secret`, `lookup`, `fp`, etc.)

## Root cause
`legion_config_hive/hives/access.go:841`: `newRecord.UsrMtd = usrMtd` — full struct assignment, no field-level merge.

## Test plan
- [x] Updated tests verify that tags/expiry/comment from existing metadata are preserved through enable/disable
- [x] All 959 unit tests pass

Follows up on #231.

🤖 Generated with [Claude Code](https://claude.com/claude-code)