### PR TITLE
feat: Add info severity level to cases CLI and SDK

### DIFF
--- a/limacharlie/commands/case_cmd.py
+++ b/limacharlie/commands/case_cmd.py
@@ -37,7 +37,7 @@ and pagination.
 
 Filters (all repeatable/comma-separated):
   --status    new, acknowledged, in_progress, escalated, resolved, closed
-  --severity  critical, high, medium, low
+  --severity  critical, high, medium, low, info
   --classification  pending, true_positive, false_positive
   --assignee  filter by assignee email
   --search    full-text search in detection_cat and hostname
@@ -354,6 +354,7 @@ Configurable fields:
     high:     {mtta_minutes: 15, mttr_minutes: 720}
     medium:   {mtta_minutes: 60, mttr_minutes: 1440}
     low:      {mtta_minutes: 100, mttr_minutes: 2800}
+    info:     {mtta_minutes: 480, mttr_minutes: 10080}
   retention_days: 90
   auto_close_resolved_after_days: 30
 
@@ -413,7 +414,7 @@ be populated later with detections, telemetry, entities, etc.
 
 If --severity is omitted, severity is derived from detect_mtd.level
 in the detection object (or defaults to 'medium').  Valid severities:
-critical, high, medium, low.
+critical, high, medium, low, info.
 
 Examples:
   limacharlie case create --detection '<full detection JSON>'
@@ -509,7 +510,7 @@ _STATUS_CHOICES = click.Choice(
     case_sensitive=False,
 )
 _SEVERITY_CHOICES = click.Choice(
-    ["critical", "high", "medium", "low"],
+    ["critical", "high", "medium", "low", "info"],
     case_sensitive=False,
 )
 _CLASSIFICATION_CHOICES = click.Choice(

--- a/limacharlie/sdk/cases.py
+++ b/limacharlie/sdk/cases.py
@@ -52,7 +52,7 @@ class Cases:
                 routing.hostname, and detect_mtd.level automatically.
                 Omit to create an empty investigation case.
             severity: Optional case severity override
-                (critical, high, medium, low).
+                (critical, high, medium, low, info).
         """
         data: dict[str, Any] = {}
         if detection is not None:


### PR DESCRIPTION
## Summary
- Adds `info` as a valid severity level in CLI choices, help text, SLA example config, and SDK docstrings
- Matches ext-cases commit `18620a2` which introduced an "info" severity below "low" for non-actionable cases (manual-only, never auto-mapped from detection priority, with relaxed SLA benchmarks of 480min MTTA / 10080min MTTR)

## Test plan
- [x] All 155 existing case unit tests pass
- [ ] Manual: `limacharlie case create --severity info` accepted
- [ ] Manual: `limacharlie case list --severity info` filters correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)