### PR TITLE
feat: Add AI session lifecycle management and usage tracking

### DIFF
--- a/limacharlie/commands/ai.py
+++ b/limacharlie/commands/ai.py
@@ -312,6 +312,25 @@ def start_session(ctx, definition, prompt, name, idempotent_key, data) -> None:
 # session subgroup – AI session lifecycle management
 # ===========================================================================
 
+_PROMPT_TRUNCATE_LEN = 120
+
+
+def _truncate_prompt(text: str, max_len: int = _PROMPT_TRUNCATE_LEN) -> str:
+    """Truncate a prompt string for display."""
+    if not text or len(text) <= max_len:
+        return text
+    return text[:max_len] + "..."
+
+
+def _clean_session_for_list(session: dict) -> dict:
+    """Strip heavy fields from a session dict for list display."""
+    s = dict(session)
+    # Replace the full prompt with a short preview.
+    if "initial_prompt" in s:
+        s["initial_prompt"] = _truncate_prompt(s["initial_prompt"])
+    return s
+
+
 @click.group("session")
 def session_group() -> None:
     """Manage AI sessions (list, inspect, terminate)."""
@@ -331,6 +350,9 @@ Statuses: running, starting, ended.
 
 Pagination is supported via --limit and --cursor.
 
+The initial_prompt field is truncated in the listing.  Use
+'ai session get --id <ID>' to see the full prompt.
+
 Example:
   limacharlie ai session list
   limacharlie ai session list --status running
@@ -348,6 +370,9 @@ def session_list(ctx, status, limit, cursor) -> None:
     org = _get_org(ctx)
     sdk = AISDK(org)
     data = sdk.list_sessions(status=status, limit=limit, cursor=cursor)
+    # Truncate prompts in the listing to keep output readable.
+    if "sessions" in data:
+        data["sessions"] = [_clean_session_for_list(s) for s in data["sessions"]]
     _output(ctx, data)
 
 
@@ -359,19 +384,28 @@ _EXPLAIN_SESSION_GET = """\
 Get details of a specific AI session including status, model,
 token usage, cost, trigger info, and end reason.
 
+By default the initial_prompt is truncated.  Use --full-prompt
+to include the entire prompt text.
+
 Example:
   limacharlie ai session get --id <SESSION_ID>
+  limacharlie ai session get --id <SESSION_ID> --full-prompt
 """
 register_explain("ai.session.get", _EXPLAIN_SESSION_GET)
 
 
 @session_group.command("get")
 @click.option("--id", "session_id", required=True, help="Session ID.")
+@click.option("--full-prompt", is_flag=True, default=False, help="Include the full initial_prompt text.")
 @pass_context
-def session_get(ctx, session_id) -> None:
+def session_get(ctx, session_id, full_prompt) -> None:
     org = _get_org(ctx)
     sdk = AISDK(org)
     data = sdk.get_session(session_id)
+    if not full_prompt and "session" in data:
+        s = data["session"]
+        if isinstance(s, dict) and "initial_prompt" in s:
+            s["initial_prompt"] = _truncate_prompt(s["initial_prompt"])
     _output(ctx, data)
 
 
@@ -406,23 +440,59 @@ def session_terminate(ctx, session_id) -> None:
 # ---------------------------------------------------------------------------
 
 _EXPLAIN_SESSION_HISTORY = """\
-Get the conversation history of an AI session.  Returns the full
+Get the conversation history of an AI session.  Returns the
 message log including user prompts, assistant responses, tool
 calls and results.
 
+By default, internal system messages (init, config, diagnostics)
+are filtered out.  Use --raw to include everything.
+
 Example:
   limacharlie ai session history --id <SESSION_ID>
+  limacharlie ai session history --id <SESSION_ID> --raw
 """
 register_explain("ai.session.history", _EXPLAIN_SESSION_HISTORY)
+
+# System subtypes that are internal plumbing, not useful conversation.
+_SYSTEM_INIT_SUBTYPES = frozenset({
+    "credential_diagnostics",
+    "init_received",
+    "claude_md_loaded",
+    "mcp_config_debug",
+    "mcp_servers_set",
+    "model_set",
+    "max_turns_set",
+    "max_budget_set",
+    "oid_added_to_system_prompt",
+    "permission_mode_set",
+    "tools_configured",
+    "system_prompt_set",
+    "sdk_session_id",
+})
+
+
+def _filter_history(messages: list[dict]) -> list[dict]:
+    """Remove internal system init messages from history."""
+    filtered = []
+    for m in messages:
+        if m.get("type") == "system":
+            payload = m.get("payload", {})
+            if isinstance(payload, dict) and payload.get("subtype") in _SYSTEM_INIT_SUBTYPES:
+                continue
+        filtered.append(m)
+    return filtered
 
 
 @session_group.command("history")
 @click.option("--id", "session_id", required=True, help="Session ID.")
+@click.option("--raw", is_flag=True, default=False, help="Include all messages including internal system init.")
 @pass_context
-def session_history(ctx, session_id) -> None:
+def session_history(ctx, session_id, raw) -> None:
     org = _get_org(ctx)
     sdk = AISDK(org)
     data = sdk.get_session_history(session_id)
+    if not raw and "messages" in data:
+        data["messages"] = _filter_history(data["messages"])
     _output(ctx, data)
 
 

--- a/limacharlie/commands/ai.py
+++ b/limacharlie/commands/ai.py
@@ -306,3 +306,180 @@ def start_session(ctx, definition, prompt, name, idempotent_key, data) -> None:
     result = sdk.start_session(definition, prompt=prompt, name=name,
                                idempotent_key=idempotent_key, data=parsed_data)
     _output(ctx, result)
+
+
+# ===========================================================================
+# session subgroup – AI session lifecycle management
+# ===========================================================================
+
+@click.group("session")
+def session_group() -> None:
+    """Manage AI sessions (list, inspect, terminate)."""
+
+group.add_command(session_group)
+
+
+# ---------------------------------------------------------------------------
+# session list
+# ---------------------------------------------------------------------------
+
+_EXPLAIN_SESSION_LIST = """\
+List AI sessions for the organization.  By default all sessions are
+returned; use --status to filter by state.
+
+Statuses: running, starting, ended.
+
+Pagination is supported via --limit and --cursor.
+
+Example:
+  limacharlie ai session list
+  limacharlie ai session list --status running
+  limacharlie ai session list --limit 10
+"""
+register_explain("ai.session.list", _EXPLAIN_SESSION_LIST)
+
+
+@session_group.command("list")
+@click.option("--status", default=None, help="Filter by session status (running, starting, ended).")
+@click.option("--limit", default=None, type=int, help="Max results per page (1-200, default 50).")
+@click.option("--cursor", default=None, help="Pagination cursor from a previous response.")
+@pass_context
+def session_list(ctx, status, limit, cursor) -> None:
+    org = _get_org(ctx)
+    sdk = AISDK(org)
+    data = sdk.list_sessions(status=status, limit=limit, cursor=cursor)
+    _output(ctx, data)
+
+
+# ---------------------------------------------------------------------------
+# session get
+# ---------------------------------------------------------------------------
+
+_EXPLAIN_SESSION_GET = """\
+Get details of a specific AI session including status, model,
+token usage, cost, trigger info, and end reason.
+
+Example:
+  limacharlie ai session get --id <SESSION_ID>
+"""
+register_explain("ai.session.get", _EXPLAIN_SESSION_GET)
+
+
+@session_group.command("get")
+@click.option("--id", "session_id", required=True, help="Session ID.")
+@pass_context
+def session_get(ctx, session_id) -> None:
+    org = _get_org(ctx)
+    sdk = AISDK(org)
+    data = sdk.get_session(session_id)
+    _output(ctx, data)
+
+
+# ---------------------------------------------------------------------------
+# session terminate
+# ---------------------------------------------------------------------------
+
+_EXPLAIN_SESSION_TERMINATE = """\
+Terminate a running AI session.  The session will be stopped and
+its status set to ended.
+
+Requires the ai_agent.set permission on the organization.
+
+Example:
+  limacharlie ai session terminate --id <SESSION_ID>
+"""
+register_explain("ai.session.terminate", _EXPLAIN_SESSION_TERMINATE)
+
+
+@session_group.command("terminate")
+@click.option("--id", "session_id", required=True, help="Session ID to terminate.")
+@pass_context
+def session_terminate(ctx, session_id) -> None:
+    org = _get_org(ctx)
+    sdk = AISDK(org)
+    data = sdk.terminate_session(session_id)
+    _output(ctx, data)
+
+
+# ---------------------------------------------------------------------------
+# session history
+# ---------------------------------------------------------------------------
+
+_EXPLAIN_SESSION_HISTORY = """\
+Get the conversation history of an AI session.  Returns the full
+message log including user prompts, assistant responses, tool
+calls and results.
+
+Example:
+  limacharlie ai session history --id <SESSION_ID>
+"""
+register_explain("ai.session.history", _EXPLAIN_SESSION_HISTORY)
+
+
+@session_group.command("history")
+@click.option("--id", "session_id", required=True, help="Session ID.")
+@pass_context
+def session_history(ctx, session_id) -> None:
+    org = _get_org(ctx)
+    sdk = AISDK(org)
+    data = sdk.get_session_history(session_id)
+    _output(ctx, data)
+
+
+# ===========================================================================
+# usage subgroup – AI session usage tracking
+# ===========================================================================
+
+@click.group("usage")
+def usage_group() -> None:
+    """AI session usage tracking per API key identity."""
+
+group.add_command(usage_group)
+
+
+# ---------------------------------------------------------------------------
+# usage list
+# ---------------------------------------------------------------------------
+
+_EXPLAIN_USAGE_LIST = """\
+List all API key identities that have AI session usage data for
+the organization.
+
+Example:
+  limacharlie ai usage list
+"""
+register_explain("ai.usage.list", _EXPLAIN_USAGE_LIST)
+
+
+@usage_group.command("list")
+@pass_context
+def usage_list(ctx) -> None:
+    org = _get_org(ctx)
+    sdk = AISDK(org)
+    data = sdk.list_usage_identities()
+    _output(ctx, data)
+
+
+# ---------------------------------------------------------------------------
+# usage get
+# ---------------------------------------------------------------------------
+
+_EXPLAIN_USAGE_GET = """\
+Get hourly token and cost usage breakdown for a specific API key
+identity.  Use 'limacharlie ai usage list' to discover available
+identities.
+
+Example:
+  limacharlie ai usage get --identity my-api-key
+"""
+register_explain("ai.usage.get", _EXPLAIN_USAGE_GET)
+
+
+@usage_group.command("get")
+@click.option("--identity", required=True, help="API key identity name.")
+@pass_context
+def usage_get(ctx, identity) -> None:
+    org = _get_org(ctx)
+    sdk = AISDK(org)
+    data = sdk.get_usage(identity)
+    _output(ctx, data)

--- a/limacharlie/sdk/ai.py
+++ b/limacharlie/sdk/ai.py
@@ -229,3 +229,108 @@ class AI:
         """
         return self.client.request("POST", "ai/det_summary",
                                    params={"query": json.dumps(detection_data)})
+
+    # ------------------------------------------------------------------
+    # Org-scoped AI Session management
+    # ------------------------------------------------------------------
+
+    def _org_request(self, verb: str, path: str,
+                     query_params: dict[str, str] | None = None,
+                     ) -> dict[str, Any]:
+        """Make an authenticated request to the ai-sessions org endpoints.
+
+        The org endpoints accept both API keys and JWTs via
+        OrgDualAuthMiddleware. We send the raw API key when available
+        (same pattern as start_session) for maximum compatibility.
+        """
+        extra: dict[str, str] = {"X-LC-OID": self.client._oid}
+        if self.client._api_key is not None:
+            extra["Authorization"] = f"Bearer {self.client._api_key}"
+            return self.client.request(
+                verb, path,
+                query_params=query_params,
+                is_no_auth=True,
+                alt_root=_AI_SESSIONS_URL,
+                extra_headers=extra,
+            )
+        return self.client.request(
+            verb, path,
+            query_params=query_params,
+            alt_root=_AI_SESSIONS_URL,
+            extra_headers=extra,
+        )
+
+    def list_sessions(self, status: str | None = None,
+                      limit: int | None = None,
+                      cursor: str | None = None) -> dict[str, Any]:
+        """List AI sessions for the organization.
+
+        Args:
+            status: Filter by session status (running, ended, starting).
+            limit: Maximum number of results (1-200, default 50).
+            cursor: Pagination cursor from a previous response.
+
+        Returns:
+            dict with ``sessions`` list and ``next_cursor`` string.
+        """
+        qp: dict[str, str] = {}
+        if status:
+            qp["status"] = status
+        if limit is not None:
+            qp["limit"] = str(limit)
+        if cursor:
+            qp["cursor"] = cursor
+        return self._org_request("GET", "v1/org/sessions",
+                                 query_params=qp or None)
+
+    def get_session(self, session_id: str) -> dict[str, Any]:
+        """Get details of a specific AI session.
+
+        Args:
+            session_id: The session ID.
+
+        Returns:
+            dict with ``session`` object.
+        """
+        return self._org_request("GET", f"v1/org/sessions/{session_id}")
+
+    def terminate_session(self, session_id: str) -> dict[str, Any]:
+        """Terminate a running AI session.
+
+        Args:
+            session_id: The session ID to terminate.
+
+        Returns:
+            dict with ``terminated: true``.
+        """
+        return self._org_request("DELETE", f"v1/org/sessions/{session_id}")
+
+    def get_session_history(self, session_id: str) -> dict[str, Any]:
+        """Get the conversation history of an AI session.
+
+        Args:
+            session_id: The session ID.
+
+        Returns:
+            dict with ``messages`` list.
+        """
+        return self._org_request("GET", f"v1/org/sessions/{session_id}/history")
+
+    def list_usage_identities(self) -> dict[str, Any]:
+        """List all API key identities with AI session usage data.
+
+        Returns:
+            dict with ``identities`` list of strings.
+        """
+        return self._org_request("GET", "v1/org/usage/identities")
+
+    def get_usage(self, identity: str) -> dict[str, Any]:
+        """Get hourly token and cost usage for a specific API key identity.
+
+        Args:
+            identity: The API key identity name.
+
+        Returns:
+            dict with ``identity`` string and ``usage`` list of data points.
+        """
+        return self._org_request("GET", f"v1/org/usage/identities/{identity}")


### PR DESCRIPTION
## Summary
- Add `ai session` subgroup for managing AI sessions (list, get, terminate, history)
- Add `ai usage` subgroup for monitoring per-identity token/cost usage
- SDK methods added to `AI` class using org-scoped ai-sessions API endpoints

## Test plan
- [ ] Verify `limacharlie ai session list` returns org sessions
- [ ] Verify `limacharlie ai session get --id <id>` returns session details
- [ ] Verify `limacharlie ai session terminate --id <id>` stops a running session
- [ ] Verify `limacharlie ai session history --id <id>` returns message history
- [ ] Verify `limacharlie ai usage list` returns identity list
- [ ] Verify `limacharlie ai usage get --identity <name>` returns usage data
- [ ] Unit tests pass (984 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)