### PR TITLE
feat: unwrap search results for human-readable table output

### DIFF
--- a/limacharlie/commands/search.py
+++ b/limacharlie/commands/search.py
@@ -2,10 +2,22 @@
 
 Commands for running and validating LCQL queries against historical
 telemetry stored in LimaCharlie Insight.
+
+Search results from the API contain wrapper objects (SearchResult) with
+metadata like searchResultId, type, nextToken, and stats.  For human-
+readable table output, these wrappers are unwrapped: event rows are
+flattened into a single table, facets and timeseries are shown as
+separate tables, and a stats summary is printed to stderr.  Machine-
+readable formats (json, yaml, csv, jsonl) pass through the raw API
+response unchanged.
 """
 
 from __future__ import annotations
 
+import json
+import sys
+from collections.abc import Callable
+from datetime import datetime, timezone
 from typing import Any
 
 import click
@@ -16,7 +28,7 @@ from ..config import get_config_value
 from ..sdk.organization import Organization
 from ..sdk.search import Search
 from ..sdk.hive import Hive, HiveRecord
-from ..output import format_output, detect_output_format
+from ..output import format_output, format_table, detect_output_format
 from ..discovery import register_explain
 from ._time_validation import validate_epoch_seconds
 
@@ -44,6 +56,351 @@ def _output(ctx: click.Context, data: Any) -> None:
 def _get_org(ctx: click.Context) -> Organization:
     client = Client(oid=ctx.obj.oid, environment=ctx.obj.environment)
     return Organization(client)
+
+
+def _make_progress_fn(ctx: click.Context) -> Callable[[str], None] | None:
+    """Return a stderr progress callback for interactive terminals.
+
+    Returns None when output is non-interactive (piped/redirected) or
+    when --quiet is set, so the SDK skips progress messages entirely.
+    """
+    if ctx.obj.quiet:
+        return None
+    if not sys.stderr.isatty():
+        return None
+    def _progress(msg: str) -> None:
+        click.echo(click.style(msg, dim=True), err=True)
+        sys.stderr.flush()
+    return _progress
+
+
+def _flatten_event_row(row: dict[str, Any]) -> dict[str, Any]:
+    """Flatten a SearchResultRow into a single-level dict for table display.
+
+    Merges metadata (mtd) fields and flattens the nested event data one
+    level deep.  For example, ``{"routing": {"event_type": "X"}}`` becomes
+    ``{"routing.event_type": "X"}``.  Deeper nesting is kept as-is (the
+    table formatter will render it as ``{N keys}``).
+
+    The ``mtd.ts`` field (millisecond epoch) is converted to a human-readable
+    UTC timestamp.
+    """
+    flat: dict[str, Any] = {}
+
+    # Metadata fields.
+    mtd = row.get("mtd", {})
+    ts = mtd.get("ts")
+    if ts is not None:
+        try:
+            flat["time"] = datetime.fromtimestamp(
+                ts / 1000, tz=timezone.utc,
+            ).strftime("%Y-%m-%d %H:%M:%S")
+        except (OSError, ValueError, OverflowError):
+            flat["time"] = str(ts)
+    stream = mtd.get("stream")
+    if stream:
+        flat["stream"] = stream
+
+    # Flatten event data one level.
+    data = row.get("data", {})
+    if isinstance(data, dict):
+        for key, value in data.items():
+            if isinstance(value, dict):
+                for sub_key, sub_value in value.items():
+                    flat[f"{key}.{sub_key}"] = sub_value
+            else:
+                flat[key] = value
+    else:
+        flat["data"] = data
+
+    return flat
+
+
+def _unwrap_search_results(results: list[dict[str, Any]]) -> dict[str, Any]:
+    """Separate raw SearchResult objects into events, facets, and timeseries.
+
+    Returns a dict with:
+        events: list of flattened event row dicts
+        facets: list of facet dicts
+        timeseries: list of timeseries point dicts
+        stats: the last non-empty stats dict (contains cumulative totals)
+    """
+    events: list[dict[str, Any]] = []
+    facets: list[dict[str, Any]] = []
+    timeseries: list[dict[str, Any]] = []
+    stats: dict[str, Any] = {}
+
+    for result in results:
+        result_type = result.get("type", "")
+
+        if result_type == "events":
+            # Only take stats from events results - other result types
+            # (facets, timeline) have their own stats that don't include
+            # event-level counters and would overwrite the real values.
+            result_stats = result.get("stats")
+            if result_stats:
+                stats = result_stats
+            for row in result.get("rows") or []:
+                events.append(_flatten_event_row(row))
+        elif result_type == "facets":
+            facets.extend(result.get("facets") or [])
+        elif result_type == "timeline":
+            timeseries.extend(result.get("timeseries") or [])
+
+    return {
+        "events": events,
+        "facets": facets,
+        "timeseries": timeseries,
+        "stats": stats,
+    }
+
+
+def _format_stats_summary(stats: dict[str, Any]) -> str:
+    """Format search stats as a one-line summary for stderr.
+
+    Prefers cumulative stats (aggregated across all pages by the server)
+    when available, falling back to the page-level stats.
+    """
+    # Use cumulative stats if available (server-aggregated across pages).
+    effective = stats.get("cumulativeStats") or stats
+
+    parts: list[str] = []
+    matched = effective.get("eventsMatched")
+    scanned = effective.get("eventsScanned")
+    if matched is not None:
+        parts.append(f"matched: {matched:,}")
+    if scanned is not None:
+        parts.append(f"scanned: {scanned:,}")
+    bytes_scanned = effective.get("bytesScanned")
+    if bytes_scanned is not None:
+        if bytes_scanned >= 1_073_741_824:
+            parts.append(f"bytes: {bytes_scanned / 1_073_741_824:.1f} GB")
+        elif bytes_scanned >= 1_048_576:
+            parts.append(f"bytes: {bytes_scanned / 1_048_576:.1f} MB")
+        else:
+            parts.append(f"bytes: {bytes_scanned:,}")
+    walltime = effective.get("walltime")
+    if walltime is not None:
+        parts.append(f"time: {walltime:.1f}s")
+    price = effective.get("estimatedPrice", {})
+    if isinstance(price, dict) and price.get("amount") is not None:
+        parts.append(f"cost: ${price['amount']:.4f}")
+    return ", ".join(parts)
+
+
+def _format_expanded_events(results: list[dict[str, Any]]) -> str:
+    """Format events as individual JSON blocks separated by dividers.
+
+    Each event is printed as pretty-printed JSON with a timestamp header,
+    separated by a horizontal rule.  Useful for investigating individual
+    events in detail.
+    """
+    parts: list[str] = []
+    for result in results:
+        if result.get("type") != "events":
+            continue
+        for row in result.get("rows") or []:
+            mtd = row.get("mtd", {})
+            ts = mtd.get("ts")
+            header_parts: list[str] = []
+            if ts is not None:
+                try:
+                    header_parts.append(
+                        datetime.fromtimestamp(ts / 1000, tz=timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+                    )
+                except (OSError, ValueError, OverflowError):
+                    header_parts.append(str(ts))
+            stream = mtd.get("stream")
+            if stream:
+                header_parts.append(stream)
+            data = row.get("data", {})
+            # Try to get event type for the header.
+            if isinstance(data, dict):
+                etype = (
+                    data.get("routing", {}).get("event_type")
+                    or data.get("cat")
+                    or data.get("etype")
+                )
+                if etype:
+                    header_parts.append(etype)
+
+            header = " | ".join(header_parts) if header_parts else "event"
+            parts.append(f"--- {header} ---")
+            parts.append(json.dumps(data, indent=2, default=str))
+    return "\n".join(parts)
+
+
+def _output_search_results(
+    ctx: click.Context,
+    results: list[dict[str, Any]],
+    raw: bool = False,
+    expand: bool = False,
+) -> None:
+    """Output search results with smart formatting for table mode.
+
+    For table output: unwraps the SearchResult wrappers and displays
+    events as a flat table.  Progress and stats go to stderr so stdout
+    can be redirected cleanly (e.g., ``limacharlie search run ... > out.txt``).
+
+    For --expand: prints each event as a pretty-printed JSON block with
+    a header showing timestamp, stream, and event type.
+
+    For machine-readable formats (json, yaml, csv, jsonl): passes the
+    raw API results through unchanged.
+
+    Args:
+        ctx: Click context with output settings.
+        results: Raw list of SearchResult dicts from the API.
+        raw: If True, skip unwrapping even in table mode.
+        expand: If True, show each event as a full JSON block.
+    """
+    if ctx.obj.quiet:
+        return
+
+    fmt = ctx.obj.output_format or detect_output_format()
+
+    # Machine-readable formats get raw output.
+    if fmt != "table" or raw:
+        click.echo(format_output(results, fmt))
+        return
+
+    # Expand mode: each event as a full JSON block.
+    if expand:
+        output = _format_expanded_events(results)
+        if output:
+            click.echo(output)
+        else:
+            click.echo("No events")
+        _print_stats_summary(results)
+        return
+
+    unwrapped = _unwrap_search_results(results)
+
+    # Events table.
+    events = unwrapped["events"]
+    if events:
+        display = events if ctx.obj.wide else _limit_event_columns(events)
+        click.echo(format_table(display))
+        click.echo(click.style(f"({len(events):,} event{'s' if len(events) != 1 else ''})", dim=True), err=True)
+    else:
+        click.echo("No events")
+
+    # Stats summary to stderr (not stdout, so redirects stay clean).
+    stats = unwrapped["stats"]
+    if stats:
+        summary = _format_stats_summary(stats)
+        if summary:
+            click.echo(click.style(f"Stats: {summary}", dim=True), err=True)
+            sys.stderr.flush()
+
+
+def _print_stats_summary(results: list[dict[str, Any]]) -> None:
+    """Extract and print stats summary from raw results to stderr."""
+    for result in reversed(results):
+        if result.get("type") == "events":
+            stats = result.get("stats")
+            if stats:
+                summary = _format_stats_summary(stats)
+                if summary:
+                    click.echo(click.style(f"Stats: {summary}", dim=True), err=True)
+                    sys.stderr.flush()
+                return
+
+
+# Maximum number of columns to display in the events table.  The table
+# formatter already drops columns that exceed terminal width, but with
+# deeply nested events (e.g., 20+ routing.* fields) the output is still
+# noisy.  This cap is applied before the table formatter so that only
+# the most useful columns are shown.  Use --output json for full data.
+_MAX_EVENT_COLUMNS = 15
+
+# Columns to always show first (in order) when present.
+_PRIORITY_COLUMNS = [
+    "time",
+    "stream",
+    "routing.event_type",
+    "cat",
+    "etype",
+    "routing.hostname",
+]
+
+# Columns to drop from table output - these are low-value routing
+# metadata or duplicates that add noise without helping the user
+# understand the event.
+_DROP_COLUMNS = frozenset({
+    # Duplicate of "time" (from mtd.ts).
+    "ts",
+    # Routing metadata - low-value for interactive display.
+    "routing.oid",
+    "routing.iid",
+    "routing.plat",
+    "routing.arch",
+    "routing.tags",
+    "routing.ext_ip",
+    "routing.int_ip",
+    "routing.sid",
+    "routing.event_id",
+    "routing.event_time",
+    "routing.this",
+    "routing.parent",
+    "routing.investigate_id",
+    "routing.moduleid",
+})
+
+
+def _limit_event_columns(events: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Select the most useful columns for table display.
+
+    Priority order:
+        1. Columns in _PRIORITY_COLUMNS (always shown first if present)
+        2. Non-routing event data columns (event.*, or flat projection fields)
+        3. Remaining routing.* columns not in _DROP_COLUMNS
+
+    Caps total columns at _MAX_EVENT_COLUMNS.  For projection queries
+    (flat data, no routing.* prefix), all columns pass through since
+    the user explicitly selected them.
+    """
+    # Collect all unique keys preserving first-seen order.
+    all_keys: list[str] = []
+    seen: set[str] = set()
+    for row in events:
+        for k in row:
+            if k not in seen:
+                all_keys.append(k)
+                seen.add(k)
+
+    # If few enough columns, pass through unchanged.
+    if len(all_keys) <= _MAX_EVENT_COLUMNS:
+        return events
+
+    # Build ordered selection.
+    selected: list[str] = []
+    used: set[str] = set()
+
+    # 1. Priority columns.
+    for col in _PRIORITY_COLUMNS:
+        if col in seen and col not in used:
+            selected.append(col)
+            used.add(col)
+
+    # 2. Non-routing, non-drop columns (event data, flat projection fields).
+    for col in all_keys:
+        if col not in used and col not in _DROP_COLUMNS:
+            if not col.startswith("routing."):
+                selected.append(col)
+                used.add(col)
+
+    # 3. Remaining routing columns not dropped.
+    for col in all_keys:
+        if col not in used and col not in _DROP_COLUMNS:
+            selected.append(col)
+            used.add(col)
+
+    # Cap at max.
+    selected = selected[:_MAX_EVENT_COLUMNS]
+    selected_set = set(selected)
+
+    return [{k: row[k] for k in selected if k in row} for row in events]
 
 
 def _resolve_token_expiry(cli_value: float | None, environment: str | None = None) -> float:
@@ -189,9 +546,11 @@ register_explain("search.run", _EXPLAIN_RUN)
     help=f"JWT token validity in hours (default: {DEFAULT_SEARCH_TOKEN_EXPIRY_HOURS}). "
          "Override the default via config key 'search_token_expiry_hours'.",
 )
+@click.option("--raw", is_flag=True, default=False, help="Show raw API result objects without unwrapping.")
+@click.option("--expand", is_flag=True, default=False, help="Show each event as a full pretty-printed JSON block.")
 @pass_context
 def run(ctx: click.Context, query: str, start: int, end: int, stream: str | None,
-        limit: int | None, token_expiry: float | None) -> None:
+        limit: int | None, token_expiry: float | None, raw: bool, expand: bool) -> None:
     validate_epoch_seconds(start, "start")
     validate_epoch_seconds(end, "end")
     org = _get_org(ctx)
@@ -204,8 +563,15 @@ def run(ctx: click.Context, query: str, start: int, end: int, stream: str | None
         )
     org.client.get_jwt(expiry_hours=effective_expiry)
     search = Search(org)
-    results = list(search.execute(query, start, end, stream=stream, limit=limit))
-    _output(ctx, results)
+    progress_fn = _make_progress_fn(ctx)
+    try:
+        results = list(search.execute(query, start, end, stream=stream, limit=limit, progress_fn=progress_fn))
+    except KeyboardInterrupt:
+        click.echo("\nSearch canceled.", err=True)
+        sys.stderr.flush()
+        ctx.exit(130)
+        return
+    _output_search_results(ctx, results, raw=raw, expand=expand)
 
 
 # ---------------------------------------------------------------------------
@@ -445,8 +811,10 @@ register_explain("search.saved-run", _EXPLAIN_SAVED_RUN)
     help=f"JWT token validity in hours (default: {DEFAULT_SEARCH_TOKEN_EXPIRY_HOURS}). "
          "Override the default via config key 'search_token_expiry_hours'.",
 )
+@click.option("--raw", is_flag=True, default=False, help="Show raw API result objects without unwrapping.")
+@click.option("--expand", is_flag=True, default=False, help="Show each event as a full pretty-printed JSON block.")
 @pass_context
-def saved_run(ctx: click.Context, name: str, limit: int | None, token_expiry: float | None) -> None:
+def saved_run(ctx: click.Context, name: str, limit: int | None, token_expiry: float | None, raw: bool, expand: bool) -> None:
     org = _get_org(ctx)
 
     effective_expiry = _resolve_token_expiry(token_expiry, environment=ctx.obj.environment)
@@ -485,5 +853,12 @@ def saved_run(ctx: click.Context, name: str, limit: int | None, token_expiry: fl
 
     stream = query_data.get("stream")
     search = Search(org)
-    results = list(search.execute(query_str, start_time, end_time, stream=stream, limit=limit))
-    _output(ctx, results)
+    progress_fn = _make_progress_fn(ctx)
+    try:
+        results = list(search.execute(query_str, start_time, end_time, stream=stream, limit=limit, progress_fn=progress_fn))
+    except KeyboardInterrupt:
+        click.echo("\nSearch canceled.", err=True)
+        sys.stderr.flush()
+        ctx.exit(130)
+        return
+    _output_search_results(ctx, results, raw=raw, expand=expand)

--- a/limacharlie/sdk/search.py
+++ b/limacharlie/sdk/search.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import json
 import re
 import time
-from collections.abc import Generator
+from collections.abc import Callable, Generator
 from typing import Any, TYPE_CHECKING
 
 from ..errors import LimaCharlieError, SearchError
@@ -112,8 +112,15 @@ class Search:
         # Estimate uses the validate endpoint with additional parameters
         return self.validate(query, start_time, end_time, stream)
 
-    def execute(self, query: str, start_time: int, end_time: int,
-                stream: str | None = None, limit: int | None = None) -> Generator[dict[str, Any], None, None]:
+    def execute(
+        self,
+        query: str,
+        start_time: int,
+        end_time: int,
+        stream: str | None = None,
+        limit: int | None = None,
+        progress_fn: Callable[[str], None] | None = None,
+    ) -> Generator[dict[str, Any], None, None]:
         """Execute an LCQL query and return results.
 
         Args:
@@ -122,6 +129,10 @@ class Search:
             end_time: End time (unix seconds).
             stream: Stream type ('event', 'detect', 'audit').
             limit: Max results.
+            progress_fn: Optional callback for progress messages (e.g.,
+                "Running search...", "Fetching page 2...").  Called with
+                a human-readable status string.  Intended for CLI progress
+                output to stderr in interactive mode.
 
         Yields:
             dict: Result records.
@@ -180,8 +191,15 @@ class Search:
                 query=query,
             )
 
+        if progress_fn:
+            progress_fn(f"Running search... query_id: {query_id}")
+
         count = 0
+        page = 1
+        total_events = 0
+        start_ts = time.monotonic()
         token: str | None = None
+        _interrupted = False
         try:
             while True:
                 qp: dict[str, str] = {}
@@ -210,6 +228,8 @@ class Search:
                 for item in poll.get("results", []):
                     if item.get("nextToken"):
                         next_token = item["nextToken"]
+                    if item.get("type") == "events":
+                        total_events += len(item.get("rows") or [])
                     yield item
                     count += 1
                     if limit and count >= limit:
@@ -220,12 +240,28 @@ class Search:
                         # More pages available - use the token to
                         # fetch the next page (may trigger a subquery).
                         token = next_token
+                        page += 1
+                        if progress_fn:
+                            elapsed = time.monotonic() - start_ts
+                            progress_fn(
+                                f"Fetching page {page}... "
+                                f"({total_events:,} events, {elapsed:.0f}s elapsed)"
+                            )
                     else:
                         break
                 else:
                     # Page still processing, poll again after a delay.
                     poll_ms = poll.get("nextPollInMs", 1000)
+                    if progress_fn:
+                        elapsed = time.monotonic() - start_ts
+                        progress_fn(
+                            f"Waiting for results... "
+                            f"(page {page}, {total_events:,} events, {elapsed:.0f}s elapsed)"
+                        )
                     time.sleep(max(poll_ms / 1000, 0.5))
+        except KeyboardInterrupt:
+            _interrupted = True
+            raise
         except SearchError:
             raise
         except Exception as exc:
@@ -237,8 +273,25 @@ class Search:
                 query=query,
             ) from exc
         finally:
-            # Cancel search to clean up
-            try:
-                self._org.client.request("DELETE", f"search/{query_id}", alt_root=search_url)
-            except Exception:
-                pass
+            # Cancel search on server to free resources.  Runs on
+            # normal completion, errors, and Ctrl+C (KeyboardInterrupt).
+            self._cancel_query(query_id, search_url, progress_fn if _interrupted else None)
+
+    def _cancel_query(
+        self,
+        query_id: str,
+        search_url: str,
+        progress_fn: Callable[[str], None] | None = None,
+    ) -> None:
+        """Cancel a search query on the server.
+
+        Always called in the finally block of execute() to clean up
+        server resources.  On keyboard interrupt, prints a cancel
+        message via progress_fn.
+        """
+        if progress_fn:
+            progress_fn(f"Canceling search query {query_id} on server...")
+        try:
+            self._org.client.request("DELETE", f"search/{query_id}", alt_root=search_url)
+        except Exception:
+            pass

--- a/tests/unit/test_search_output.py
+++ b/tests/unit/test_search_output.py
@@ -1,0 +1,1200 @@
+"""Tests for search result unwrapping and formatting.
+
+Validates that search results are correctly unwrapped from raw API
+SearchResult objects into user-friendly table output, including event
+row flattening, facet extraction, timeseries extraction, and stats
+summary formatting.  Machine-readable formats (json, yaml, csv, jsonl)
+should pass through unchanged.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import time
+from dataclasses import dataclass
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import click
+import pytest
+
+from limacharlie.commands.search import (
+    _MAX_EVENT_COLUMNS,
+    _DROP_COLUMNS,
+    _PRIORITY_COLUMNS,
+    _flatten_event_row,
+    _format_expanded_events,
+    _format_stats_summary,
+    _limit_event_columns,
+    _make_progress_fn,
+    _output_search_results,
+    _unwrap_search_results,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: realistic search result objects
+# ---------------------------------------------------------------------------
+
+def _make_event_row(
+    event_id: str = "evt-1",
+    ts: int = 1700000000000,
+    stream: str = "event",
+    data: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build a single SearchResultRow dict."""
+    if data is None:
+        data = {
+            "routing": {
+                "event_type": "NEW_PROCESS",
+                "oid": "oid-1",
+                "hostname": "web-01",
+                "sid": "sid-1",
+                "event_time": 1700000000,
+            },
+            "event": {
+                "FILE_PATH": "/usr/bin/curl",
+                "COMMAND_LINE": "curl https://example.com",
+            },
+        }
+    return {
+        "mtd": {
+            "id": event_id,
+            "ts": ts,
+            "stream": stream,
+            "projection": False,
+        },
+        "data": data,
+    }
+
+
+def _make_search_result(
+    result_type: str = "events",
+    rows: list[dict] | None = None,
+    facets: list[dict] | None = None,
+    timeseries: list[dict] | None = None,
+    stats: dict[str, Any] | None = None,
+    next_token: str = "",
+) -> dict[str, Any]:
+    """Build a SearchResult dict as returned by the API."""
+    result: dict[str, Any] = {
+        "searchResultId": "12345",
+        "created": "2026-03-13T16:43:08.467",
+        "type": result_type,
+        "stats": stats or {},
+    }
+    if next_token:
+        result["nextToken"] = next_token
+    if result_type == "events":
+        result["rows"] = rows or []
+    elif result_type == "facets":
+        result["facets"] = facets or []
+    elif result_type == "timeline":
+        result["timeseries"] = timeseries or []
+    return result
+
+
+def _make_stats(
+    events_matched: int = 100,
+    events_scanned: int = 5000,
+    bytes_scanned: int = 1_048_576,
+    walltime: float = 2.5,
+    price_amount: float | None = 0.0012,
+) -> dict[str, Any]:
+    stats: dict[str, Any] = {
+        "eventsMatched": events_matched,
+        "eventsScanned": events_scanned,
+        "bytesScanned": bytes_scanned,
+        "walltime": walltime,
+    }
+    if price_amount is not None:
+        stats["estimatedPrice"] = {"amount": price_amount}
+    return stats
+
+
+# ---------------------------------------------------------------------------
+# TestFlattenEventRow
+# ---------------------------------------------------------------------------
+
+class TestFlattenEventRow:
+    """Tests for _flatten_event_row - converting SearchResultRow to flat dict."""
+
+    def test_basic_event_row(self):
+        """Standard event stream row with routing and event data."""
+        row = _make_event_row()
+        flat = _flatten_event_row(row)
+
+        assert flat["time"] == "2023-11-14 22:13:20"
+        assert flat["stream"] == "event"
+        assert flat["routing.event_type"] == "NEW_PROCESS"
+        assert flat["routing.hostname"] == "web-01"
+        assert flat["event.FILE_PATH"] == "/usr/bin/curl"
+        assert flat["event.COMMAND_LINE"] == "curl https://example.com"
+
+    def test_detect_stream_row(self):
+        """Detect stream row has 'cat' as top-level field, no 'routing.event_type'."""
+        data = {
+            "cat": "Suspicious PowerShell",
+            "detect": {"op": "is"},
+            "routing": {
+                "event_type": "NEW_PROCESS",
+                "hostname": "win-01",
+            },
+        }
+        row = _make_event_row(stream="detect", data=data)
+        flat = _flatten_event_row(row)
+
+        assert flat["stream"] == "detect"
+        assert flat["cat"] == "Suspicious PowerShell"
+        assert flat["detect.op"] == "is"
+        assert flat["routing.event_type"] == "NEW_PROCESS"
+
+    def test_audit_stream_row(self):
+        """Audit stream has different top-level structure."""
+        data = {
+            "etype": "user_login",
+            "oid": "oid-1",
+            "msg": "User logged in",
+            "ident": "user@example.com",
+            "time": 1700000000,
+        }
+        row = _make_event_row(stream="audit", data=data)
+        flat = _flatten_event_row(row)
+
+        assert flat["stream"] == "audit"
+        assert flat["etype"] == "user_login"
+        assert flat["msg"] == "User logged in"
+
+    def test_projection_row(self):
+        """Projection queries return flat data - no nesting to flatten."""
+        data = {"path": "/usr/bin/curl", "count": 42, "hostname": "web-01"}
+        row = _make_event_row(data=data)
+        flat = _flatten_event_row(row)
+
+        assert flat["path"] == "/usr/bin/curl"
+        assert flat["count"] == 42
+        assert flat["hostname"] == "web-01"
+        # No dotted keys for flat data.
+        assert not any("." in k for k in flat if k not in ("time", "stream"))
+
+    def test_missing_mtd(self):
+        """Row with no mtd field should still produce a dict."""
+        row = {"data": {"key": "value"}}
+        flat = _flatten_event_row(row)
+
+        assert flat["key"] == "value"
+        assert "time" not in flat
+        assert "stream" not in flat
+
+    def test_empty_row(self):
+        """Completely empty row produces empty dict."""
+        flat = _flatten_event_row({})
+        assert flat == {}
+
+    def test_ts_zero(self):
+        """Timestamp of zero is still converted."""
+        row = _make_event_row(ts=0)
+        flat = _flatten_event_row(row)
+        assert flat["time"] == "1970-01-01 00:00:00"
+
+    def test_non_dict_data(self):
+        """Non-dict data field is preserved as-is."""
+        row = {"mtd": {"ts": 1700000000000, "stream": "event"}, "data": "raw string"}
+        flat = _flatten_event_row(row)
+        assert flat["data"] == "raw string"
+
+    def test_deeply_nested_data(self):
+        """Data nested beyond one level is kept as a dict value."""
+        data = {
+            "event": {
+                "PARENT": {"FILE_PATH": "/usr/bin/bash", "COMMAND_LINE": "bash"},
+                "FILE_PATH": "/usr/bin/curl",
+            },
+        }
+        row = _make_event_row(data=data)
+        flat = _flatten_event_row(row)
+
+        assert flat["event.FILE_PATH"] == "/usr/bin/curl"
+        # PARENT is a nested dict - kept as-is at event.PARENT level.
+        assert isinstance(flat["event.PARENT"], dict)
+        assert flat["event.PARENT"]["FILE_PATH"] == "/usr/bin/bash"
+
+    def test_empty_data_dict(self):
+        """Empty data dict produces only metadata fields."""
+        row = _make_event_row(data={})
+        flat = _flatten_event_row(row)
+        assert "time" in flat
+        assert "stream" in flat
+        # No data keys.
+        data_keys = [k for k in flat if k not in ("time", "stream")]
+        assert data_keys == []
+
+    def test_ts_overflow(self):
+        """Extremely large timestamp falls back to string representation."""
+        row = {"mtd": {"ts": 99999999999999999, "stream": "event"}, "data": {}}
+        flat = _flatten_event_row(row)
+        # Should not raise; falls back to string.
+        assert "time" in flat
+        assert flat["time"] == "99999999999999999"
+
+    def test_mixed_data_types(self):
+        """Data with mix of dicts, lists, strings, numbers."""
+        data = {
+            "routing": {"event_type": "DNS_REQUEST"},
+            "tags": ["prod", "web"],
+            "score": 0.95,
+            "name": "test-event",
+        }
+        row = _make_event_row(data=data)
+        flat = _flatten_event_row(row)
+
+        assert flat["routing.event_type"] == "DNS_REQUEST"
+        assert flat["tags"] == ["prod", "web"]
+        assert flat["score"] == 0.95
+        assert flat["name"] == "test-event"
+
+
+# ---------------------------------------------------------------------------
+# TestUnwrapSearchResults
+# ---------------------------------------------------------------------------
+
+class TestUnwrapSearchResults:
+    """Tests for _unwrap_search_results - separating result types."""
+
+    def test_events_only(self):
+        """Single events result with rows."""
+        rows = [_make_event_row(), _make_event_row(event_id="evt-2")]
+        results = [_make_search_result("events", rows=rows, stats=_make_stats())]
+
+        unwrapped = _unwrap_search_results(results)
+        assert len(unwrapped["events"]) == 2
+        assert unwrapped["facets"] == []
+        assert unwrapped["timeseries"] == []
+        assert unwrapped["stats"]["eventsMatched"] == 100
+
+    def test_multiple_pages_events(self):
+        """Events from multiple pages are merged."""
+        page1 = _make_search_result(
+            "events",
+            rows=[_make_event_row(event_id="evt-1")],
+            stats=_make_stats(events_matched=50),
+            next_token="token-2",
+        )
+        page2 = _make_search_result(
+            "events",
+            rows=[_make_event_row(event_id="evt-2"), _make_event_row(event_id="evt-3")],
+            stats=_make_stats(events_matched=100),
+        )
+
+        unwrapped = _unwrap_search_results([page1, page2])
+        assert len(unwrapped["events"]) == 3
+        # Last stats wins (page 2 has cumulative).
+        assert unwrapped["stats"]["eventsMatched"] == 100
+
+    def test_facets_extraction(self):
+        """Facets from facets-type results are collected."""
+        facets = [
+            {"type": "event_type", "name": "routing.event_type", "value": "NEW_PROCESS", "count": 42},
+            {"type": "event_type", "name": "routing.event_type", "value": "DNS_REQUEST", "count": 10},
+        ]
+        results = [_make_search_result("facets", facets=facets)]
+
+        unwrapped = _unwrap_search_results(results)
+        assert len(unwrapped["facets"]) == 2
+        assert unwrapped["events"] == []
+
+    def test_timeseries_extraction(self):
+        """Timeseries from timeline-type results are collected."""
+        timeseries = [
+            {"ts": 1700000000000, "type": "total", "count": 100},
+            {"ts": 1700003600000, "type": "total", "count": 50},
+        ]
+        results = [_make_search_result("timeline", timeseries=timeseries)]
+
+        unwrapped = _unwrap_search_results(results)
+        assert len(unwrapped["timeseries"]) == 2
+        assert unwrapped["events"] == []
+
+    def test_mixed_result_types(self):
+        """Typical real response: events + facets + 2x timeline per page."""
+        results = [
+            _make_search_result("events", rows=[_make_event_row()], stats=_make_stats()),
+            _make_search_result("timeline", timeseries=[{"ts": 1700000000000, "type": "total", "count": 100}]),
+            _make_search_result("timeline", timeseries=[{"ts": 1700000000000, "type": "event", "count": 100}]),
+            _make_search_result("facets", facets=[{"type": "event_type", "value": "NEW_PROCESS", "count": 42}]),
+        ]
+
+        unwrapped = _unwrap_search_results(results)
+        assert len(unwrapped["events"]) == 1
+        assert len(unwrapped["facets"]) == 1
+        assert len(unwrapped["timeseries"]) == 2
+
+    def test_empty_results(self):
+        """No results at all."""
+        unwrapped = _unwrap_search_results([])
+        assert unwrapped["events"] == []
+        assert unwrapped["facets"] == []
+        assert unwrapped["timeseries"] == []
+        assert unwrapped["stats"] == {}
+
+    def test_events_with_empty_rows(self):
+        """Events result with no rows (e.g. final page)."""
+        results = [_make_search_result("events", rows=[], stats=_make_stats())]
+        unwrapped = _unwrap_search_results(results)
+        assert unwrapped["events"] == []
+        assert unwrapped["stats"]["eventsMatched"] == 100
+
+    def test_unknown_result_type(self):
+        """Unknown result type is silently ignored."""
+        results = [{"type": "unknown_future_type", "data": "something"}]
+        unwrapped = _unwrap_search_results(results)
+        assert unwrapped["events"] == []
+        assert unwrapped["facets"] == []
+        assert unwrapped["timeseries"] == []
+
+    def test_stats_from_last_events_result(self):
+        """Stats come from the last events result, not facets/timeline."""
+        results = [
+            _make_search_result("events", rows=[], stats=_make_stats(events_matched=99)),
+            _make_search_result("facets", facets=[], stats=_make_stats(events_matched=0)),
+            _make_search_result("timeline", timeseries=[], stats=_make_stats(events_matched=0)),
+        ]
+        unwrapped = _unwrap_search_results(results)
+        assert unwrapped["stats"]["eventsMatched"] == 99
+
+    def test_stats_from_last_events_page(self):
+        """Multi-page: stats from last events result win."""
+        results = [
+            _make_search_result("events", rows=[], stats=_make_stats(events_matched=10)),
+            _make_search_result("facets", facets=[], stats=_make_stats(events_matched=0)),
+            _make_search_result("events", rows=[], stats=_make_stats(events_matched=99)),
+            _make_search_result("facets", facets=[], stats=_make_stats(events_matched=0)),
+        ]
+        unwrapped = _unwrap_search_results(results)
+        assert unwrapped["stats"]["eventsMatched"] == 99
+
+    def test_facets_across_pages(self):
+        """Facets from multiple pages are merged."""
+        page1 = _make_search_result("facets", facets=[{"value": "A", "count": 10}])
+        page2 = _make_search_result("facets", facets=[{"value": "B", "count": 20}])
+        unwrapped = _unwrap_search_results([page1, page2])
+        assert len(unwrapped["facets"]) == 2
+
+    def test_timeseries_across_pages(self):
+        """Timeseries points from multiple pages are merged."""
+        page1 = _make_search_result("timeline", timeseries=[{"ts": 1, "count": 10}])
+        page2 = _make_search_result("timeline", timeseries=[{"ts": 2, "count": 20}])
+        unwrapped = _unwrap_search_results([page1, page2])
+        assert len(unwrapped["timeseries"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# TestFormatStatsSummary
+# ---------------------------------------------------------------------------
+
+class TestFormatStatsSummary:
+    """Tests for _format_stats_summary."""
+
+    def test_full_stats(self):
+        summary = _format_stats_summary(_make_stats())
+        assert "matched: 100" in summary
+        assert "scanned: 5,000" in summary
+        assert "1.0 MB" in summary
+        assert "time: 2.5s" in summary
+        assert "cost: $0.0012" in summary
+
+    def test_gb_bytes(self):
+        summary = _format_stats_summary(_make_stats(bytes_scanned=2_147_483_648))
+        assert "2.0 GB" in summary
+
+    def test_small_bytes(self):
+        summary = _format_stats_summary(_make_stats(bytes_scanned=512))
+        assert "bytes: 512" in summary
+
+    def test_empty_stats(self):
+        summary = _format_stats_summary({})
+        assert summary == ""
+
+    def test_no_price(self):
+        summary = _format_stats_summary(_make_stats(price_amount=None))
+        assert "cost:" not in summary
+
+    def test_large_numbers(self):
+        summary = _format_stats_summary(_make_stats(
+            events_matched=1_234_567,
+            events_scanned=99_999_999,
+        ))
+        assert "matched: 1,234,567" in summary
+        assert "scanned: 99,999,999" in summary
+
+    def test_zero_walltime(self):
+        summary = _format_stats_summary(_make_stats(walltime=0.0))
+        assert "time: 0.0s" in summary
+
+    def test_partial_stats(self):
+        """Only some fields present."""
+        summary = _format_stats_summary({"eventsMatched": 42})
+        assert "matched: 42" in summary
+        assert "scanned" not in summary
+        assert "bytes" not in summary
+
+    def test_cumulative_stats_preferred(self):
+        """Cumulative stats (server-aggregated) are used when present."""
+        stats = {
+            "eventsMatched": 10,  # Page-level.
+            "eventsScanned": 500,
+            "cumulativeStats": {
+                "eventsMatched": 100,  # Cumulative across all pages.
+                "eventsScanned": 5000,
+                "bytesScanned": 2_097_152,
+            },
+        }
+        summary = _format_stats_summary(stats)
+        assert "matched: 100" in summary
+        assert "scanned: 5,000" in summary
+        assert "2.0 MB" in summary
+
+    def test_cumulative_stats_null_fallback(self):
+        """Falls back to page stats when cumulativeStats is null."""
+        stats = {
+            "eventsMatched": 10,
+            "cumulativeStats": None,
+        }
+        summary = _format_stats_summary(stats)
+        assert "matched: 10" in summary
+
+
+# ---------------------------------------------------------------------------
+# TestOutputSearchResults
+# ---------------------------------------------------------------------------
+
+@dataclass
+class _FakeCtxObj:
+    quiet: bool = False
+    output_format: str | None = None
+    wide: bool = False
+
+
+class TestOutputSearchResults:
+    """Tests for _output_search_results - end-to-end output formatting."""
+
+    def _make_ctx(self, output_format: str | None = None, quiet: bool = False) -> click.Context:
+        ctx = click.Context(click.Command("test"))
+        ctx.obj = _FakeCtxObj(output_format=output_format, quiet=quiet)
+        return ctx
+
+    def test_json_format_passes_raw(self, capsys):
+        """JSON output should pass raw results unchanged."""
+        results = [_make_search_result("events", rows=[_make_event_row()])]
+        ctx = self._make_ctx(output_format="json")
+        _output_search_results(ctx, results)
+        captured = capsys.readouterr()
+        parsed = json.loads(captured.out)
+        assert isinstance(parsed, list)
+        assert parsed[0]["type"] == "events"
+        assert "rows" in parsed[0]
+
+    def test_yaml_format_passes_raw(self, capsys):
+        """YAML output should pass raw results unchanged."""
+        results = [_make_search_result("events", rows=[_make_event_row()])]
+        ctx = self._make_ctx(output_format="yaml")
+        _output_search_results(ctx, results)
+        captured = capsys.readouterr()
+        assert "type: events" in captured.out
+
+    def test_jsonl_format_passes_raw(self, capsys):
+        """JSONL output should pass raw results unchanged."""
+        results = [_make_search_result("events", rows=[_make_event_row()])]
+        ctx = self._make_ctx(output_format="jsonl")
+        _output_search_results(ctx, results)
+        captured = capsys.readouterr()
+        parsed = json.loads(captured.out.strip())
+        assert parsed["type"] == "events"
+
+    def test_csv_format_passes_raw(self, capsys):
+        """CSV output should pass raw results unchanged."""
+        results = [_make_search_result("events", rows=[_make_event_row()])]
+        ctx = self._make_ctx(output_format="csv")
+        _output_search_results(ctx, results)
+        captured = capsys.readouterr()
+        assert "searchResultId" in captured.out
+
+    def test_table_format_unwraps_events(self, capsys):
+        """Table output should show flattened event rows, not raw results."""
+        results = [_make_search_result(
+            "events",
+            rows=[_make_event_row(), _make_event_row(event_id="evt-2")],
+            stats=_make_stats(),
+        )]
+        ctx = self._make_ctx(output_format="table")
+        _output_search_results(ctx, results)
+        captured = capsys.readouterr()
+
+        # Should NOT contain raw SearchResult fields.
+        assert "searchResultId" not in captured.out
+        assert "nextToken" not in captured.out
+        # Should contain flattened event fields.
+        assert "NEW_PROCESS" in captured.out or "routing.event_type" in captured.out
+        # Stats on stderr.
+        assert "matched:" in captured.err or "Stats:" in captured.err
+
+    def test_table_raw_flag(self, capsys):
+        """--raw flag should pass raw results in table mode."""
+        results = [_make_search_result("events", rows=[_make_event_row()])]
+        ctx = self._make_ctx(output_format="table")
+        _output_search_results(ctx, results, raw=True)
+        captured = capsys.readouterr()
+        # Raw mode shows SearchResult-level fields.
+        assert "searchResultId" in captured.out or "events" in captured.out
+
+    def test_quiet_mode(self, capsys):
+        """Quiet mode suppresses all output."""
+        results = [_make_search_result("events", rows=[_make_event_row()])]
+        ctx = self._make_ctx(output_format="table", quiet=True)
+        _output_search_results(ctx, results)
+        captured = capsys.readouterr()
+        assert captured.out == ""
+
+    def test_no_events_message(self, capsys):
+        """Empty events should show 'No events' message."""
+        results = [_make_search_result("events", rows=[], stats=_make_stats(events_matched=0))]
+        ctx = self._make_ctx(output_format="table")
+        _output_search_results(ctx, results)
+        captured = capsys.readouterr()
+        assert "No events" in captured.out
+
+    def test_table_ignores_facets_and_timeseries(self, capsys):
+        """Table mode only shows events, not facets or timeseries."""
+        results = [
+            _make_search_result("events", rows=[_make_event_row()]),
+            _make_search_result("facets", facets=[{"value": "NEW_PROCESS", "count": 42}]),
+            _make_search_result("timeline", timeseries=[{"ts": 1700000000000, "count": 100}]),
+        ]
+        ctx = self._make_ctx(output_format="table")
+        _output_search_results(ctx, results)
+        captured = capsys.readouterr()
+
+        assert "Facets:" not in captured.err
+        assert "Timeseries:" not in captured.err
+
+    def test_multi_page_events_merged(self, capsys):
+        """Events from multiple pages appear in single table."""
+        results = [
+            _make_search_result("events", rows=[_make_event_row(event_id="evt-1")]),
+            _make_search_result("facets", facets=[]),
+            _make_search_result("timeline", timeseries=[]),
+            # Page 2
+            _make_search_result("events", rows=[_make_event_row(event_id="evt-2")], stats=_make_stats()),
+            _make_search_result("facets", facets=[]),
+            _make_search_result("timeline", timeseries=[]),
+        ]
+        ctx = self._make_ctx(output_format="table")
+        _output_search_results(ctx, results)
+        captured = capsys.readouterr()
+
+        # Both events should be in the output, not split into separate sections.
+        lines = captured.out.strip().split("\n")
+        # At least header + separator + 2 data rows.
+        assert len(lines) >= 3
+
+    def test_wide_mode_skips_column_limit(self):
+        """--wide should pass all columns to format_table without limiting."""
+        data = {"routing": {f"field_{i}": f"val_{i}" for i in range(20)}}
+        row = _make_event_row(data=data)
+        flat = _flatten_event_row(row)
+        events = [flat]
+        # Without wide, columns are limited.
+        limited = _limit_event_columns(events)
+        assert len(limited[0]) <= _MAX_EVENT_COLUMNS
+        # With wide, _output_search_results skips _limit_event_columns
+        # so all columns are preserved (> _MAX_EVENT_COLUMNS).
+        assert len(flat) > _MAX_EVENT_COLUMNS
+
+    def test_projection_events_flat_columns(self, capsys):
+        """Projection queries produce flat columns without dot notation."""
+        data = {"path": "/usr/bin/curl", "count": 42}
+        results = [_make_search_result(
+            "events",
+            rows=[_make_event_row(data=data)],
+            stats=_make_stats(),
+        )]
+        ctx = self._make_ctx(output_format="table")
+        _output_search_results(ctx, results)
+        captured = capsys.readouterr()
+
+        assert "path" in captured.out
+        assert "count" in captured.out
+        assert "/usr/bin/curl" in captured.out
+        assert "42" in captured.out
+
+
+# ---------------------------------------------------------------------------
+# TestLimitEventColumns
+# ---------------------------------------------------------------------------
+
+class TestLimitEventColumns:
+    """Tests for _limit_event_columns - smart column selection."""
+
+    def test_few_columns_pass_through(self):
+        """Rows with <= _MAX_EVENT_COLUMNS columns are unchanged."""
+        events = [{"time": "2023-01-01", "stream": "event", "a": 1, "b": 2}]
+        result = _limit_event_columns(events)
+        assert result == events
+
+    def test_many_columns_capped(self):
+        """Rows with > _MAX_EVENT_COLUMNS columns are trimmed."""
+        row = {f"col_{i}": i for i in range(30)}
+        events = [row]
+        result = _limit_event_columns(events)
+        assert len(result[0]) <= _MAX_EVENT_COLUMNS
+
+    def test_priority_columns_kept(self):
+        """Priority columns (time, stream, routing.event_type) are always kept."""
+        row = {"time": "2023-01-01", "stream": "event", "routing.event_type": "NEW_PROCESS"}
+        # Add many filler columns to exceed the cap.
+        for i in range(20):
+            row[f"routing.filler_{i}"] = i
+        events = [row]
+        result = _limit_event_columns(events)
+        assert "time" in result[0]
+        assert "stream" in result[0]
+        assert "routing.event_type" in result[0]
+
+    def test_drop_columns_excluded(self):
+        """Columns in _DROP_COLUMNS are excluded."""
+        row = {
+            "time": "2023-01-01",
+            "routing.event_type": "X",
+            "routing.oid": "should-be-dropped",
+            "routing.sid": "should-be-dropped",
+            "routing.plat": "should-be-dropped",
+            "event.FILE_PATH": "/usr/bin/curl",
+        }
+        events = [row]
+        # Need > _MAX_EVENT_COLUMNS to trigger limiting.
+        for i in range(20):
+            row[f"event.field_{i}"] = i
+        result = _limit_event_columns(events)
+        assert "routing.oid" not in result[0]
+        assert "routing.sid" not in result[0]
+        assert "routing.plat" not in result[0]
+
+    def test_event_data_before_routing(self):
+        """Event data columns are prioritized over remaining routing columns."""
+        row = {"time": "t", "routing.event_type": "X"}
+        # Add event.* columns.
+        for i in range(10):
+            row[f"event.field_{i}"] = i
+        # Add routing.* columns (not in drop list).
+        for i in range(10):
+            row[f"routing.custom_{i}"] = i
+        events = [row]
+        result = _limit_event_columns(events)
+        keys = list(result[0].keys())
+        # event.field_0 should appear before routing.custom_0.
+        event_keys = [k for k in keys if k.startswith("event.")]
+        routing_keys = [k for k in keys if k.startswith("routing.custom_")]
+        if event_keys and routing_keys:
+            assert keys.index(event_keys[0]) < keys.index(routing_keys[0])
+
+    def test_projection_query_passthrough(self):
+        """Projection queries have flat keys (no routing.*), all pass through."""
+        row = {f"field_{i}": i for i in range(10)}
+        row["time"] = "t"
+        events = [row]
+        result = _limit_event_columns(events)
+        assert len(result[0]) == len(row)
+
+    def test_multiple_rows_same_columns(self):
+        """All rows get the same column selection."""
+        base = {"time": "t", "stream": "event", "routing.event_type": "X"}
+        for i in range(20):
+            base[f"routing.extra_{i}"] = i
+        events = [dict(base), dict(base)]
+        result = _limit_event_columns(events)
+        assert set(result[0].keys()) == set(result[1].keys())
+
+
+# ---------------------------------------------------------------------------
+# TestEdgeCases
+# ---------------------------------------------------------------------------
+
+class TestEdgeCases:
+    """Edge cases and error scenarios."""
+
+    def test_flatten_row_with_none_ts(self):
+        """Row where mtd.ts is None."""
+        row = {"mtd": {"ts": None, "stream": "event"}, "data": {"key": "val"}}
+        flat = _flatten_event_row(row)
+        assert "time" not in flat
+        assert flat["stream"] == "event"
+        assert flat["key"] == "val"
+
+    def test_flatten_row_with_negative_ts(self):
+        """Negative timestamp (before epoch)."""
+        row = {"mtd": {"ts": -1000, "stream": "event"}, "data": {}}
+        flat = _flatten_event_row(row)
+        assert "time" in flat
+
+    def test_unwrap_result_missing_type(self):
+        """Result with no 'type' field is silently skipped."""
+        results = [{"stats": _make_stats(), "rows": [_make_event_row()]}]
+        unwrapped = _unwrap_search_results(results)
+        assert unwrapped["events"] == []
+
+    def test_unwrap_result_missing_rows(self):
+        """Events result with no 'rows' key."""
+        results = [{"type": "events", "stats": {}}]
+        unwrapped = _unwrap_search_results(results)
+        assert unwrapped["events"] == []
+
+    def test_unwrap_result_missing_facets(self):
+        """Facets result with no 'facets' key."""
+        results = [{"type": "facets", "stats": {}}]
+        unwrapped = _unwrap_search_results(results)
+        assert unwrapped["facets"] == []
+
+    def test_unwrap_result_missing_timeseries(self):
+        """Timeline result with no 'timeseries' key."""
+        results = [{"type": "timeline", "stats": {}}]
+        unwrapped = _unwrap_search_results(results)
+        assert unwrapped["timeseries"] == []
+
+    def test_stats_summary_non_dict_price(self):
+        """Price field that is not a dict."""
+        stats = {"estimatedPrice": "invalid"}
+        summary = _format_stats_summary(stats)
+        assert "cost:" not in summary
+
+    def test_flatten_data_with_empty_nested_dict(self):
+        """Nested dict that is empty."""
+        row = _make_event_row(data={"routing": {}, "key": "val"})
+        flat = _flatten_event_row(row)
+        assert flat["key"] == "val"
+        # Empty routing dict produces no routing.* keys.
+        routing_keys = [k for k in flat if k.startswith("routing.")]
+        assert routing_keys == []
+
+    def test_flatten_data_key_collision(self):
+        """When flattened keys would collide, last one wins."""
+        # This is a pathological case - flat "routing.event_type" key
+        # and nested routing.event_type would collide.
+        row = _make_event_row(data={
+            "routing": {"event_type": "from_nested"},
+        })
+        flat = _flatten_event_row(row)
+        assert flat["routing.event_type"] == "from_nested"
+
+    def test_large_result_set(self):
+        """Handling many events doesn't error."""
+        rows = [_make_event_row(event_id=f"evt-{i}") for i in range(1000)]
+        results = [_make_search_result("events", rows=rows, stats=_make_stats(events_matched=1000))]
+        unwrapped = _unwrap_search_results(results)
+        assert len(unwrapped["events"]) == 1000
+
+    def test_null_rows_in_api_response(self):
+        """API returns null for rows/facets/timeseries instead of omitting them.
+
+        JSON null becomes Python None, so result.get("rows", []) returns
+        None (key exists but value is null), not the default [].
+        """
+        results = [
+            {"type": "events", "rows": None, "facets": None, "timeseries": None, "stats": {}},
+            {"type": "facets", "facets": None, "stats": {}},
+            {"type": "timeline", "timeseries": None, "stats": {}},
+        ]
+        unwrapped = _unwrap_search_results(results)
+        assert unwrapped["events"] == []
+        assert unwrapped["facets"] == []
+        assert unwrapped["timeseries"] == []
+
+    def test_mixed_null_and_populated_fields(self):
+        """Real API response: events result has rows but null facets/timeseries."""
+        results = [
+            {
+                "type": "events",
+                "searchResultId": "123",
+                "created": "2026-03-13T16:43:08.467",
+                "rows": [_make_event_row()],
+                "facets": None,
+                "timeseries": None,
+                "stats": _make_stats(),
+                "nextToken": "token-2",
+            },
+            {
+                "type": "timeline",
+                "searchResultId": "456",
+                "created": "2026-03-13T16:43:08.467",
+                "rows": None,
+                "facets": None,
+                "timeseries": [{"ts": 1700000000000, "type": "total", "count": 100}],
+                "stats": {},
+            },
+        ]
+        unwrapped = _unwrap_search_results(results)
+        assert len(unwrapped["events"]) == 1
+        assert len(unwrapped["timeseries"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# TestProgressCallback
+# ---------------------------------------------------------------------------
+
+class TestProgressCallback:
+    """Tests for _make_progress_fn and progress callback behavior."""
+
+    def test_progress_fn_none_when_quiet(self):
+        """Progress is suppressed in quiet mode."""
+        ctx = click.Context(click.Command("test"))
+        ctx.obj = _FakeCtxObj(quiet=True)
+        assert _make_progress_fn(ctx) is None
+
+    def test_progress_fn_none_when_not_tty(self):
+        """Progress is suppressed when stderr is not a TTY."""
+        ctx = click.Context(click.Command("test"))
+        ctx.obj = _FakeCtxObj(quiet=False)
+        with patch.object(sys.stderr, "isatty", return_value=False):
+            assert _make_progress_fn(ctx) is None
+
+    def test_progress_fn_callable_when_tty(self):
+        """Progress callback is returned when stderr is a TTY."""
+        ctx = click.Context(click.Command("test"))
+        ctx.obj = _FakeCtxObj(quiet=False)
+        with patch.object(sys.stderr, "isatty", return_value=True):
+            fn = _make_progress_fn(ctx)
+            assert callable(fn)
+
+    def test_progress_fn_writes_to_stderr(self, capsys):
+        """Progress callback writes to stderr, not stdout."""
+        ctx = click.Context(click.Command("test"))
+        ctx.obj = _FakeCtxObj(quiet=False)
+        with patch.object(sys.stderr, "isatty", return_value=True):
+            fn = _make_progress_fn(ctx)
+            fn("test message")
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        assert "test message" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# TestSearchExecuteProgress
+# ---------------------------------------------------------------------------
+
+class TestSearchExecuteProgress:
+    """Tests for progress callbacks in Search.execute().
+
+    These test the SDK-level progress_fn parameter by mocking the
+    HTTP client to simulate multi-page search responses.
+    """
+
+    def _make_search(self):
+        """Create a Search instance with mocked org/client."""
+        from limacharlie.sdk.search import Search
+
+        org = MagicMock()
+        org.oid = "test-oid"
+        org.get_urls.return_value = {"search": "https://abc123.replay-search.limacharlie.io"}
+        search = Search(org)
+        return search, org
+
+    def test_progress_called_on_start(self):
+        """progress_fn is called with query_id on search start."""
+        search, org = self._make_search()
+        messages: list[str] = []
+
+        # Mock: POST returns queryId, GET returns completed with results.
+        org.client.request.side_effect = [
+            {"queryId": "q-123"},  # POST /search
+            {"completed": True, "results": [{"type": "events", "rows": []}]},  # GET
+        ]
+
+        list(search.execute("*|*|*", 100, 200, progress_fn=messages.append))
+
+        assert any("q-123" in m for m in messages)
+
+    def test_progress_called_on_pagination(self):
+        """progress_fn shows page number and event count on pagination."""
+        search, org = self._make_search()
+        messages: list[str] = []
+
+        org.client.request.side_effect = [
+            {"queryId": "q-123"},
+            {"completed": True, "results": [
+                {"type": "events", "rows": [{"mtd": {}, "data": {}}] * 5, "nextToken": "tok-2"},
+            ]},
+            {"completed": True, "results": [
+                {"type": "events", "rows": [{"mtd": {}, "data": {}}] * 3},
+            ]},
+        ]
+
+        list(search.execute("*|*|*", 100, 200, progress_fn=messages.append))
+
+        # Should have progress about page 2.
+        page_msgs = [m for m in messages if "page 2" in m.lower() or "Fetching page 2" in m]
+        assert len(page_msgs) >= 1
+        # Should mention event count.
+        assert any("5" in m for m in page_msgs)
+
+    def test_progress_called_on_poll_wait(self):
+        """progress_fn shows waiting status during polling."""
+        search, org = self._make_search()
+        messages: list[str] = []
+
+        org.client.request.side_effect = [
+            {"queryId": "q-123"},
+            {"completed": False, "nextPollInMs": 100, "results": []},  # Not ready yet.
+            {"completed": True, "results": [{"type": "events", "rows": []}]},  # Done.
+        ]
+
+        with patch("limacharlie.sdk.search.time.sleep"):
+            list(search.execute("*|*|*", 100, 200, progress_fn=messages.append))
+
+        wait_msgs = [m for m in messages if "Waiting" in m or "waiting" in m.lower()]
+        assert len(wait_msgs) >= 1
+
+    def test_no_progress_when_fn_is_none(self):
+        """No errors when progress_fn is None."""
+        search, org = self._make_search()
+
+        org.client.request.side_effect = [
+            {"queryId": "q-123"},
+            {"completed": True, "results": [{"type": "events", "rows": []}]},
+        ]
+
+        # Should not raise.
+        list(search.execute("*|*|*", 100, 200, progress_fn=None))
+
+    def test_keyboard_interrupt_cancels_query(self):
+        """KeyboardInterrupt triggers server-side cancel and re-raises."""
+        search, org = self._make_search()
+        messages: list[str] = []
+
+        def side_effect(*args, **kwargs):
+            call_count = org.client.request.call_count
+            if call_count == 1:
+                return {"queryId": "q-123"}
+            elif call_count == 2:
+                raise KeyboardInterrupt()
+            else:
+                return {}  # DELETE response
+
+        org.client.request.side_effect = side_effect
+
+        with pytest.raises(KeyboardInterrupt):
+            list(search.execute("*|*|*", 100, 200, progress_fn=messages.append))
+
+        # Verify DELETE was called to cancel the query.
+        delete_calls = [
+            c for c in org.client.request.call_args_list
+            if c.args[0] == "DELETE"
+        ]
+        assert len(delete_calls) == 1
+        assert "q-123" in delete_calls[0].args[1]
+
+        # Verify cancel message was printed.
+        assert any("Cancel" in m for m in messages)
+
+    def test_keyboard_interrupt_no_cancel_message_without_progress(self):
+        """KeyboardInterrupt still cancels but no message without progress_fn."""
+        search, org = self._make_search()
+
+        def side_effect(*args, **kwargs):
+            call_count = org.client.request.call_count
+            if call_count == 1:
+                return {"queryId": "q-123"}
+            elif call_count == 2:
+                raise KeyboardInterrupt()
+            else:
+                return {}
+
+        org.client.request.side_effect = side_effect
+
+        with pytest.raises(KeyboardInterrupt):
+            list(search.execute("*|*|*", 100, 200, progress_fn=None))
+
+        # DELETE still called.
+        delete_calls = [
+            c for c in org.client.request.call_args_list
+            if c.args[0] == "DELETE"
+        ]
+        assert len(delete_calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# TestStatsFromEventsOnly
+# ---------------------------------------------------------------------------
+
+class TestStatsFromEventsOnly:
+    """Verify stats are only taken from 'events' type results."""
+
+    def test_facets_stats_ignored(self):
+        """Facets result stats don't overwrite event stats."""
+        results = [
+            _make_search_result("events", rows=[], stats=_make_stats(events_matched=42)),
+            _make_search_result("facets", facets=[], stats=_make_stats(events_matched=0)),
+        ]
+        unwrapped = _unwrap_search_results(results)
+        assert unwrapped["stats"]["eventsMatched"] == 42
+
+    def test_timeline_stats_ignored(self):
+        """Timeline result stats don't overwrite event stats."""
+        results = [
+            _make_search_result("events", rows=[], stats=_make_stats(events_matched=42)),
+            _make_search_result("timeline", timeseries=[], stats=_make_stats(events_matched=0)),
+        ]
+        unwrapped = _unwrap_search_results(results)
+        assert unwrapped["stats"]["eventsMatched"] == 42
+
+    def test_no_events_results_empty_stats(self):
+        """When only facets/timeline results, stats remain empty."""
+        results = [
+            _make_search_result("facets", facets=[], stats=_make_stats(events_matched=10)),
+            _make_search_result("timeline", timeseries=[], stats=_make_stats(events_matched=5)),
+        ]
+        unwrapped = _unwrap_search_results(results)
+        assert unwrapped["stats"] == {}
+
+    def test_multiple_events_pages_last_wins(self):
+        """Last events result stats (with cumulative) win."""
+        results = [
+            _make_search_result("events", rows=[], stats=_make_stats(events_matched=10)),
+            _make_search_result("facets", facets=[], stats=_make_stats(events_matched=0)),
+            _make_search_result("events", rows=[], stats=_make_stats(events_matched=100)),
+            _make_search_result("timeline", timeseries=[], stats=_make_stats(events_matched=0)),
+        ]
+        unwrapped = _unwrap_search_results(results)
+        assert unwrapped["stats"]["eventsMatched"] == 100
+
+
+# ---------------------------------------------------------------------------
+# TestFormatExpandedEvents
+# ---------------------------------------------------------------------------
+
+class TestFormatExpandedEvents:
+    """Tests for _format_expanded_events and --expand output mode."""
+
+    def test_basic_expand(self):
+        """Each event is rendered as a JSON block with a header."""
+        results = [_make_search_result(
+            "events",
+            rows=[_make_event_row()],
+        )]
+        output = _format_expanded_events(results)
+        assert "--- 2023-11-14 22:13:20 | event | NEW_PROCESS ---" in output
+        parsed = json.loads(output.split("---\n", 1)[1])
+        assert parsed["routing"]["event_type"] == "NEW_PROCESS"
+
+    def test_expand_multiple_events(self):
+        """Multiple events produce multiple JSON blocks."""
+        results = [_make_search_result(
+            "events",
+            rows=[
+                _make_event_row(event_id="evt-1", ts=1700000000000),
+                _make_event_row(event_id="evt-2", ts=1700003600000),
+            ],
+        )]
+        output = _format_expanded_events(results)
+        # Two header lines.
+        assert output.count("---") >= 4  # 2 headers, each has 2 "---"
+
+    def test_expand_detect_stream(self):
+        """Detect stream events show 'cat' in header."""
+        data = {"cat": "Suspicious PowerShell", "routing": {"event_type": "NEW_PROCESS"}}
+        results = [_make_search_result(
+            "events",
+            rows=[_make_event_row(stream="detect", data=data)],
+        )]
+        output = _format_expanded_events(results)
+        # Header uses routing.event_type first, then cat.
+        assert "NEW_PROCESS" in output.split("\n")[0] or "Suspicious PowerShell" in output.split("\n")[0]
+
+    def test_expand_audit_stream(self):
+        """Audit stream events show 'etype' in header."""
+        data = {"etype": "user_login", "msg": "User logged in"}
+        results = [_make_search_result(
+            "events",
+            rows=[_make_event_row(stream="audit", data=data)],
+        )]
+        output = _format_expanded_events(results)
+        assert "user_login" in output.split("\n")[0]
+
+    def test_expand_skips_non_events(self):
+        """Facets and timeline results are ignored."""
+        results = [
+            _make_search_result("facets", facets=[{"value": "X", "count": 1}]),
+            _make_search_result("timeline", timeseries=[{"ts": 1, "count": 1}]),
+        ]
+        output = _format_expanded_events(results)
+        assert output == ""
+
+    def test_expand_empty_events(self):
+        """No events produces empty string."""
+        results = [_make_search_result("events", rows=[])]
+        output = _format_expanded_events(results)
+        assert output == ""
+
+    def test_expand_null_rows(self):
+        """Null rows (API returns null instead of []) handled gracefully."""
+        results = [{"type": "events", "rows": None, "stats": {}}]
+        output = _format_expanded_events(results)
+        assert output == ""
+
+    def test_expand_missing_mtd(self):
+        """Row with no mtd still renders the data."""
+        results = [_make_search_result(
+            "events",
+            rows=[{"data": {"key": "value"}}],
+        )]
+        output = _format_expanded_events(results)
+        assert "--- event ---" in output
+        assert '"key": "value"' in output
+
+    def test_expand_multi_page(self):
+        """Events from multiple pages are all expanded."""
+        results = [
+            _make_search_result("events", rows=[_make_event_row(event_id="evt-1")]),
+            _make_search_result("facets", facets=[]),
+            _make_search_result("events", rows=[_make_event_row(event_id="evt-2")]),
+        ]
+        output = _format_expanded_events(results)
+        # Two JSON blocks.
+        blocks = [line for line in output.split("\n") if line.startswith("---")]
+        assert len(blocks) == 2
+
+    def test_expand_output_mode(self, capsys):
+        """_output_search_results with expand=True uses expand format."""
+        results = [_make_search_result(
+            "events",
+            rows=[_make_event_row()],
+            stats=_make_stats(),
+        )]
+        ctx = click.Context(click.Command("test"))
+        ctx.obj = _FakeCtxObj(output_format="table")
+        _output_search_results(ctx, results, expand=True)
+        captured = capsys.readouterr()
+        assert "---" in captured.out
+        assert "NEW_PROCESS" in captured.out
+        # Stats on stderr.
+        assert "matched:" in captured.err or "Stats:" in captured.err
+
+    def test_expand_no_events_message(self, capsys):
+        """Expand mode with no events shows 'No events'."""
+        results = [_make_search_result("events", rows=[])]
+        ctx = click.Context(click.Command("test"))
+        ctx.obj = _FakeCtxObj(output_format="table")
+        _output_search_results(ctx, results, expand=True)
+        captured = capsys.readouterr()
+        assert "No events" in captured.out
+
+    def test_expand_ignored_for_json_format(self, capsys):
+        """--expand is ignored for machine-readable formats."""
+        results = [_make_search_result("events", rows=[_make_event_row()])]
+        ctx = click.Context(click.Command("test"))
+        ctx.obj = _FakeCtxObj(output_format="json")
+        _output_search_results(ctx, results, expand=True)
+        captured = capsys.readouterr()
+        parsed = json.loads(captured.out)
+        # Should be raw API format, not expanded.
+        assert isinstance(parsed, list)
+        assert parsed[0]["type"] == "events"


### PR DESCRIPTION
## Details

Improves the `search run` and `search saved-run` commands by unwrapping raw API SearchResult wrapper objects into a clean, human-readable table of events. Previously, the table output showed raw API metadata (searchResultId, nextToken, type, stats) with actual event data collapsed into `[1546 items]`, making it unusable for interactive use.

Now in table mode, events from all pages are flattened into a single table with smart column selection (priority columns first, noisy routing metadata dropped, capped at 15 columns). Machine-readable formats (json, yaml, csv, jsonl) pass through the raw API response unchanged.

### stderr/stdout separation

All progress messages, event counts, and stats summaries are printed to **stderr**, keeping stdout clean for data. This means `limacharlie search run ... > results.txt` captures only the table/data, while progress and stats appear in the terminal. This applies to:
- Progress messages during search execution (query_id, page fetching, waiting for results)
- Event count footer (e.g., `(1,546 events)`)
- Stats summary (matched, scanned, bytes, time, cost)

### New flags

- `--raw`: Show raw API result objects without unwrapping (restores old behavior)
- `--expand`: Show each event as a full pretty-printed JSON block with a `--- timestamp | stream | event_type ---` header, useful for investigating individual events in detail

### Ctrl+C handling

Pressing Ctrl+C during a search automatically sends a DELETE request to cancel the query on the server, freeing resources. A "Canceling search query..." message is shown when in interactive mode.

<details>
<summary>Before (raw API wrapper objects)</summary>

```
searchResultId    created                      type      stats                   nextToken    rows
12345             2026-03-13T16:43:08.467      events    {7 keys}               token-2      [1546 items]
12346             2026-03-13T16:43:08.467      facets    {7 keys}                            [4 items]
12347             2026-03-13T16:43:08.467      timeline  {7 keys}                            [24 items]
```
</details>

<details>
<summary>After (unwrapped event table)</summary>

```
time                 stream    routing.event_type    routing.hostname    event.FILE_PATH       event.COMMAND_LINE
2026-03-13 15:43:08  event     NEW_PROCESS           web-01              /usr/bin/curl          curl https://example.com
2026-03-13 15:43:09  event     DNS_REQUEST           web-01              -                      -
2026-03-13 15:43:10  event     NEW_PROCESS           db-02               /usr/bin/psql          psql -h localhost
...
(1,546 events)
Stats: matched: 1,546, scanned: 50,000, bytes: 2.1 GB, time: 4.2s, cost: $0.0050
```
</details>

<details>
<summary>After with --expand (full JSON per event)</summary>

```
--- 2026-03-13 15:43:08 | event | NEW_PROCESS ---
{
  "routing": {
    "event_type": "NEW_PROCESS",
    "hostname": "web-01",
    ...
  },
  "event": {
    "FILE_PATH": "/usr/bin/curl",
    "COMMAND_LINE": "curl https://example.com"
  }
}
--- 2026-03-13 15:43:09 | event | DNS_REQUEST ---
{
  ...
}
```
</details>

## Changes

### `limacharlie/commands/search.py`
- `_flatten_event_row()`: Flattens SearchResultRow into single-level dict with human-readable timestamps
- `_unwrap_search_results()`: Separates results by type (events/facets/timeseries), only takes stats from "events" type
- `_format_stats_summary()`: Formats stats line with cumulative stats preferred, human-readable byte sizes
- `_limit_event_columns()`: Smart column selection - priority columns first, drop noisy routing metadata, cap at 15
- `_format_expanded_events()`: Formats each event as a JSON block with timestamp/stream/type header
- `_make_progress_fn()`: Returns stderr callback for interactive terminals (TTY + not quiet)
- `_output_search_results()`: Routes to table/expand/raw format, prints event count and stats to stderr
- `run` and `saved-run` commands: Added `--raw`, `--expand` flags, progress_fn, KeyboardInterrupt handling

### `limacharlie/sdk/search.py`
- `execute()`: Added `progress_fn` callback, tracks pages/events/elapsed time
- `_cancel_query()`: Sends DELETE on all exit paths (normal, error, Ctrl+C)
- KeyboardInterrupt handled separately from Exception (not wrapped in SearchError)

### `tests/unit/test_search_output.py`
- 91 tests across 9 test classes covering all new functionality

## Blast radius / isolation

- Only affects `search run` and `search saved-run` CLI commands
- SDK `Search.execute()` gains `progress_fn` parameter (backward compatible, defaults to None)
- No changes to other commands, API contracts, or data formats
- Machine-readable output formats completely unchanged

## Performance characteristics

- No additional API calls (same pagination, same polling)
- Column limiting is O(rows * columns), negligible for typical result sets
- Event flattening is a single pass over rows

## Notable contracts / APIs

- `Search.execute()` now accepts `progress_fn: Callable[[str], None] | None` - callback for progress messages
- `Search._cancel_query()` - always called in finally block to clean up server resources
- No wire format or API contract changes