### PR TITLE
fix: auth whoami without OID falls back to dash

### DIFF
--- a/limacharlie/commands/auth.py
+++ b/limacharlie/commands/auth.py
@@ -271,6 +271,9 @@ register_explain("auth.whoami", _EXPLAIN_WHOAMI)
 @pass_context
 def whoami(ctx: click.Context, show_perms: bool, check_perm: str | None) -> None:
     client = _get_client(ctx)
+    # whoami works without a specific org — fall back to "-" if no OID resolved.
+    if client.oid is None:
+        client = _get_client(ctx, oid_override="-")
     org = Organization(client)
     data = org.who_am_i()
 


### PR DESCRIPTION
## Summary
- `limacharlie auth whoami` now works without a configured OID by falling back to `"-"` as the org identifier
- If an OID is available (from `--oid` flag, env var, or `~/.limacharlie` config), it is used normally

## Test plan
- [x] Run `limacharlie auth whoami` with no default OID configured — should succeed using `-`
- [x] Run `limacharlie auth whoami` with a default OID in `~/.limacharlie` — should use that OID
- [x] Run `limacharlie --oid <OID> auth whoami` — should use the explicit OID

🤖 Generated with [Claude Code](https://claude.com/claude-code)