### PR TITLE
Fix org list to auto-paginate and return all results

### DIFF
--- a/limacharlie/sdk/organization.py
+++ b/limacharlie/sdk/organization.py
@@ -242,6 +242,11 @@ class Organization:
     def list_accessible_orgs(self, offset: int | None = None, limit: int | None = None, filter_text: str | None = None) -> dict[str, Any]:
         """List organizations accessible to the current user.
 
+        When neither *offset* nor *limit* is provided the method
+        auto-paginates and returns **all** accessible organizations.
+        When either is set explicitly a single page is returned so
+        callers can paginate manually.
+
         Args:
             offset: Pagination offset.
             limit: Maximum number of results.
@@ -250,7 +255,9 @@ class Organization:
         Returns:
             dict: Organization list with 'orgs' and 'names' keys.
         """
-        qp = {}
+        auto_paginate = offset is None and limit is None
+
+        qp: dict[str, str] = {}
         if offset is not None:
             qp["offset"] = str(offset)
         if limit is not None:
@@ -262,14 +269,39 @@ class Organization:
         original_jwt = self._client._jwt
         try:
             self._client.refresh_jwt(oid_override="-")
-            resp = self._client.request("GET", "user/orgs", query_params=qp or None)
+
+            all_oids: list[str] = []
+            all_names: dict[str, str] = {}
+
+            if not auto_paginate:
+                resp = self._client.request("GET", "user/orgs", query_params=qp or None)
+                for org in resp.get("orgs", []):
+                    oid = org.get("oid")
+                    if oid:
+                        all_oids.append(oid)
+                        all_names[oid] = org.get("name", "")
+            else:
+                # Fetch pages until we have all results.
+                page_size = 50
+                current_offset = 0
+                while True:
+                    qp["offset"] = str(current_offset)
+                    qp["limit"] = str(page_size)
+                    resp = self._client.request("GET", "user/orgs", query_params=qp)
+                    orgs_page = resp.get("orgs", [])
+                    for org in orgs_page:
+                        oid = org.get("oid")
+                        if oid:
+                            all_oids.append(oid)
+                            all_names[oid] = org.get("name", "")
+                    total = resp.get("total")
+                    current_offset += len(orgs_page)
+                    if not orgs_page or (total is not None and current_offset >= total):
+                        break
         finally:
             self._client._jwt = original_jwt
 
-        orgs_list = resp.get("orgs", [])
-        oids = [org.get("oid") for org in orgs_list if org.get("oid")]
-        names = {org.get("oid"): org.get("name") for org in orgs_list if org.get("oid")}
-        return {"orgs": oids, "names": names}
+        return {"orgs": all_oids, "names": all_names}
 
     @staticmethod
     def create_org(client: Client, name: str, location: str | None = None, template: str | None = None) -> dict[str, Any]:

--- a/tests/unit/test_sdk_organization.py
+++ b/tests/unit/test_sdk_organization.py
@@ -304,20 +304,44 @@ class TestTestAuth:
 
 
 class TestListAccessibleOrgs:
-    def test_list_accessible_orgs_basic(self, org, mock_client):
+    def test_list_accessible_orgs_auto_paginates(self, org, mock_client):
+        """Without offset/limit the SDK should fetch all pages."""
+        mock_client.request.side_effect = [
+            {
+                "orgs": [
+                    {"oid": "oid-1", "name": "Org One"},
+                    {"oid": "oid-2", "name": "Org Two"},
+                ],
+                "total": 3,
+            },
+            {
+                "orgs": [
+                    {"oid": "oid-3", "name": "Org Three"},
+                ],
+                "total": 3,
+            },
+        ]
+        result = org.list_accessible_orgs()
+        mock_client.refresh_jwt.assert_called_once_with(oid_override="-")
+        assert mock_client.request.call_count == 2
+        assert result["orgs"] == ["oid-1", "oid-2", "oid-3"]
+        assert result["names"]["oid-1"] == "Org One"
+        assert result["names"]["oid-3"] == "Org Three"
+
+    def test_list_accessible_orgs_single_page(self, org, mock_client):
+        """When all results fit in one page, only one request is made."""
         mock_client.request.return_value = {
             "orgs": [
                 {"oid": "oid-1", "name": "Org One"},
-                {"oid": "oid-2", "name": "Org Two"},
-            ]
+            ],
+            "total": 1,
         }
         result = org.list_accessible_orgs()
-        mock_client.refresh_jwt.assert_called_once_with(oid_override="-")
-        mock_client.request.assert_called_once_with("GET", "user/orgs", query_params=None)
-        assert result["orgs"] == ["oid-1", "oid-2"]
-        assert result["names"]["oid-1"] == "Org One"
+        assert mock_client.request.call_count == 1
+        assert result["orgs"] == ["oid-1"]
 
-    def test_list_accessible_orgs_with_pagination(self, org, mock_client):
+    def test_list_accessible_orgs_with_explicit_pagination(self, org, mock_client):
+        """With explicit offset/limit a single page is returned."""
         mock_client.request.return_value = {"orgs": []}
         org.list_accessible_orgs(offset=10, limit=5, filter_text="test")
         mock_client.request.assert_called_once_with(
@@ -328,7 +352,7 @@ class TestListAccessibleOrgs:
     def test_list_accessible_orgs_restores_jwt(self, org, mock_client):
         original_jwt = "original-jwt-token"
         mock_client._jwt = original_jwt
-        mock_client.request.return_value = {"orgs": []}
+        mock_client.request.return_value = {"orgs": [], "total": 0}
         org.list_accessible_orgs()
         assert mock_client._jwt == original_jwt
 


### PR DESCRIPTION
## Summary
- `list_accessible_orgs` was only returning the first page (default limit=10) from the `user/orgs` API since commit d3c1384 switched from the old `/user_key_info` endpoint to paginated `user/orgs`
- Now auto-paginates through all pages when neither `offset` nor `limit` is explicitly provided
- Explicit `offset`/`limit` still does a single-page fetch for manual pagination
- Fixes both `limacharlie org list` and `limacharlie auth list-orgs` commands

## Test plan
- [x] Unit tests updated and passing (965 passed)
- [ ] Manual test with an account that has >10 orgs to verify all are returned

🤖 Generated with [Claude Code](https://claude.com/claude-code)