### PR TITLE
Add --check-perm and --show-perms flags to auth whoami

### DIFF
--- a/limacharlie/commands/auth.py
+++ b/limacharlie/commands/auth.py
@@ -247,20 +247,46 @@ def logout(ctx: click.Context, environment: str | None) -> None:
 # ---------------------------------------------------------------------------
 
 _EXPLAIN_WHOAMI = """\
-Display the identity, permissions, and accessible organizations for the
-currently configured credentials.  This calls the /who API endpoint and
-shows the result.  Useful for verifying which API key or user account is
-active, what permissions it has, and which organizations it can access.
+Display the identity and accessible organizations for the currently
+configured credentials.  This calls the /who API endpoint and shows
+the result.  Useful for verifying which API key or user account is
+active and which organizations it can access.
+
+By default, permissions are omitted to keep the output compact (helpful
+for automated / LLM-driven workflows).  Use the flags below to control
+permission output:
+
+  --show-perms       Include the full list of permissions in the output.
+  --check-perm NAME  Check whether a specific permission is present.
+                     Returns {"has_perm": true/false, "perm": "NAME"}.
 """
 register_explain("auth.whoami", _EXPLAIN_WHOAMI)
 
 
 @group.command()
+@click.option("--show-perms", is_flag=True, default=False,
+              help="Include full permissions in the output.")
+@click.option("--check-perm", default=None,
+              help="Check for a specific permission and return a boolean result.")
 @pass_context
-def whoami(ctx: click.Context) -> None:
+def whoami(ctx: click.Context, show_perms: bool, check_perm: str | None) -> None:
     client = _get_client(ctx)
     org = Organization(client)
     data = org.who_am_i()
+
+    # --check-perm: return a minimal boolean result and exit early.
+    if check_perm is not None:
+        all_perms: list[str] = []
+        raw = data.get("perms", [])
+        if isinstance(raw, list):
+            all_perms.extend(raw)
+        raw_user = data.get("user_perms", {})
+        if isinstance(raw_user, dict):
+            for v in raw_user.values():
+                if isinstance(v, list):
+                    all_perms.extend(v)
+        _output(ctx, {"perm": check_perm, "has_perm": check_perm in all_perms})
+        return
 
     # Prepend stored credential info like the old CLI did.
     cred_info = {}
@@ -269,16 +295,21 @@ def whoami(ctx: click.Context) -> None:
     if client.uid:
         cred_info["uid"] = client.uid
 
-    # Expand list fields (like perms) so they display in full
-    # instead of being truncated to "[N items]" in table mode.
-    for key in ("perms", "user_perms"):
-        val = data.get(key)
-        if isinstance(val, list):
-            data[key] = ", ".join(str(v) for v in val)
-        elif isinstance(val, dict):
-            # user_perms is {oid: [perms]} — expand each sub-list.
-            data[key] = {k: ", ".join(str(p) for p in v) if isinstance(v, list) else v
-                         for k, v in val.items()}
+    if show_perms:
+        # Expand list fields so they display in full
+        # instead of being truncated to "[N items]" in table mode.
+        for key in ("perms", "user_perms"):
+            val = data.get(key)
+            if isinstance(val, list):
+                data[key] = ", ".join(str(v) for v in val)
+            elif isinstance(val, dict):
+                # user_perms is {oid: [perms]} — expand each sub-list.
+                data[key] = {k: ", ".join(str(p) for p in v) if isinstance(v, list) else v
+                             for k, v in val.items()}
+    else:
+        # Strip permission fields to keep output compact.
+        data.pop("perms", None)
+        data.pop("user_perms", None)
 
     merged = {**cred_info, **data}
     _output(ctx, merged)

--- a/tests/unit/test_cli_commands.py
+++ b/tests/unit/test_cli_commands.py
@@ -158,10 +158,31 @@ class TestAuthCommands:
         assert parsed["ident"] == "user@test.com"
         assert parsed["oid"] == "test-oid"
         assert parsed["uid"] == "test-uid"
+        # Perms hidden by default
+        assert "perms" not in parsed
 
     @patch("limacharlie.commands.auth.Client")
     @patch("limacharlie.commands.auth.Organization")
-    def test_whoami_expands_perms(self, mock_org_cls, mock_client_cls):
+    def test_whoami_hides_perms_by_default(self, mock_org_cls, mock_client_cls):
+        mock_client = MagicMock()
+        mock_client.oid = "test-oid"
+        mock_client.uid = None
+        mock_client_cls.return_value = mock_client
+
+        mock_org = MagicMock()
+        mock_org.who_am_i.return_value = {"ident": "user@test.com", "perms": ["a", "b"]}
+        mock_org_cls.return_value = mock_org
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--output", "json", "auth", "whoami"])
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert "perms" not in parsed
+        assert parsed["ident"] == "user@test.com"
+
+    @patch("limacharlie.commands.auth.Client")
+    @patch("limacharlie.commands.auth.Organization")
+    def test_whoami_show_perms(self, mock_org_cls, mock_client_cls):
         mock_client = MagicMock()
         mock_client.oid = "test-oid"
         mock_client.uid = None
@@ -173,11 +194,77 @@ class TestAuthCommands:
         mock_org_cls.return_value = mock_org
 
         runner = CliRunner()
-        result = runner.invoke(cli, ["auth", "whoami"])
+        result = runner.invoke(cli, ["auth", "whoami", "--show-perms"])
         assert result.exit_code == 0
         # Perms should be expanded, not shown as "[100 items]"
         assert "[100 items]" not in result.output
         assert "perm0" in result.output
+
+    @patch("limacharlie.commands.auth.Client")
+    @patch("limacharlie.commands.auth.Organization")
+    def test_whoami_check_perm_found(self, mock_org_cls, mock_client_cls):
+        mock_client = MagicMock()
+        mock_client.oid = "test-oid"
+        mock_client.uid = None
+        mock_client_cls.return_value = mock_client
+
+        mock_org = MagicMock()
+        mock_org.who_am_i.return_value = {
+            "ident": "user@test.com",
+            "perms": ["ai_agent.operate", "sensor.list"],
+        }
+        mock_org_cls.return_value = mock_org
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--output", "json", "auth", "whoami", "--check-perm", "ai_agent.operate"])
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert parsed["has_perm"] is True
+        assert parsed["perm"] == "ai_agent.operate"
+
+    @patch("limacharlie.commands.auth.Client")
+    @patch("limacharlie.commands.auth.Organization")
+    def test_whoami_check_perm_missing(self, mock_org_cls, mock_client_cls):
+        mock_client = MagicMock()
+        mock_client.oid = "test-oid"
+        mock_client.uid = None
+        mock_client_cls.return_value = mock_client
+
+        mock_org = MagicMock()
+        mock_org.who_am_i.return_value = {
+            "ident": "user@test.com",
+            "perms": ["sensor.list"],
+        }
+        mock_org_cls.return_value = mock_org
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--output", "json", "auth", "whoami", "--check-perm", "ai_agent.operate"])
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert parsed["has_perm"] is False
+        assert parsed["perm"] == "ai_agent.operate"
+
+    @patch("limacharlie.commands.auth.Client")
+    @patch("limacharlie.commands.auth.Organization")
+    def test_whoami_check_perm_in_user_perms(self, mock_org_cls, mock_client_cls):
+        mock_client = MagicMock()
+        mock_client.oid = "test-oid"
+        mock_client.uid = None
+        mock_client_cls.return_value = mock_client
+
+        mock_org = MagicMock()
+        mock_org.who_am_i.return_value = {
+            "ident": "user@test.com",
+            "perms": [],
+            "user_perms": {"some-oid": ["ai_agent.operate", "sensor.list"]},
+        }
+        mock_org_cls.return_value = mock_org
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--output", "json", "auth", "whoami", "--check-perm", "ai_agent.operate"])
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert parsed["has_perm"] is True
 
     @patch("limacharlie.commands.auth.Client")
     def test_auth_test_success(self, mock_client_cls):


### PR DESCRIPTION
## Summary

- **Permissions hidden by default** in `auth whoami` output to keep responses compact — saves hundreds of tokens per call in LLM-driven workflows.
- **`--show-perms`** flag opts in to the full permission listing (previous behavior).
- **`--check-perm NAME`** flag returns a minimal `{"perm": "...", "has_perm": true/false}` result, useful for quick authorization checks (e.g. `limacharlie auth whoami --check-perm ai_agent.operate`) without parsing the full permission set.

## Test plan

- [x] Existing whoami tests updated for new default (perms omitted)
- [x] New tests for `--show-perms` (full permission expansion)
- [x] New tests for `--check-perm` (found in `perms`, missing, found in `user_perms`)
- [x] All 980 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)