### PR TITLE
fix: Don't send null data in metadata-only hive updates

### DIFF
--- a/limacharlie/sdk/hive.py
+++ b/limacharlie/sdk/hive.py
@@ -166,7 +166,9 @@ class Hive:
         if record.data is not None or record.arl is not None:
             target = "data"
 
-        req = {"data": json.dumps(record.data)}
+        req: dict[str, Any] = {}
+        if record.data is not None:
+            req["data"] = json.dumps(record.data)
 
         if record.etag is not None:
             req["etag"] = record.etag

--- a/tests/unit/test_sdk_hive.py
+++ b/tests/unit/test_sdk_hive.py
@@ -180,6 +180,8 @@ class TestHiveSet:
         hive.set(rec)
         call_args = mock_org.client.request.call_args
         assert "rule/mtd" in call_args[0][1]
+        params = call_args[1]["params"]
+        assert "data" not in params
 
     def test_set_with_arl(self, hive, mock_org):
         rec = HiveRecord("rule", data={"a": 1})


### PR DESCRIPTION
## Summary

- `Hive.set()` always included `data: json.dumps(record.data)` in request params, even for metadata-only updates (enable/disable)
- When `record.data` is `None` (from `get_metadata()`), this sent `data: "null"` to the server
- The secret hive validator rejected this with "secret value empty"
- Fix: only include `data` in the request when `record.data is not None`

## Related

- Both fixes together ensure `secret enable/disable` works correctly

## Test plan

- [x] `test_set_without_data_targets_mtd` now also verifies `data` is not in params
- [x] All 974 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)