### PR TITLE
Fix help topic fallthrough, whoami output, and sync debug logging

### DIFF
--- a/limacharlie/client.py
+++ b/limacharlie/client.py
@@ -212,6 +212,11 @@ class Client:
         if expiry is not None:
             auth_data["expiry"] = int(expiry)
 
+        self._debug(
+            f"JWT request: oid={effective_oid}, uid={'set' if self._uid else 'not set'}, "
+            f"key={self._api_key[:8]}..."
+        )
+
         self._jwt = self._call_jwt_endpoint(auth_data)
 
         if self._on_refresh_auth is not None:

--- a/limacharlie/commands/auth.py
+++ b/limacharlie/commands/auth.py
@@ -258,9 +258,30 @@ register_explain("auth.whoami", _EXPLAIN_WHOAMI)
 @group.command()
 @pass_context
 def whoami(ctx: click.Context) -> None:
-    org = _get_org(ctx)
+    client = _get_client(ctx)
+    org = Organization(client)
     data = org.who_am_i()
-    _output(ctx, data)
+
+    # Prepend stored credential info like the old CLI did.
+    cred_info = {}
+    if client.oid:
+        cred_info["oid"] = client.oid
+    if client.uid:
+        cred_info["uid"] = client.uid
+
+    # Expand list fields (like perms) so they display in full
+    # instead of being truncated to "[N items]" in table mode.
+    for key in ("perms", "user_perms"):
+        val = data.get(key)
+        if isinstance(val, list):
+            data[key] = ", ".join(str(v) for v in val)
+        elif isinstance(val, dict):
+            # user_perms is {oid: [perms]} — expand each sub-list.
+            data[key] = {k: ", ".join(str(p) for p in v) if isinstance(v, list) else v
+                         for k, v in val.items()}
+
+    merged = {**cred_info, **data}
+    _output(ctx, merged)
 
 
 # ---------------------------------------------------------------------------

--- a/limacharlie/commands/help_cmd.py
+++ b/limacharlie/commands/help_cmd.py
@@ -21,12 +21,45 @@ from ..discovery import format_discovery, register_explain
 # Group
 # ---------------------------------------------------------------------------
 
-@click.group("help", invoke_without_command=True)
+class _HelpGroup(click.Group):
+    """Help group that falls through to topic lookup for unknown subcommands.
+
+    This allows ``limacharlie help auth`` to work as a shortcut for
+    ``limacharlie help topic auth``.
+    """
+
+    def get_command(self, ctx: click.Context, cmd_name: str) -> click.Command | None:
+        # Try real subcommands first (topic, discover, cheatsheet).
+        rv = super().get_command(ctx, cmd_name)
+        if rv is not None:
+            return rv
+
+        # Fall through: treat the name as a help topic.
+        content = get_help_topic(cmd_name)
+        if content is not None:
+            @click.command(cmd_name, hidden=True)
+            def _show_topic() -> None:
+                click.echo(content)
+            return _show_topic
+
+        return None
+
+    def resolve_command(self, ctx: click.Context, args: list[str]) -> tuple:
+        # Override so Click doesn't reject unknown names before get_command runs.
+        cmd_name = click.utils.make_str(args[0]) if args else None
+        if cmd_name and super().get_command(ctx, cmd_name) is None:
+            cmd = self.get_command(ctx, cmd_name)
+            if cmd is not None:
+                return cmd_name, cmd, args[1:]
+        return super().resolve_command(ctx, args)
+
+
+@click.group("help", cls=_HelpGroup, invoke_without_command=True)
 @click.pass_context
 def group(ctx) -> None:
     """Inline help topics, command discovery, and cheatsheets.
 
-    Use 'limacharlie help topic <name>' for concept guides.
+    Use 'limacharlie help <name>' for a concept guide (e.g. auth, hive, lcql).
     Use 'limacharlie help discover' to explore commands by use-case.
     Use 'limacharlie help cheatsheet' for quick-reference examples.
     """

--- a/limacharlie/commands/sync.py
+++ b/limacharlie/commands/sync.py
@@ -36,7 +36,15 @@ def _output(ctx: click.Context, data: Any) -> None:
 
 
 def _get_org(ctx: click.Context) -> Organization:
-    client = Client(oid=ctx.obj.oid, environment=ctx.obj.environment)
+    debug_fn = None
+    if ctx.obj.debug:
+        import sys
+        debug_fn = lambda msg: print(msg, file=sys.stderr)
+    client = Client(
+        oid=ctx.obj.oid,
+        environment=ctx.obj.environment,
+        print_debug_fn=debug_fn,
+    )
     return Organization(client)
 
 

--- a/tests/unit/test_cli_commands.py
+++ b/tests/unit/test_cli_commands.py
@@ -76,23 +76,60 @@ class TestCLIGlobalOptions:
             output_mod._filter_expr = original
 
 
+class TestHelpTopicFallthrough:
+    def test_help_topic_shortcut(self):
+        """limacharlie help auth should work like limacharlie help topic auth."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["help", "auth"])
+        assert result.exit_code == 0
+        assert "Authentication" in result.output
+
+    def test_help_topic_explicit(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["help", "topic", "auth"])
+        assert result.exit_code == 0
+        assert "Authentication" in result.output
+
+    def test_help_unknown_topic(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["help", "nonexistent_xyz"])
+        assert result.exit_code != 0
+
+    def test_help_subcommands_still_work(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["help", "discover"])
+        assert result.exit_code == 0
+
+
 class TestAuthCommands:
     @patch("limacharlie.commands.auth.Client")
     @patch("limacharlie.commands.auth.Organization")
     def test_whoami(self, mock_org_cls, mock_client_cls):
+        mock_client = MagicMock()
+        mock_client.oid = "test-oid"
+        mock_client.uid = "test-uid"
+        mock_client_cls.return_value = mock_client
+
         mock_org = MagicMock()
-        mock_org.who_am_i.return_value = {"ident": "user@test.com"}
+        mock_org.who_am_i.return_value = {"ident": "user@test.com", "perms": ["a", "b"]}
         mock_org_cls.return_value = mock_org
 
         runner = CliRunner()
         result = runner.invoke(cli, ["auth", "whoami"])
         assert result.exit_code == 0
         assert "user@test.com" in result.output
+        assert "test-oid" in result.output
+        assert "test-uid" in result.output
         mock_org.who_am_i.assert_called_once()
 
     @patch("limacharlie.commands.auth.Client")
     @patch("limacharlie.commands.auth.Organization")
     def test_whoami_quiet(self, mock_org_cls, mock_client_cls):
+        mock_client = MagicMock()
+        mock_client.oid = "test-oid"
+        mock_client.uid = None
+        mock_client_cls.return_value = mock_client
+
         mock_org = MagicMock()
         mock_org.who_am_i.return_value = {"ident": "user@test.com"}
         mock_org_cls.return_value = mock_org
@@ -105,8 +142,13 @@ class TestAuthCommands:
     @patch("limacharlie.commands.auth.Client")
     @patch("limacharlie.commands.auth.Organization")
     def test_whoami_json(self, mock_org_cls, mock_client_cls):
+        mock_client = MagicMock()
+        mock_client.oid = "test-oid"
+        mock_client.uid = "test-uid"
+        mock_client_cls.return_value = mock_client
+
         mock_org = MagicMock()
-        mock_org.who_am_i.return_value = {"ident": "user@test.com"}
+        mock_org.who_am_i.return_value = {"ident": "user@test.com", "perms": ["p1", "p2"]}
         mock_org_cls.return_value = mock_org
 
         runner = CliRunner()
@@ -114,6 +156,28 @@ class TestAuthCommands:
         assert result.exit_code == 0
         parsed = json.loads(result.output)
         assert parsed["ident"] == "user@test.com"
+        assert parsed["oid"] == "test-oid"
+        assert parsed["uid"] == "test-uid"
+
+    @patch("limacharlie.commands.auth.Client")
+    @patch("limacharlie.commands.auth.Organization")
+    def test_whoami_expands_perms(self, mock_org_cls, mock_client_cls):
+        mock_client = MagicMock()
+        mock_client.oid = "test-oid"
+        mock_client.uid = None
+        mock_client_cls.return_value = mock_client
+
+        mock_org = MagicMock()
+        perms = [f"perm{i}" for i in range(100)]
+        mock_org.who_am_i.return_value = {"ident": "user@test.com", "perms": perms}
+        mock_org_cls.return_value = mock_org
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["auth", "whoami"])
+        assert result.exit_code == 0
+        # Perms should be expanded, not shown as "[100 items]"
+        assert "[100 items]" not in result.output
+        assert "perm0" in result.output
 
     @patch("limacharlie.commands.auth.Client")
     def test_auth_test_success(self, mock_client_cls):


### PR DESCRIPTION
## Summary

Addresses feedback from Ben Webb on the new CLI:

- **`limacharlie help auth` now works** — The `help` group falls through to topic lookup for unknown subcommand names, so `limacharlie help auth` works as a shortcut for `limacharlie help topic auth`.
- **`auth whoami` output improved** — Now shows stored credential info (OID, UID) at the top of the output like the old CLI did. Expands the `perms` list in full instead of truncating to `[83 items]` in table mode.
- **Debug logging for sync/auth** — `sync pull/push` now passes `--debug` through to the Client. `client.refresh_jwt` logs the credential summary (oid, uid presence, key prefix) when debug is enabled, to help diagnose the cross-org UNAUTHORIZED issue Ben reported.

Note: The `sync pull --oid OTHER_ORG` UNAUTHORIZED issue could not be reproduced from code analysis alone — the credential resolution and JWT generation paths are functionally identical to the old CLI. The debug logging added here should help Ben diagnose it with `limacharlie --debug sync pull ...`.

## Test plan

- [x] All 964 unit tests pass
- [x] `limacharlie help auth` shows the auth topic
- [x] `limacharlie help topic auth` still works
- [x] `limacharlie help nonexistent` still errors
- [x] `limacharlie help discover` still works
- [ ] Manual test: `limacharlie auth whoami` shows OID, UID, full perms
- [ ] Manual test: `limacharlie --debug sync pull ...` shows JWT request details

🤖 Generated with [Claude Code](https://claude.com/claude-code)