### PR TITLE
Support full detection object in ticket create and detection add

### DIFF
--- a/limacharlie/commands/ticket.py
+++ b/limacharlie/commands/ticket.py
@@ -221,16 +221,20 @@ Example:
 """
 
 _EXPLAIN_TELEMETRY_ADD = """\
-Link a LimaCharlie telemetry event to a ticket by its atom and
-sensor ID.
+Link a LimaCharlie telemetry event to a ticket.
 
-Required: --atom and --sid.  Optional: --event-type, --event-summary,
---verdict, --relevance.
+Pass either (--atom + --sid) for a bare reference, or --event with a
+full LC event JSON object for automatic field extraction (routing.this
+→ atom, routing.sid → sid, routing.event_type → event_type).
+
+Optional: --event-type, --event-summary, --verdict, --relevance.
 
 Examples:
   limacharlie ticket telemetry add --ticket 42 \\
       --atom <ATOM_UUID> --sid <SENSOR_ID> \\
       --event-type NEW_PROCESS --verdict suspicious
+  limacharlie ticket telemetry add --ticket 42 \\
+      --event '<full LC event JSON>'
 """
 
 _EXPLAIN_TELEMETRY_UPDATE = """\
@@ -1116,24 +1120,41 @@ def telemetry_list(ctx, ticket) -> None:
 
 @telemetry_group.command("add")
 @click.option("--ticket", required=True, type=int, help="Ticket number.")
-@click.option("--atom", required=True, help="LC event atom (UUID).")
-@click.option("--sid", required=True, help="LC sensor ID (UUID).")
+@click.option("--atom", default=None, help="LC event atom (UUID).")
+@click.option("--sid", default=None, help="LC sensor ID (UUID).")
+@click.option("--event", "event_json", default=None, help="Full LC event JSON object.")
 @click.option("--event-type", default=None, help="Event type (e.g., NEW_PROCESS).")
 @click.option("--event-summary", default=None, help="Human-readable event summary.")
 @click.option("--verdict", default=None, type=_VERDICT_CHOICES, help="Verdict assessment.")
 @click.option("--relevance", default=None, help="Relevance notes (max 1024 chars).")
 @pass_context
-def telemetry_add(ctx, ticket, atom, sid, event_type, event_summary,
-                  verdict, relevance) -> None:
+def telemetry_add(ctx, ticket, atom, sid, event_json, event_type,
+                  event_summary, verdict, relevance) -> None:
     """Link a telemetry event to a ticket.
 
     Examples:
         limacharlie ticket telemetry add --ticket 42 \\
             --atom <ATOM> --sid <SID> --event-type NEW_PROCESS
+        limacharlie ticket telemetry add --ticket 42 \\
+            --event '<full LC event JSON>'
     """
+    if atom is None and sid is None and event_json is None:
+        raise click.UsageError(
+            "At least one of (--atom + --sid) or --event is required."
+        )
+    event = None
+    if event_json is not None:
+        try:
+            event = json.loads(event_json)
+        except json.JSONDecodeError as exc:
+            raise click.BadParameter(
+                f"invalid JSON for --event: {exc}",
+                param_hint="--event",
+            )
     t = _get_ticketing(ctx)
     data = t.add_telemetry(
         ticket, atom, sid,
+        event=event,
         event_type=event_type, event_summary=event_summary,
         verdict=verdict, relevance=relevance,
     )

--- a/limacharlie/commands/ticket.py
+++ b/limacharlie/commands/ticket.py
@@ -288,11 +288,18 @@ Example:
 """
 
 _EXPLAIN_DETECTION_ADD = """\
-Link an additional detection to a ticket.
+Link an additional detection to a ticket.  Pass either --detection-id
+for a bare reference or --detection with a full detection JSON object
+for automatic field extraction (detect_id, cat, routing.sid,
+routing.hostname extracted by the backend).
+
+At least one of --detection-id or --detection is required.
 
 Examples:
   limacharlie ticket detection add --ticket 42 \\
       --detection-id <DETECTION_ID>
+  limacharlie ticket detection add --ticket 42 \\
+      --detection '<full detection JSON>'
   limacharlie ticket detection add --ticket 42 \\
       --detection-id <DETECTION_ID> \\
       --detection-cat "lateral_movement" --hostname "ws-01"
@@ -403,17 +410,22 @@ Examples:
 """
 
 _EXPLAIN_CREATE = """\
-Create a new SOC ticket from a detection.  This calls the ext-ticketing
-extension to create a ticket and returns the new ticket ID.
+Create a new SOC ticket.  Pass either --detection-id for a bare reference
+or --detection with a full detection JSON object for automatic field
+extraction (detect_id, cat, routing.sid, routing.hostname extracted
+by the backend).
 
-A detection_id is required.  Additional metadata (category, severity,
-sensor, hostname) can be provided to enrich the ticket.
+At least one of --detection-id or --detection is required.  Additional
+metadata (category, severity, sensor, hostname) can be provided to
+enrich the ticket and will take precedence over values in the detection
+object.
 
 If --severity is omitted the extension defaults to 'medium'.  Valid
 severities: critical, high, medium, low.
 
 Examples:
   limacharlie ticket create --detection-id <DETECTION_ID>
+  limacharlie ticket create --detection '<full detection JSON>'
   limacharlie ticket create --detection-id <DETECTION_ID> \\
       --detection-cat "lateral_movement" --severity high \\
       --sensor-id <SID> --hostname ws-01
@@ -555,7 +567,8 @@ def group() -> None:
 # ---------------------------------------------------------------------------
 
 @group.command()
-@click.option("--detection-id", required=True, help="Detection ID to create the ticket for.")
+@click.option("--detection-id", default=None, help="Detection ID to create the ticket for.")
+@click.option("--detection", "detection_json", default=None, help="Full detection JSON object.")
 @click.option("--detection-cat", default=None, help="Detection category / rule name.")
 @click.option("--severity", default=None, type=_SEVERITY_CHOICES, help="Ticket severity (default: medium).")
 @click.option("--detection-source", default=None, help="Detection source (e.g. dr-general).")
@@ -563,18 +576,33 @@ def group() -> None:
 @click.option("--sensor-id", default=None, help="Sensor ID.")
 @click.option("--hostname", default=None, help="Hostname.")
 @pass_context
-def create(ctx, detection_id, detection_cat, severity, detection_source,
-           detection_priority, sensor_id, hostname) -> None:
+def create(ctx, detection_id, detection_json, detection_cat, severity,
+           detection_source, detection_priority, sensor_id, hostname) -> None:
     """Create a new ticket from a detection.
 
     Examples:
         limacharlie ticket create --detection-id <DET_ID>
+        limacharlie ticket create --detection '<full detection JSON>'
         limacharlie ticket create --detection-id <DET_ID> \\
             --severity high --hostname ws-01
     """
+    if detection_id is None and detection_json is None:
+        raise click.UsageError(
+            "At least one of --detection-id or --detection is required."
+        )
+    detection = None
+    if detection_json is not None:
+        try:
+            detection = json.loads(detection_json)
+        except json.JSONDecodeError as exc:
+            raise click.BadParameter(
+                f"invalid JSON for --detection: {exc}",
+                param_hint="--detection",
+            )
     t = _get_ticketing(ctx)
     data = t.create_ticket(
         detection_id,
+        detection=detection,
         detection_cat=detection_cat,
         severity=severity,
         detection_source=detection_source,
@@ -1253,26 +1281,44 @@ def detection_list(ctx, ticket) -> None:
 
 @detection_group.command("add")
 @click.option("--ticket", required=True, type=int, help="Ticket number.")
-@click.option("--detection-id", required=True, help="Detection ID to link.")
+@click.option("--detection-id", default=None, help="Detection ID to link.")
+@click.option("--detection", "detection_json", default=None, help="Full detection JSON object.")
 @click.option("--detection-cat", default=None, help="Detection category/rule name.")
 @click.option("--detection-source", default=None, help="Detection source (e.g., dr-general).")
 @click.option("--detection-priority", default=None, type=int, help="Priority (0-10).")
 @click.option("--sensor-id", default=None, help="Sensor ID.")
 @click.option("--hostname", default=None, help="Hostname.")
 @pass_context
-def detection_add(ctx, ticket, detection_id, detection_cat, detection_source,
-                  detection_priority, sensor_id, hostname) -> None:
+def detection_add(ctx, ticket, detection_id, detection_json, detection_cat,
+                  detection_source, detection_priority, sensor_id,
+                  hostname) -> None:
     """Link a detection to a ticket.
 
     Examples:
         limacharlie ticket detection add --ticket 42 \\
             --detection-id <DET_ID>
         limacharlie ticket detection add --ticket 42 \\
+            --detection '<full detection JSON>'
+        limacharlie ticket detection add --ticket 42 \\
             --detection-id <DET_ID> --detection-cat lateral_movement
     """
+    if detection_id is None and detection_json is None:
+        raise click.UsageError(
+            "At least one of --detection-id or --detection is required."
+        )
+    detection = None
+    if detection_json is not None:
+        try:
+            detection = json.loads(detection_json)
+        except json.JSONDecodeError as exc:
+            raise click.BadParameter(
+                f"invalid JSON for --detection: {exc}",
+                param_hint="--detection",
+            )
     t = _get_ticketing(ctx)
     data = t.add_detection(
         ticket, detection_id,
+        detection=detection,
         detection_cat=detection_cat,
         detection_source=detection_source,
         detection_priority=detection_priority,

--- a/limacharlie/commands/ticket.py
+++ b/limacharlie/commands/ticket.py
@@ -402,11 +402,14 @@ Examples:
 """
 
 _EXPLAIN_CREATE = """\
-Create a new SOC ticket from a full LimaCharlie detection object.
+Create a new SOC ticket, optionally from a detection.
 
-The --detection flag takes the full detection JSON as produced by
+With --detection: pass the full detection JSON as produced by
 LimaCharlie D&R rules.  The backend automatically extracts detect_id,
 cat, source, routing.sid, routing.hostname, and detect_mtd.level.
+
+Without --detection: creates an empty investigation ticket that can
+be populated later with detections, telemetry, entities, etc.
 
 If --severity is omitted, severity is derived from detect_mtd.level
 in the detection object (or defaults to 'medium').  Valid severities:
@@ -416,6 +419,8 @@ Examples:
   limacharlie ticket create --detection '<full detection JSON>'
   limacharlie ticket create --detection '<full detection JSON>' \\
       --severity high
+  limacharlie ticket create --severity medium
+  limacharlie ticket create
 """
 
 register_explain("ticket.create", _EXPLAIN_CREATE)
@@ -552,26 +557,30 @@ def group() -> None:
 # ---------------------------------------------------------------------------
 
 @group.command()
-@click.option("--detection", "detection_json", required=True,
-              help="Full detection JSON object.")
+@click.option("--detection", "detection_json", default=None,
+              help="Full detection JSON object (optional).")
 @click.option("--severity", default=None, type=_SEVERITY_CHOICES,
               help="Ticket severity override (default: derived from detection).")
 @pass_context
 def create(ctx, detection_json, severity) -> None:
-    """Create a new ticket from a detection.
+    """Create a new ticket, optionally from a detection.
 
     Examples:
         limacharlie ticket create --detection '<full detection JSON>'
         limacharlie ticket create --detection '<full detection JSON>' \\
             --severity high
+        limacharlie ticket create --severity medium
+        limacharlie ticket create
     """
-    try:
-        detection = json.loads(detection_json)
-    except json.JSONDecodeError as exc:
-        raise click.BadParameter(
-            f"invalid JSON for --detection: {exc}",
-            param_hint="--detection",
-        )
+    detection = None
+    if detection_json is not None:
+        try:
+            detection = json.loads(detection_json)
+        except json.JSONDecodeError as exc:
+            raise click.BadParameter(
+                f"invalid JSON for --detection: {exc}",
+                param_hint="--detection",
+            )
     t = _get_ticketing(ctx)
     data = t.create_ticket(detection, severity=severity)
     _output(ctx, data)

--- a/limacharlie/commands/ticket.py
+++ b/limacharlie/commands/ticket.py
@@ -221,20 +221,15 @@ Example:
 """
 
 _EXPLAIN_TELEMETRY_ADD = """\
-Link a LimaCharlie telemetry event to a ticket.
+Link a LimaCharlie telemetry event to a ticket.  Pass the full event
+JSON object via --event.  The backend automatically extracts
+routing.this (atom), routing.sid, and routing.event_type.
 
-Pass either (--atom + --sid) for a bare reference, or --event with a
-full LC event JSON object for automatic field extraction (routing.this
-→ atom, routing.sid → sid, routing.event_type → event_type).
+Optional: --event-summary, --verdict, --relevance.
 
-Optional: --event-type, --event-summary, --verdict, --relevance.
-
-Examples:
+Example:
   limacharlie ticket telemetry add --ticket 42 \\
-      --atom <ATOM_UUID> --sid <SENSOR_ID> \\
-      --event-type NEW_PROCESS --verdict suspicious
-  limacharlie ticket telemetry add --ticket 42 \\
-      --event '<full LC event JSON>'
+      --event '<full LC event JSON>' --verdict suspicious
 """
 
 _EXPLAIN_TELEMETRY_UPDATE = """\
@@ -292,21 +287,14 @@ Example:
 """
 
 _EXPLAIN_DETECTION_ADD = """\
-Link an additional detection to a ticket.  Pass either --detection-id
-for a bare reference or --detection with a full detection JSON object
-for automatic field extraction (detect_id, cat, routing.sid,
-routing.hostname extracted by the backend).
+Link an additional detection to a ticket.  Pass the full detection
+JSON object via --detection.  The backend automatically extracts
+detect_id, cat, source, routing.sid, routing.hostname, and
+detect_mtd.level.
 
-At least one of --detection-id or --detection is required.
-
-Examples:
-  limacharlie ticket detection add --ticket 42 \\
-      --detection-id <DETECTION_ID>
+Example:
   limacharlie ticket detection add --ticket 42 \\
       --detection '<full detection JSON>'
-  limacharlie ticket detection add --ticket 42 \\
-      --detection-id <DETECTION_ID> \\
-      --detection-cat "lateral_movement" --hostname "ws-01"
 """
 
 _EXPLAIN_DETECTION_REMOVE = """\
@@ -414,27 +402,20 @@ Examples:
 """
 
 _EXPLAIN_CREATE = """\
-Create a new SOC ticket.  Pass either --detection-id for a bare reference
-or --detection with a full detection JSON object for automatic field
-extraction (detect_id, cat, routing.sid, routing.hostname extracted
-by the backend).
+Create a new SOC ticket from a full LimaCharlie detection object.
 
-At least one of --detection-id or --detection is required.  Additional
-metadata (category, severity, sensor, hostname) can be provided to
-enrich the ticket and will take precedence over values in the detection
-object.
+The --detection flag takes the full detection JSON as produced by
+LimaCharlie D&R rules.  The backend automatically extracts detect_id,
+cat, source, routing.sid, routing.hostname, and detect_mtd.level.
 
-If --severity is omitted the extension defaults to 'medium'.  Valid
-severities: critical, high, medium, low.
+If --severity is omitted, severity is derived from detect_mtd.level
+in the detection object (or defaults to 'medium').  Valid severities:
+critical, high, medium, low.
 
 Examples:
-  limacharlie ticket create --detection-id <DETECTION_ID>
   limacharlie ticket create --detection '<full detection JSON>'
-  limacharlie ticket create --detection-id <DETECTION_ID> \\
-      --detection-cat "lateral_movement" --severity high \\
-      --sensor-id <SID> --hostname ws-01
-  limacharlie ticket create --detection-id <DETECTION_ID> \\
-      --detection-source dr-general --detection-priority 7
+  limacharlie ticket create --detection '<full detection JSON>' \\
+      --severity high
 """
 
 register_explain("ticket.create", _EXPLAIN_CREATE)
@@ -571,49 +552,28 @@ def group() -> None:
 # ---------------------------------------------------------------------------
 
 @group.command()
-@click.option("--detection-id", default=None, help="Detection ID to create the ticket for.")
-@click.option("--detection", "detection_json", default=None, help="Full detection JSON object.")
-@click.option("--detection-cat", default=None, help="Detection category / rule name.")
-@click.option("--severity", default=None, type=_SEVERITY_CHOICES, help="Ticket severity (default: medium).")
-@click.option("--detection-source", default=None, help="Detection source (e.g. dr-general).")
-@click.option("--detection-priority", default=None, type=int, help="Detection priority (0-10).")
-@click.option("--sensor-id", default=None, help="Sensor ID.")
-@click.option("--hostname", default=None, help="Hostname.")
+@click.option("--detection", "detection_json", required=True,
+              help="Full detection JSON object.")
+@click.option("--severity", default=None, type=_SEVERITY_CHOICES,
+              help="Ticket severity override (default: derived from detection).")
 @pass_context
-def create(ctx, detection_id, detection_json, detection_cat, severity,
-           detection_source, detection_priority, sensor_id, hostname) -> None:
+def create(ctx, detection_json, severity) -> None:
     """Create a new ticket from a detection.
 
     Examples:
-        limacharlie ticket create --detection-id <DET_ID>
         limacharlie ticket create --detection '<full detection JSON>'
-        limacharlie ticket create --detection-id <DET_ID> \\
-            --severity high --hostname ws-01
+        limacharlie ticket create --detection '<full detection JSON>' \\
+            --severity high
     """
-    if detection_id is None and detection_json is None:
-        raise click.UsageError(
-            "At least one of --detection-id or --detection is required."
+    try:
+        detection = json.loads(detection_json)
+    except json.JSONDecodeError as exc:
+        raise click.BadParameter(
+            f"invalid JSON for --detection: {exc}",
+            param_hint="--detection",
         )
-    detection = None
-    if detection_json is not None:
-        try:
-            detection = json.loads(detection_json)
-        except json.JSONDecodeError as exc:
-            raise click.BadParameter(
-                f"invalid JSON for --detection: {exc}",
-                param_hint="--detection",
-            )
     t = _get_ticketing(ctx)
-    data = t.create_ticket(
-        detection_id,
-        detection=detection,
-        detection_cat=detection_cat,
-        severity=severity,
-        detection_source=detection_source,
-        detection_priority=detection_priority,
-        sensor_id=sensor_id,
-        hostname=hostname,
-    )
+    data = t.create_ticket(detection, severity=severity)
     _output(ctx, data)
 
 
@@ -1120,42 +1080,31 @@ def telemetry_list(ctx, ticket) -> None:
 
 @telemetry_group.command("add")
 @click.option("--ticket", required=True, type=int, help="Ticket number.")
-@click.option("--atom", default=None, help="LC event atom (UUID).")
-@click.option("--sid", default=None, help="LC sensor ID (UUID).")
-@click.option("--event", "event_json", default=None, help="Full LC event JSON object.")
-@click.option("--event-type", default=None, help="Event type (e.g., NEW_PROCESS).")
+@click.option("--event", "event_json", required=True,
+              help="Full LC event JSON object.")
 @click.option("--event-summary", default=None, help="Human-readable event summary.")
 @click.option("--verdict", default=None, type=_VERDICT_CHOICES, help="Verdict assessment.")
 @click.option("--relevance", default=None, help="Relevance notes (max 1024 chars).")
 @pass_context
-def telemetry_add(ctx, ticket, atom, sid, event_json, event_type,
-                  event_summary, verdict, relevance) -> None:
+def telemetry_add(ctx, ticket, event_json, event_summary, verdict,
+                  relevance) -> None:
     """Link a telemetry event to a ticket.
 
-    Examples:
+    Example:
         limacharlie ticket telemetry add --ticket 42 \\
-            --atom <ATOM> --sid <SID> --event-type NEW_PROCESS
-        limacharlie ticket telemetry add --ticket 42 \\
-            --event '<full LC event JSON>'
+            --event '<full LC event JSON>' --verdict suspicious
     """
-    if atom is None and sid is None and event_json is None:
-        raise click.UsageError(
-            "At least one of (--atom + --sid) or --event is required."
+    try:
+        event = json.loads(event_json)
+    except json.JSONDecodeError as exc:
+        raise click.BadParameter(
+            f"invalid JSON for --event: {exc}",
+            param_hint="--event",
         )
-    event = None
-    if event_json is not None:
-        try:
-            event = json.loads(event_json)
-        except json.JSONDecodeError as exc:
-            raise click.BadParameter(
-                f"invalid JSON for --event: {exc}",
-                param_hint="--event",
-            )
     t = _get_ticketing(ctx)
     data = t.add_telemetry(
-        ticket, atom, sid,
-        event=event,
-        event_type=event_type, event_summary=event_summary,
+        ticket, event,
+        event_summary=event_summary,
         verdict=verdict, relevance=relevance,
     )
     _output(ctx, data)
@@ -1302,50 +1251,25 @@ def detection_list(ctx, ticket) -> None:
 
 @detection_group.command("add")
 @click.option("--ticket", required=True, type=int, help="Ticket number.")
-@click.option("--detection-id", default=None, help="Detection ID to link.")
-@click.option("--detection", "detection_json", default=None, help="Full detection JSON object.")
-@click.option("--detection-cat", default=None, help="Detection category/rule name.")
-@click.option("--detection-source", default=None, help="Detection source (e.g., dr-general).")
-@click.option("--detection-priority", default=None, type=int, help="Priority (0-10).")
-@click.option("--sensor-id", default=None, help="Sensor ID.")
-@click.option("--hostname", default=None, help="Hostname.")
+@click.option("--detection", "detection_json", required=True,
+              help="Full detection JSON object.")
 @pass_context
-def detection_add(ctx, ticket, detection_id, detection_json, detection_cat,
-                  detection_source, detection_priority, sensor_id,
-                  hostname) -> None:
+def detection_add(ctx, ticket, detection_json) -> None:
     """Link a detection to a ticket.
 
-    Examples:
-        limacharlie ticket detection add --ticket 42 \\
-            --detection-id <DET_ID>
+    Example:
         limacharlie ticket detection add --ticket 42 \\
             --detection '<full detection JSON>'
-        limacharlie ticket detection add --ticket 42 \\
-            --detection-id <DET_ID> --detection-cat lateral_movement
     """
-    if detection_id is None and detection_json is None:
-        raise click.UsageError(
-            "At least one of --detection-id or --detection is required."
+    try:
+        detection = json.loads(detection_json)
+    except json.JSONDecodeError as exc:
+        raise click.BadParameter(
+            f"invalid JSON for --detection: {exc}",
+            param_hint="--detection",
         )
-    detection = None
-    if detection_json is not None:
-        try:
-            detection = json.loads(detection_json)
-        except json.JSONDecodeError as exc:
-            raise click.BadParameter(
-                f"invalid JSON for --detection: {exc}",
-                param_hint="--detection",
-            )
     t = _get_ticketing(ctx)
-    data = t.add_detection(
-        ticket, detection_id,
-        detection=detection,
-        detection_cat=detection_cat,
-        detection_source=detection_source,
-        detection_priority=detection_priority,
-        sensor_id=sensor_id,
-        hostname=hostname,
-    )
+    data = t.add_detection(ticket, detection)
     _output(ctx, data)
 
 

--- a/limacharlie/sdk/ticketing.py
+++ b/limacharlie/sdk/ticketing.py
@@ -369,12 +369,31 @@ class Ticketing:
     def add_telemetry(
         self,
         ticket_number: int,
-        atom: str,
-        sid: str,
+        atom: str | None = None,
+        sid: str | None = None,
+        *,
+        event: dict | None = None,
         **fields: Any,
     ) -> dict[str, Any]:
-        """Link a telemetry event reference to a ticket."""
-        body: dict[str, Any] = {"atom": atom, "sid": sid}
+        """Link a telemetry event reference to a ticket.
+
+        Callers may pass a full LC event object via *event* for
+        automatic field extraction (routing.this → atom, routing.sid
+        → sid, routing.event_type → event_type), or provide
+        individual fields.  At least one of (*atom* + *sid*) or
+        *event* is required.
+        """
+        if atom is None and sid is None and event is None:
+            raise ValueError(
+                "At least one of (atom + sid) or event must be provided"
+            )
+        body: dict[str, Any] = {}
+        if atom is not None:
+            body["atom"] = atom
+        if sid is not None:
+            body["sid"] = sid
+        if event is not None:
+            body["event"] = event
         body.update({k: v for k, v in fields.items() if v is not None})
         return self._request(
             "POST",

--- a/limacharlie/sdk/ticketing.py
+++ b/limacharlie/sdk/ticketing.py
@@ -40,7 +40,7 @@ class Ticketing:
 
     def create_ticket(
         self,
-        detection: dict,
+        detection: dict | None = None,
         *,
         severity: str | None = None,
     ) -> dict[str, Any]:
@@ -51,13 +51,16 @@ class Ticketing:
         REST API.
 
         Args:
-            detection: Full LC detection dict.  The backend extracts
-                detect_id, cat, source, routing.sid, routing.hostname,
-                and detect_mtd.level automatically.
+            detection: Optional full LC detection dict.  The backend
+                extracts detect_id, cat, source, routing.sid,
+                routing.hostname, and detect_mtd.level automatically.
+                Omit to create an empty investigation ticket.
             severity: Optional ticket severity override
                 (critical, high, medium, low).
         """
-        data: dict[str, Any] = {"detection": detection}
+        data: dict[str, Any] = {}
+        if detection is not None:
+            data["detection"] = detection
         if severity is not None:
             data["severity"] = severity
         ext = Extensions(self._org)

--- a/limacharlie/sdk/ticketing.py
+++ b/limacharlie/sdk/ticketing.py
@@ -60,7 +60,9 @@ class Ticketing:
         """
         data: dict[str, Any] = {}
         if detection is not None:
-            data["detection"] = detection
+            # The extension schema declares detection as type "json",
+            # which the platform validates as a JSON string (not a dict).
+            data["detection"] = json.dumps(detection)
         if severity is not None:
             data["severity"] = severity
         ext = Extensions(self._org)

--- a/limacharlie/sdk/ticketing.py
+++ b/limacharlie/sdk/ticketing.py
@@ -40,15 +40,9 @@ class Ticketing:
 
     def create_ticket(
         self,
-        detection_id: str | None = None,
+        detection: dict,
         *,
-        detection: dict | None = None,
-        detection_cat: str | None = None,
         severity: str | None = None,
-        detection_source: str | None = None,
-        detection_priority: int | None = None,
-        sensor_id: str | None = None,
-        hostname: str | None = None,
     ) -> dict[str, Any]:
         """Create a new ticket via the ext-ticketing extension.
 
@@ -56,44 +50,16 @@ class Ticketing:
         mechanism (``create_ticket`` action) rather than the ticketing
         REST API.
 
-        Callers may pass a full detection object via *detection* for
-        automatic field extraction by the backend, or provide individual
-        fields.  At least one of *detection_id* or *detection* is
-        required.
-
         Args:
-            detection_id: Detection ID to create the ticket for.
             detection: Full LC detection dict.  The backend extracts
-                detect_id, cat, routing.sid, routing.hostname
-                automatically.
-            detection_cat: Detection category / rule name.
-            severity: Ticket severity (critical, high, medium, low).
-            detection_source: Detection source (e.g. dr-general).
-            detection_priority: Detection priority (0-10).
-            sensor_id: Sensor ID from the triggering event.
-            hostname: Hostname from the triggering event.
+                detect_id, cat, source, routing.sid, routing.hostname,
+                and detect_mtd.level automatically.
+            severity: Optional ticket severity override
+                (critical, high, medium, low).
         """
-        if detection_id is None and detection is None:
-            raise ValueError(
-                "At least one of detection_id or detection must be provided"
-            )
-        data: dict[str, Any] = {}
-        if detection_id is not None:
-            data["detection_id"] = detection_id
-        if detection is not None:
-            data["detection"] = detection
-        if detection_cat is not None:
-            data["detection_cat"] = detection_cat
+        data: dict[str, Any] = {"detection": detection}
         if severity is not None:
             data["severity"] = severity
-        if detection_source is not None:
-            data["detection_source"] = detection_source
-        if detection_priority is not None:
-            data["detection_priority"] = detection_priority
-        if sensor_id is not None:
-            data["sensor_id"] = sensor_id
-        if hostname is not None:
-            data["hostname"] = hostname
         ext = Extensions(self._org)
         return ext.request(self._EXTENSION_NAME, "create_ticket", data=data)
 
@@ -240,32 +206,21 @@ class Ticketing:
     def add_detection(
         self,
         ticket_number: int,
-        detection_id: str | None = None,
-        *,
-        detection: dict | None = None,
-        **fields: Any,
+        detection: dict,
     ) -> dict[str, Any]:
         """Link a detection to a ticket.
 
-        At least one of *detection_id* or *detection* must be provided.
-        When a full *detection* dict is supplied the backend extracts
-        the relevant fields automatically.
+        Args:
+            ticket_number: Ticket number.
+            detection: Full LC detection dict.  The backend extracts
+                detect_id, cat, source, routing, and detect_mtd
+                automatically.
         """
-        if detection_id is None and detection is None:
-            raise ValueError(
-                "At least one of detection_id or detection must be provided"
-            )
-        body: dict[str, Any] = {}
-        if detection_id is not None:
-            body["detection_id"] = detection_id
-        if detection is not None:
-            body["detection"] = detection
-        body.update({k: v for k, v in fields.items() if v is not None})
         return self._request(
             "POST",
             f"tickets/{ticket_number}/detections",
             query_params={"oid": self.oid},
-            body=body,
+            body={"detection": detection},
         )
 
     def remove_detection(
@@ -369,32 +324,30 @@ class Ticketing:
     def add_telemetry(
         self,
         ticket_number: int,
-        atom: str | None = None,
-        sid: str | None = None,
+        event: dict,
         *,
-        event: dict | None = None,
-        **fields: Any,
+        event_summary: str | None = None,
+        verdict: str | None = None,
+        relevance: str | None = None,
     ) -> dict[str, Any]:
         """Link a telemetry event reference to a ticket.
 
-        Callers may pass a full LC event object via *event* for
-        automatic field extraction (routing.this → atom, routing.sid
-        → sid, routing.event_type → event_type), or provide
-        individual fields.  At least one of (*atom* + *sid*) or
-        *event* is required.
+        Args:
+            ticket_number: Ticket number.
+            event: Full LC event dict.  The backend extracts
+                routing.this (atom), routing.sid, and
+                routing.event_type automatically.
+            event_summary: Human-readable event summary.
+            verdict: Verdict assessment.
+            relevance: Relevance notes.
         """
-        if atom is None and sid is None and event is None:
-            raise ValueError(
-                "At least one of (atom + sid) or event must be provided"
-            )
-        body: dict[str, Any] = {}
-        if atom is not None:
-            body["atom"] = atom
-        if sid is not None:
-            body["sid"] = sid
-        if event is not None:
-            body["event"] = event
-        body.update({k: v for k, v in fields.items() if v is not None})
+        body: dict[str, Any] = {"event": event}
+        if event_summary is not None:
+            body["event_summary"] = event_summary
+        if verdict is not None:
+            body["verdict"] = verdict
+        if relevance is not None:
+            body["relevance"] = relevance
         return self._request(
             "POST",
             f"tickets/{ticket_number}/telemetry",

--- a/limacharlie/sdk/ticketing.py
+++ b/limacharlie/sdk/ticketing.py
@@ -40,8 +40,9 @@ class Ticketing:
 
     def create_ticket(
         self,
-        detection_id: str,
+        detection_id: str | None = None,
         *,
+        detection: dict | None = None,
         detection_cat: str | None = None,
         severity: str | None = None,
         detection_source: str | None = None,
@@ -55,8 +56,16 @@ class Ticketing:
         mechanism (``create_ticket`` action) rather than the ticketing
         REST API.
 
+        Callers may pass a full detection object via *detection* for
+        automatic field extraction by the backend, or provide individual
+        fields.  At least one of *detection_id* or *detection* is
+        required.
+
         Args:
-            detection_id: Detection ID to create the ticket for (required).
+            detection_id: Detection ID to create the ticket for.
+            detection: Full LC detection dict.  The backend extracts
+                detect_id, cat, routing.sid, routing.hostname
+                automatically.
             detection_cat: Detection category / rule name.
             severity: Ticket severity (critical, high, medium, low).
             detection_source: Detection source (e.g. dr-general).
@@ -64,7 +73,15 @@ class Ticketing:
             sensor_id: Sensor ID from the triggering event.
             hostname: Hostname from the triggering event.
         """
-        data: dict[str, Any] = {"detection_id": detection_id}
+        if detection_id is None and detection is None:
+            raise ValueError(
+                "At least one of detection_id or detection must be provided"
+            )
+        data: dict[str, Any] = {}
+        if detection_id is not None:
+            data["detection_id"] = detection_id
+        if detection is not None:
+            data["detection"] = detection
         if detection_cat is not None:
             data["detection_cat"] = detection_cat
         if severity is not None:
@@ -223,11 +240,26 @@ class Ticketing:
     def add_detection(
         self,
         ticket_number: int,
-        detection_id: str,
+        detection_id: str | None = None,
+        *,
+        detection: dict | None = None,
         **fields: Any,
     ) -> dict[str, Any]:
-        """Link a detection to a ticket."""
-        body: dict[str, Any] = {"detection_id": detection_id}
+        """Link a detection to a ticket.
+
+        At least one of *detection_id* or *detection* must be provided.
+        When a full *detection* dict is supplied the backend extracts
+        the relevant fields automatically.
+        """
+        if detection_id is None and detection is None:
+            raise ValueError(
+                "At least one of detection_id or detection must be provided"
+            )
+        body: dict[str, Any] = {}
+        if detection_id is not None:
+            body["detection_id"] = detection_id
+        if detection is not None:
+            body["detection"] = detection
         body.update({k: v for k, v in fields.items() if v is not None})
         return self._request(
             "POST",

--- a/tests/unit/test_cli_ticket.py
+++ b/tests/unit/test_cli_ticket.py
@@ -103,54 +103,45 @@ class TestTicketHelp:
 
 
 class TestTicketCreate:
-    def test_create_minimal(self):
+    _SAMPLE_DETECTION = json.dumps({
+        "detect_id": "det-abc",
+        "cat": "lateral_movement",
+        "source": "dr-general",
+        "routing": {"sid": "sid-123", "hostname": "ws-01"},
+        "detect_mtd": {"level": "high"},
+    })
+
+    def test_create_with_detection(self):
         p1, p2, p3 = _patch_ticketing()
         with p1, p2, p3 as mock_t_cls:
             result, mock_t = _invoke(
-                ["ticket", "create", "--detection-id", "det-abc"],
+                ["ticket", "create", "--detection", self._SAMPLE_DETECTION],
                 mock_t_cls,
                 return_value={"created": 1, "ticket_id": "tid-new"},
             )
             assert result.exit_code == 0
             mock_t.create_ticket.assert_called_once_with(
-                "det-abc",
-                detection=None,
-                detection_cat=None,
+                json.loads(self._SAMPLE_DETECTION),
                 severity=None,
-                detection_source=None,
-                detection_priority=None,
-                sensor_id=None,
-                hostname=None,
             )
 
-    def test_create_all_fields(self):
+    def test_create_with_severity_override(self):
         p1, p2, p3 = _patch_ticketing()
         with p1, p2, p3 as mock_t_cls:
             result, mock_t = _invoke(
                 ["ticket", "create",
-                 "--detection-id", "det-abc",
-                 "--detection-cat", "lateral_movement",
-                 "--severity", "high",
-                 "--detection-source", "dr-general",
-                 "--detection-priority", "7",
-                 "--sensor-id", "sid-123",
-                 "--hostname", "ws-01"],
+                 "--detection", self._SAMPLE_DETECTION,
+                 "--severity", "critical"],
                 mock_t_cls,
                 return_value={"created": 1, "ticket_id": "tid-new"},
             )
             assert result.exit_code == 0
             mock_t.create_ticket.assert_called_once_with(
-                "det-abc",
-                detection=None,
-                detection_cat="lateral_movement",
-                severity="high",
-                detection_source="dr-general",
-                detection_priority=7,
-                sensor_id="sid-123",
-                hostname="ws-01",
+                json.loads(self._SAMPLE_DETECTION),
+                severity="critical",
             )
 
-    def test_create_requires_detection_id(self):
+    def test_create_requires_detection(self):
         runner = CliRunner()
         result = runner.invoke(cli, ["ticket", "create"])
         assert result.exit_code != 0
@@ -158,7 +149,16 @@ class TestTicketCreate:
     def test_create_invalid_severity_rejected(self):
         runner = CliRunner()
         result = runner.invoke(cli, [
-            "ticket", "create", "--detection-id", "det-1", "--severity", "extreme",
+            "ticket", "create",
+            "--detection", self._SAMPLE_DETECTION,
+            "--severity", "extreme",
+        ])
+        assert result.exit_code != 0
+
+    def test_create_invalid_json_rejected(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, [
+            "ticket", "create", "--detection", "not-json",
         ])
         assert result.exit_code != 0
 
@@ -814,6 +814,14 @@ class TestTicketEntity:
 
 
 class TestTicketTelemetry:
+    _SAMPLE_EVENT = json.dumps({
+        "routing": {
+            "this": "atom-1",
+            "sid": "sid-1",
+            "event_type": "NEW_PROCESS",
+        },
+    })
+
     def test_telemetry_list(self):
         p1, p2, p3 = _patch_ticketing()
         with p1, p2, p3 as mock_t_cls:
@@ -830,17 +838,50 @@ class TestTicketTelemetry:
         with p1, p2, p3 as mock_t_cls:
             result, mock_t = _invoke(
                 ["ticket", "telemetry", "add", "--ticket", "42",
-                 "--atom", "atom-1", "--sid", "sid-1",
-                 "--event-type", "NEW_PROCESS", "--verdict", "suspicious"],
+                 "--event", self._SAMPLE_EVENT,
+                 "--verdict", "suspicious"],
                 mock_t_cls,
                 return_value={},
             )
             assert result.exit_code == 0
             mock_t.add_telemetry.assert_called_once_with(
-                42, "atom-1", "sid-1",
-                event=None,
-                event_type="NEW_PROCESS", event_summary=None,
+                42, json.loads(self._SAMPLE_EVENT),
+                event_summary=None,
                 verdict="suspicious", relevance=None,
+            )
+
+    def test_telemetry_add_requires_event(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, [
+            "ticket", "telemetry", "add", "--ticket", "42",
+        ])
+        assert result.exit_code != 0
+
+    def test_telemetry_add_invalid_json_rejected(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, [
+            "ticket", "telemetry", "add", "--ticket", "42",
+            "--event", "not-json",
+        ])
+        assert result.exit_code != 0
+
+    def test_telemetry_add_with_all_optional_fields(self):
+        p1, p2, p3 = _patch_ticketing()
+        with p1, p2, p3 as mock_t_cls:
+            result, mock_t = _invoke(
+                ["ticket", "telemetry", "add", "--ticket", "42",
+                 "--event", self._SAMPLE_EVENT,
+                 "--event-summary", "Process spawned",
+                 "--verdict", "malicious",
+                 "--relevance", "Key evidence"],
+                mock_t_cls,
+                return_value={},
+            )
+            assert result.exit_code == 0
+            mock_t.add_telemetry.assert_called_once_with(
+                42, json.loads(self._SAMPLE_EVENT),
+                event_summary="Process spawned",
+                verdict="malicious", relevance="Key evidence",
             )
 
     def test_telemetry_update(self):
@@ -927,6 +968,14 @@ class TestTicketArtifact:
 
 
 class TestTicketDetection:
+    _SAMPLE_DETECTION = json.dumps({
+        "detect_id": "det-1",
+        "cat": "lateral_movement",
+        "source": "dr-general",
+        "routing": {"sid": "sid-1", "hostname": "ws-01"},
+        "detect_mtd": {"level": "high"},
+    })
+
     def test_detection_list(self):
         p1, p2, p3 = _patch_ticketing()
         with p1, p2, p3 as mock_t_cls:
@@ -943,20 +992,29 @@ class TestTicketDetection:
         with p1, p2, p3 as mock_t_cls:
             result, mock_t = _invoke(
                 ["ticket", "detection", "add", "--ticket", "42",
-                 "--detection-id", "det-1", "--detection-cat", "lateral_movement"],
+                 "--detection", self._SAMPLE_DETECTION],
                 mock_t_cls,
                 return_value={},
             )
             assert result.exit_code == 0
             mock_t.add_detection.assert_called_once_with(
-                42, "det-1",
-                detection=None,
-                detection_cat="lateral_movement",
-                detection_source=None,
-                detection_priority=None,
-                sensor_id=None,
-                hostname=None,
+                42, json.loads(self._SAMPLE_DETECTION),
             )
+
+    def test_detection_add_requires_detection(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, [
+            "ticket", "detection", "add", "--ticket", "42",
+        ])
+        assert result.exit_code != 0
+
+    def test_detection_add_invalid_json_rejected(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, [
+            "ticket", "detection", "add", "--ticket", "42",
+            "--detection", "not-json",
+        ])
+        assert result.exit_code != 0
 
     def test_detection_remove(self):
         p1, p2, p3 = _patch_ticketing()

--- a/tests/unit/test_cli_ticket.py
+++ b/tests/unit/test_cli_ticket.py
@@ -114,6 +114,7 @@ class TestTicketCreate:
             assert result.exit_code == 0
             mock_t.create_ticket.assert_called_once_with(
                 "det-abc",
+                detection=None,
                 detection_cat=None,
                 severity=None,
                 detection_source=None,
@@ -140,6 +141,7 @@ class TestTicketCreate:
             assert result.exit_code == 0
             mock_t.create_ticket.assert_called_once_with(
                 "det-abc",
+                detection=None,
                 detection_cat="lateral_movement",
                 severity="high",
                 detection_source="dr-general",
@@ -947,6 +949,7 @@ class TestTicketDetection:
             assert result.exit_code == 0
             mock_t.add_detection.assert_called_once_with(
                 42, "det-1",
+                detection=None,
                 detection_cat="lateral_movement",
                 detection_source=None,
                 detection_priority=None,

--- a/tests/unit/test_cli_ticket.py
+++ b/tests/unit/test_cli_ticket.py
@@ -141,10 +141,33 @@ class TestTicketCreate:
                 severity="critical",
             )
 
-    def test_create_requires_detection(self):
-        runner = CliRunner()
-        result = runner.invoke(cli, ["ticket", "create"])
-        assert result.exit_code != 0
+    def test_create_without_detection(self):
+        p1, p2, p3 = _patch_ticketing()
+        with p1, p2, p3 as mock_t_cls:
+            result, mock_t = _invoke(
+                ["ticket", "create"],
+                mock_t_cls,
+                return_value={"created": 1, "ticket_id": "tid-new"},
+            )
+            assert result.exit_code == 0
+            mock_t.create_ticket.assert_called_once_with(
+                None,
+                severity=None,
+            )
+
+    def test_create_without_detection_with_severity(self):
+        p1, p2, p3 = _patch_ticketing()
+        with p1, p2, p3 as mock_t_cls:
+            result, mock_t = _invoke(
+                ["ticket", "create", "--severity", "medium"],
+                mock_t_cls,
+                return_value={"created": 1, "ticket_id": "tid-new"},
+            )
+            assert result.exit_code == 0
+            mock_t.create_ticket.assert_called_once_with(
+                None,
+                severity="medium",
+            )
 
     def test_create_invalid_severity_rejected(self):
         runner = CliRunner()

--- a/tests/unit/test_cli_ticket.py
+++ b/tests/unit/test_cli_ticket.py
@@ -838,6 +838,7 @@ class TestTicketTelemetry:
             assert result.exit_code == 0
             mock_t.add_telemetry.assert_called_once_with(
                 42, "atom-1", "sid-1",
+                event=None,
                 event_type="NEW_PROCESS", event_summary=None,
                 verdict="suspicious", relevance=None,
             )

--- a/tests/unit/test_sdk_ticketing.py
+++ b/tests/unit/test_sdk_ticketing.py
@@ -67,16 +67,24 @@ class TestTicketingInit:
 
 
 class TestCreateTicket:
+    _SAMPLE_DETECTION = {
+        "detect_id": "det-1",
+        "cat": "lateral_movement",
+        "source": "dr-general",
+        "routing": {"sid": "sid-1", "hostname": "ws-01"},
+        "detect_mtd": {"level": "high"},
+    }
+
     def test_calls_extension_request(self, ticketing, mock_org):
         with patch("limacharlie.sdk.ticketing.Extensions") as MockExt:
             mock_ext = MagicMock()
             MockExt.return_value = mock_ext
             mock_ext.request.return_value = {"created": 1, "ticket_id": "tid-new"}
-            result = ticketing.create_ticket("det-1")
+            result = ticketing.create_ticket(self._SAMPLE_DETECTION)
             MockExt.assert_called_once_with(mock_org)
             mock_ext.request.assert_called_once_with(
                 "ext-ticketing", "create_ticket",
-                data={"detection_id": "det-1"},
+                data={"detection": json.dumps(self._SAMPLE_DETECTION)},
             )
             assert result["ticket_id"] == "tid-new"
 
@@ -85,24 +93,11 @@ class TestCreateTicket:
             mock_ext = MagicMock()
             MockExt.return_value = mock_ext
             mock_ext.request.return_value = {"created": 1}
-            ticketing.create_ticket(
-                "det-1",
-                detection_cat="lateral_movement",
-                severity="high",
-                detection_source="dr-general",
-                detection_priority=7,
-                sensor_id="sid-1",
-                hostname="ws-01",
-            )
+            ticketing.create_ticket(self._SAMPLE_DETECTION, severity="high")
             call_data = mock_ext.request.call_args[1]["data"]
             assert call_data == {
-                "detection_id": "det-1",
-                "detection_cat": "lateral_movement",
+                "detection": json.dumps(self._SAMPLE_DETECTION),
                 "severity": "high",
-                "detection_source": "dr-general",
-                "detection_priority": 7,
-                "sensor_id": "sid-1",
-                "hostname": "ws-01",
             }
 
     def test_none_optional_fields_excluded(self, ticketing, mock_org):
@@ -110,11 +105,27 @@ class TestCreateTicket:
             mock_ext = MagicMock()
             MockExt.return_value = mock_ext
             mock_ext.request.return_value = {"created": 1}
-            ticketing.create_ticket("det-1", severity=None, hostname=None)
+            ticketing.create_ticket(self._SAMPLE_DETECTION, severity=None)
             call_data = mock_ext.request.call_args[1]["data"]
-            assert call_data == {"detection_id": "det-1"}
             assert "severity" not in call_data
-            assert "hostname" not in call_data
+
+    def test_without_detection(self, ticketing, mock_org):
+        with patch("limacharlie.sdk.ticketing.Extensions") as MockExt:
+            mock_ext = MagicMock()
+            MockExt.return_value = mock_ext
+            mock_ext.request.return_value = {"created": 1}
+            ticketing.create_ticket()
+            call_data = mock_ext.request.call_args[1]["data"]
+            assert call_data == {}
+
+    def test_without_detection_with_severity(self, ticketing, mock_org):
+        with patch("limacharlie.sdk.ticketing.Extensions") as MockExt:
+            mock_ext = MagicMock()
+            MockExt.return_value = mock_ext
+            mock_ext.request.return_value = {"created": 1}
+            ticketing.create_ticket(severity="medium")
+            call_data = mock_ext.request.call_args[1]["data"]
+            assert call_data == {"severity": "medium"}
 
 
 # ---------------------------------------------------------------------------
@@ -283,25 +294,27 @@ class TestListDetections:
 
 
 class TestAddDetection:
+    _SAMPLE_DETECTION = {
+        "detect_id": "det-1",
+        "cat": "lateral_movement",
+        "source": "dr-general",
+        "routing": {"sid": "sid-1", "hostname": "ws-01"},
+    }
+
     def test_minimal(self, ticketing, mock_org):
         mock_org.client.request.return_value = {}
-        ticketing.add_detection(42, "det-1")
+        det = {"detect_id": "det-1"}
+        ticketing.add_detection(42, det)
         args, kwargs = _extract_call(mock_org)
         assert args == ("POST", "api/v1/tickets/42/detections")
         body = json.loads(kwargs["raw_body"])
-        assert body == {"detection_id": "det-1"}
+        assert body == {"detection": det}
 
-    def test_with_optional_fields(self, ticketing, mock_org):
+    def test_with_full_detection(self, ticketing, mock_org):
         mock_org.client.request.return_value = {}
-        ticketing.add_detection(
-            42, "det-1",
-            detection_cat="lateral_movement",
-            hostname="ws-01",
-        )
+        ticketing.add_detection(42, self._SAMPLE_DETECTION)
         body = _extract_body(mock_org)
-        assert body["detection_id"] == "det-1"
-        assert body["detection_cat"] == "lateral_movement"
-        assert body["hostname"] == "ws-01"
+        assert body == {"detection": self._SAMPLE_DETECTION}
 
 
 class TestRemoveDetection:
@@ -411,24 +424,30 @@ class TestListTelemetry:
 
 
 class TestAddTelemetry:
+    _SAMPLE_EVENT = {
+        "routing": {
+            "this": "atom-uuid",
+            "sid": "sid-uuid",
+            "event_type": "NEW_PROCESS",
+        },
+    }
+
     def test_required_fields(self, ticketing, mock_org):
         mock_org.client.request.return_value = {}
-        ticketing.add_telemetry(42, "atom-uuid", "sid-uuid")
+        ticketing.add_telemetry(42, self._SAMPLE_EVENT)
         body = _extract_body(mock_org)
-        assert body["atom"] == "atom-uuid"
-        assert body["sid"] == "sid-uuid"
+        assert body == {"event": self._SAMPLE_EVENT}
 
     def test_with_optional_fields(self, ticketing, mock_org):
         mock_org.client.request.return_value = {}
         ticketing.add_telemetry(
-            42, "atom-uuid", "sid-uuid",
-            event_type="NEW_PROCESS",
+            42, self._SAMPLE_EVENT,
             event_summary="Suspicious process",
             verdict="suspicious",
             relevance="Related to C2",
         )
         body = _extract_body(mock_org)
-        assert body["event_type"] == "NEW_PROCESS"
+        assert body["event"] == self._SAMPLE_EVENT
         assert body["event_summary"] == "Suspicious process"
         assert body["verdict"] == "suspicious"
         assert body["relevance"] == "Related to C2"


### PR DESCRIPTION
## Summary

Overhaul the ticket SDK and CLI to use **full detection/event objects only** — no bare IDs, no individual field parameters. This matches how the backend actually works (extracting fields from the full LC detection/event JSON) and simplifies the interface for AI agents and automation.

### Key changes

- **`ticket create`**: accepts optional `--detection` (full LC detection JSON) and `--severity`. Omit detection to create an empty investigation container ticket.
- **`ticket detection add`**: requires `--detection` (full detection JSON). Backend extracts `detect_id`, `cat`, `source`, `routing.sid`, `routing.hostname`, `detect_mtd.level`.
- **`ticket telemetry add`**: requires `--event` (full LC event JSON). Backend extracts `routing.this` (atom), `routing.sid`, `routing.event_type`.
- **SDK `create_ticket()`**: JSON-encodes the detection dict for extension schema `json` type validation.
- **SDK `add_detection()`**: takes `(ticket_number, detection_dict)` instead of individual fields.
- **SDK `add_telemetry()`**: takes `(ticket_number, event_dict)` instead of `(ticket_number, atom, sid)`.
- Removed all individual-field parameters (`--detection-id`, `--detection-cat`, `--sensor-id`, `--hostname`, `--atom`, `--sid`, etc.).

### Tests

- 97 CLI tests (`test_cli_ticket.py`) — all passing
- 58 SDK tests (`test_sdk_ticketing.py`) — all passing, updated for new signatures

## Depends on

Backend changes (already deployed):
- Schema migration to make `detection_id` nullable (allows detection-less tickets)
- `scanTicket` fix for NULL `detection_id` (`spanner.NullString`)
- Extension handler accepts detection as both JSON string and map
- `detect_mtd.level` flexible unmarshal (string or number)

## Verified end-to-end

All 29 CLI operations tested against a live org:

| Operation | Status |
|---|---|
| `ticket create` (no detection) | PASS |
| `ticket create --detection ... --severity` | PASS |
| `ticket get` (NULL detection_id) | PASS |
| `ticket get` (with detection) | PASS |
| `ticket update` (status, assignee, summary, classification, conclusion) | PASS |
| `ticket add-note` (plain + typed) | PASS |
| `ticket entity add` (IP, domain, with verdicts) | PASS |
| `ticket detection add` (to empty ticket) | PASS |
| `ticket detection add` (numeric level) | PASS |
| `ticket telemetry add` (with summary/verdict/relevance) | PASS |
| `ticket artifact add` | PASS |
| `ticket detection/entity/telemetry/artifact list` | PASS |
| `ticket export` (all components) | PASS |
| `ticket list` (with --limit, --status, --severity filters) | PASS |
| `ticket dashboard` | PASS |
| `ticket assignees` | PASS |
| `ticket config-get` | PASS |
| Full lifecycle: new → acknowledged → in_progress → resolved → closed | PASS |

🤖 Generated with [Claude Code](https://claude.com/claude-code)