### PR TITLE
fix: Follow pagination tokens in search SDK

### DIFF
--- a/limacharlie/sdk/search.py
+++ b/limacharlie/sdk/search.py
@@ -123,18 +123,28 @@ class Search:
                     alt_root=search_url,
                 )
 
+                # The nextToken for pagination lives inside each
+                # SearchResult, not at the top level of SearchResponse.
+                next_token: str | None = None
                 for item in poll.get("results", []):
+                    if item.get("nextToken"):
+                        next_token = item["nextToken"]
                     yield item
                     count += 1
                     if limit and count >= limit:
                         return
 
                 if poll.get("completed", False):
-                    break
-
-                token = poll.get("nextToken")
-                if not token:
-                    time.sleep(1)
+                    if next_token:
+                        # More pages available — use the token to
+                        # fetch the next page (may trigger a subquery).
+                        token = next_token
+                    else:
+                        break
+                else:
+                    # Page still processing, poll again after a delay.
+                    poll_ms = poll.get("nextPollInMs", 1000)
+                    time.sleep(max(poll_ms / 1000, 0.5))
         finally:
             # Cancel search to clean up
             try:

--- a/tests/unit/test_sdk_search.py
+++ b/tests/unit/test_sdk_search.py
@@ -76,13 +76,45 @@ class TestSearchExecute:
         results = list(search.execute("event", 1000, 2000))
         assert len(results) == 0
 
-    def test_execute_multi_page(self, search, mock_org):
+    @patch("limacharlie.sdk.search.time.sleep")
+    def test_execute_polls_until_completed(self, mock_sleep, search, mock_org):
+        """Query still processing (completed=False) triggers re-poll."""
         mock_org.client.request.side_effect = [
             {"queryId": "q-789"},
-            {"results": [{"a": 1}], "completed": False, "nextToken": "tok1"},
-            {"results": [{"a": 2}], "completed": True},
+            {"results": [], "completed": False, "nextPollInMs": 500},
+            {"results": [{"type": "events", "rows": [{"a": 1}]}], "completed": True},
+            {},  # DELETE cleanup
+        ]
+
+        results = list(search.execute("event", 1000, 2000))
+        assert len(results) == 1
+        mock_sleep.assert_called_once_with(0.5)
+
+    @patch("limacharlie.sdk.search.time.sleep")
+    def test_execute_pagination_follows_next_token(self, mock_sleep, search, mock_org):
+        """When a result has nextToken and completed=True, fetch next page."""
+        mock_org.client.request.side_effect = [
+            {"queryId": "q-pag"},
+            # Page 1: completed with nextToken inside the result
+            {"results": [{"type": "events", "rows": [{"a": 1}], "nextToken": "tok1"}], "completed": True},
+            # Page 2 subquery not ready yet
+            {"results": [], "completed": False, "nextPollInMs": 500},
+            # Page 2 ready, no more pages
+            {"results": [{"type": "events", "rows": [{"a": 2}]}], "completed": True},
             {},  # DELETE cleanup
         ]
 
         results = list(search.execute("event", 1000, 2000))
         assert len(results) == 2
+        assert results[0]["rows"] == [{"a": 1}]
+        assert results[1]["rows"] == [{"a": 2}]
+
+        # Verify the second GET used the pagination token
+        get_calls = [c for c in mock_org.client.request.call_args_list if c[0][0] == "GET"]
+        assert len(get_calls) == 3  # page1 poll, page2 poll (not ready), page2 poll (ready)
+        # First GET: no token
+        assert get_calls[0][1].get("query_params") is None
+        # Second GET: token from page 1
+        assert get_calls[1][1]["query_params"] == {"token": "tok1"}
+        # Third GET: same token (re-poll same page)
+        assert get_calls[2][1]["query_params"] == {"token": "tok1"}


### PR DESCRIPTION
## Summary
- The SDK was reading `nextToken` from the top-level `SearchResponse`, but the replay backend places it inside each `SearchResult` item (`results[i].nextToken`). This meant only the first page of results was ever returned — explaining customer reports of truncated search exports.
- Also use the backend's `nextPollInMs` hint for poll delays instead of a hardcoded 1 second.
- Verified live: a 3-hour filtered query now returns 12 pages / 3,823 events instead of 1 page / ~300.

## Test plan
- [x] Unit tests updated and passing (984 passed)
- [x] Tested live against default org with broad query (`* | * | *`, 1h) — 7 pages, 2,146 events
- [x] Tested live with filtered query (`WEL | _event_id == "4625"`, 3h) — 12 pages, 3,823 events

🤖 Generated with [Claude Code](https://claude.com/claude-code)