### PR TITLE
feat: On-disk JWT caching for CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,57 @@
 
 ### Authentication
 
+- **On-disk JWT caching**: JWTs are now cached to disk at
+  `~/.limacharlie_jwt_cache` so that repeated CLI invocations reuse the same
+  token instead of generating a new one each time. This reduces the number of
+  active JWTs, eliminates a ~100-200ms HTTP roundtrip per command, and lowers
+  load on `jwt.limacharlie.io`. Cached tokens are reused until they are within
+  10 minutes of expiry, then a fresh one is fetched and cached automatically.
+
+  The cache works for both API key and OAuth authentication paths. Search
+  commands (`search run`, `search saved-run`) also benefit: if the cached JWT
+  has enough remaining TTL for the requested expiry (default 4 hours), it is
+  reused instead of generating a new long-lived token.
+
+  If the server rejects a cached JWT (401), it is automatically invalidated, a
+  fresh token is fetched, cached, and the request is retried.
+
+  **Cache file security:**
+  - File permissions: 0o600 (owner-only read/write)
+  - Atomic writes via tempfile + `os.replace` (no partial reads)
+  - Symlink rejection on read and write paths (`O_NOFOLLOW` on Unix)
+  - Cross-platform (Linux, macOS, Windows)
+
+  **Disabling the cache:**
+
+  There are three ways to disable JWT caching:
+
+  1. Set the `LC_NO_JWT_CACHE` environment variable:
+     ```bash
+     LC_NO_JWT_CACHE=1 limacharlie sensors list
+     ```
+
+  2. Set `no_jwt_cache: true` in `~/.limacharlie`:
+     ```yaml
+     oid: my-org-id
+     api_key: my-api-key
+     no_jwt_cache: true
+     ```
+
+  3. Use ephemeral credentials mode (also disables config file):
+     ```bash
+     LC_EPHEMERAL_CREDS=1 LC_OID=... LC_API_KEY=... limacharlie sensors list
+     ```
+
+  **Debug logging:**
+
+  Use `--debug` to see cache operations:
+  ```
+  $ limacharlie --debug sensors list
+  2026-03-14 12:00:00Z: JWT cache: checking /home/user/.limacharlie_jwt_cache
+  2026-03-14 12:00:00Z: JWT cache: hit, reusing cached token (expires in 2847s, 47m)
+  ```
+
 - **`auth get-token` command**: New command to generate JWT tokens with custom
   expiry for long-running operations. Supports `--hours` for expiry duration and
   `--format json` for metadata output (token, expiry timestamp, oid).
@@ -32,6 +83,14 @@
 
 - **`get_config_value()` function**: New config helper for reading arbitrary
   config keys with environment-aware lookup.
+
+- **Per-process config caching**: `load_config()` now caches its result for the
+  process lifetime, avoiding repeated YAML parsing when multiple subsystems
+  read the config file.
+
+- **Cross-platform `save_config()`**: Config file writes now use a shared
+  cross-platform `atomic_write` helper, fixing an existing bug on Windows where
+  the Unix-only `os.chown` call would fail.
 
 ## 5.0.0 - February 18th, 2026
 

--- a/cloudbuild_pr.yaml
+++ b/cloudbuild_pr.yaml
@@ -26,6 +26,19 @@ steps:
       pytest -s -v --durations=10 tests/integration/ --oid=${_OID} --key=${_KEY}
   waitFor: ["-"]  # Run in parallel with other steps.
 
+- id: "Run Microbenchmarks"
+  name: "python:3.14"
+  entrypoint: "bash"
+  args:
+    - "-c"
+    - |
+      cp -r /workspace /tmp/src
+      pip install --upgrade pip
+      pip install "/tmp/src[dev]"
+
+      pytest -v --benchmark-only --benchmark-columns=mean,stddev,rounds tests/microbenchmarks/
+  waitFor: ["-"]  # Run in parallel with other steps.
+
 - id: "Run wheel Sanity Checks"
   name: 'python:3.14'
   entrypoint: "bash"

--- a/limacharlie/client.py
+++ b/limacharlie/client.py
@@ -120,9 +120,37 @@ class Client:
         self._api_key = creds["api_key"]
         self._oauth_creds = creds["oauth"]
         self._environment = environment
-        self._jwt = jwt
-        self._is_retry_quota_errors = is_retry_quota_errors
         self._debug_fn = print_debug_fn
+        self._jwt = jwt
+        if self._jwt is None:
+            from .jwt_cache import get_cached_jwt, _get_cache_path, _decode_jwt_exp
+
+            # Mirror the auth path selection in refresh_jwt: if oauth_creds
+            # is set, OAuth path is used regardless of api_key. Pass
+            # credentials accordingly so the cache key matches what
+            # _refresh_jwt_oauth / refresh_jwt will write.
+            if self._oauth_creds is not None:
+                cache_api_key = None
+                cache_oauth = self._oauth_creds
+            else:
+                cache_api_key = self._api_key
+                cache_oauth = None
+            self._debug(f"JWT cache: checking {_get_cache_path()}")
+            self._jwt = get_cached_jwt(
+                self._oid, cache_api_key, cache_oauth, self._uid,
+            )
+            if self._jwt is not None:
+                exp = _decode_jwt_exp(self._jwt)
+                remaining = int(exp - time.time()) if exp else 0
+                self._debug(
+                    f"JWT cache: hit, reusing cached token "
+                    f"(expires in {remaining}s, {remaining // 60}m)"
+                )
+            else:
+                self._debug("JWT cache: miss, will fetch fresh token on first request")
+        else:
+            self._debug("JWT: using pre-generated token, skipping cache")
+        self._is_retry_quota_errors = is_retry_quota_errors
         self._on_refresh_auth = on_refresh_auth
         self._inv_id = inv_id
         self._timeout = timeout
@@ -178,6 +206,11 @@ class Client:
         run for several hours. By default, JWTs expire after ~1 hour.
         For operations that take longer, specify a custom expiry in hours.
 
+        If the currently cached JWT already has enough remaining TTL to
+        cover the requested expiry_hours, it is reused instead of
+        generating a new one. This avoids unnecessary JWT requests when
+        running multiple search commands in sequence.
+
         Args:
             expiry_hours: Token validity duration in hours. If None, uses
                 the default expiry (~1 hour). For long-running search
@@ -202,11 +235,48 @@ class Client:
                 )
             expiry_ts = int(time_module.time()) + int(expiry_hours * 3600)
 
+        # If we already have a JWT (from cache or prior call), check if it
+        # has enough remaining TTL for the requested expiry. If so, reuse it.
+        if self._jwt is not None and expiry_hours is not None:
+            from .jwt_cache import _decode_jwt_exp
+
+            current_exp = _decode_jwt_exp(self._jwt)
+            if current_exp is not None:
+                remaining_hours = (current_exp - time_module.time()) / 3600
+                if remaining_hours >= expiry_hours:
+                    self._debug(
+                        f"JWT: reusing current token "
+                        f"({remaining_hours:.1f}h remaining >= {expiry_hours}h requested)"
+                    )
+                    return self._jwt
+                self._debug(
+                    f"JWT: current token has {remaining_hours:.1f}h remaining, "
+                    f"need {expiry_hours}h, fetching new one"
+                )
+
         self.refresh_jwt(expiry=expiry_ts)
 
         if self._jwt is None:
             from .errors import AuthenticationError
             raise AuthenticationError("Failed to generate JWT token.")
+
+        # Cache the long-lived JWT so subsequent CLI invocations reuse it.
+        # Mirror auth path selection: OAuth takes priority over api_key.
+        if expiry_ts is not None:
+            from .jwt_cache import put_cached_jwt
+
+            self._debug(
+                f"JWT cache: writing long-lived token to disk "
+                f"(requested {expiry_hours}h expiry)"
+            )
+            if self._oauth_creds is not None:
+                put_cached_jwt(
+                    self._jwt, self._oid, None, self._oauth_creds, self._uid
+                )
+            else:
+                put_cached_jwt(
+                    self._jwt, self._oid, self._api_key, None, self._uid
+                )
 
         return self._jwt
 
@@ -236,7 +306,7 @@ class Client:
 
         # Check if we're using OAuth
         if self._oauth_creds is not None:
-            self._refresh_jwt_oauth(effective_oid, expiry)
+            self._refresh_jwt_oauth(effective_oid, expiry, oid_override)
             return
 
         # Traditional API key flow
@@ -257,11 +327,31 @@ class Client:
         )
 
         self._jwt = self._call_jwt_endpoint(auth_data)
+        self._debug("JWT: fetched fresh token from jwt.limacharlie.io")
+
+        if expiry is None and oid_override is None:
+            from .jwt_cache import put_cached_jwt, _decode_jwt_exp
+
+            exp = _decode_jwt_exp(self._jwt)
+            remaining = int(exp - time.time()) if exp else 0
+            self._debug(
+                f"JWT cache: writing token to disk "
+                f"(expires in {remaining}s, {remaining // 60}m)"
+            )
+            put_cached_jwt(
+                self._jwt, effective_oid, self._api_key, self._oauth_creds, self._uid
+            )
+        else:
+            self._debug(
+                f"JWT cache: skipping cache write "
+                f"(expiry={'set' if expiry else 'None'}, "
+                f"oid_override={'set' if oid_override else 'None'})"
+            )
 
         if self._on_refresh_auth is not None:
             self._on_refresh_auth(self)
 
-    def _refresh_jwt_oauth(self, effective_oid: str | None, expiry: int | None) -> None:
+    def _refresh_jwt_oauth(self, effective_oid: str | None, expiry: int | None, oid_override: str | None = None) -> None:
         """Refresh JWT using OAuth credentials."""
         from .oauth_simple import SimpleOAuthManager
 
@@ -292,6 +382,26 @@ class Client:
             auth_data["expiry"] = int(expiry)
 
         self._jwt = self._call_jwt_endpoint(auth_data)
+        self._debug("JWT: fetched fresh OAuth token from jwt.limacharlie.io")
+
+        if expiry is None and oid_override is None:
+            from .jwt_cache import put_cached_jwt, _decode_jwt_exp
+
+            exp = _decode_jwt_exp(self._jwt)
+            remaining = int(exp - time.time()) if exp else 0
+            self._debug(
+                f"JWT cache: writing OAuth token to disk "
+                f"(expires in {remaining}s, {remaining // 60}m)"
+            )
+            put_cached_jwt(
+                self._jwt, effective_oid, None, self._oauth_creds, self._uid
+            )
+        else:
+            self._debug(
+                f"JWT cache: skipping cache write "
+                f"(expiry={'set' if expiry else 'None'}, "
+                f"oid_override={'set' if oid_override else 'None'})"
+            )
 
         if self._on_refresh_auth is not None:
             self._on_refresh_auth(self)
@@ -462,6 +572,18 @@ class Client:
                     break
                 if not is_no_auth:
                     has_auth_refreshed = True
+                    self._debug("JWT cache: 401 received, invalidating cached token")
+                    from .jwt_cache import invalidate_cached_jwt
+
+                    # Mirror auth path selection: OAuth takes priority
+                    if self._oauth_creds is not None:
+                        invalidate_cached_jwt(
+                            self._oid, None, self._oauth_creds, self._uid
+                        )
+                    else:
+                        invalidate_cached_jwt(
+                            self._oid, self._api_key, None, self._uid
+                        )
                     if self._on_refresh_auth is not None:
                         self._on_refresh_auth(self)
                     else:
@@ -542,6 +664,18 @@ class Client:
 
         # Single 401 retry with JWT refresh.
         if code == HTTP_UNAUTHORIZED and not is_no_auth:
+            self._debug("JWT cache: 401 received (raw_request), invalidating cached token")
+            from .jwt_cache import invalidate_cached_jwt
+
+            # Mirror auth path selection: OAuth takes priority
+            if self._oauth_creds is not None:
+                invalidate_cached_jwt(
+                    self._oid, None, self._oauth_creds, self._uid
+                )
+            else:
+                invalidate_cached_jwt(
+                    self._oid, self._api_key, None, self._uid
+                )
             if self._on_refresh_auth is not None:
                 self._on_refresh_auth(self)
             else:

--- a/limacharlie/config.py
+++ b/limacharlie/config.py
@@ -11,15 +11,14 @@ Credential resolution order (highest priority first):
     4. Default credentials in ~/.limacharlie config file
 """
 
+import copy
 import os
-import stat
-import shutil
-import tempfile
 from typing import Any, TypedDict
 
 import yaml
 
 from .errors import ConfigError
+from .file_utils import atomic_write, safe_open_read
 
 
 class Credentials(TypedDict):
@@ -41,6 +40,7 @@ ENV_UID = "LC_UID"
 ENV_CURRENT_ENV = "LC_CURRENT_ENV"
 ENV_CREDS_FILE = "LC_CREDS_FILE"
 ENV_EPHEMERAL_CREDS = "LC_EPHEMERAL_CREDS"
+ENV_NO_JWT_CACHE = "LC_NO_JWT_CACHE"
 
 
 def _get_config_path() -> str:
@@ -53,20 +53,46 @@ def is_ephemeral() -> bool:
     return bool(os.environ.get(ENV_EPHEMERAL_CREDS))
 
 
+# Per-process cache for config file. Each CLI invocation is a separate
+# process, so the config file won't change mid-execution. Avoids
+# repeated disk I/O and YAML parsing when multiple subsystems
+# (resolve_credentials, jwt_cache, etc.) call load_config().
+_cached_config: dict[str, Any] | None = None
+_config_loaded: bool = False
+
+
 def load_config() -> dict[str, Any] | None:
     """Load the config file as a dict.
+
+    Result is cached per-process. The config file does not change
+    mid-execution for a CLI tool, so one read is sufficient.
 
     Returns:
         dict or None if the file does not exist or ephemeral mode is active.
     """
+    global _cached_config, _config_loaded
+    if _config_loaded:
+        return _cached_config
     if is_ephemeral():
+        _cached_config = None
+        _config_loaded = True
         return None
     path = _get_config_path()
     if not os.path.isfile(path):
+        _cached_config = None
+        _config_loaded = True
         return None
-    with open(path, "rb") as f:
-        data = yaml.safe_load(f.read())
-    return data or {}
+    data = yaml.safe_load(safe_open_read(path))
+    _cached_config = data or {}
+    _config_loaded = True
+    return _cached_config
+
+
+def _reset_config_cache() -> None:
+    """Reset the cached config. For testing only."""
+    global _cached_config, _config_loaded
+    _cached_config = None
+    _config_loaded = False
 
 
 def save_config(config: dict[str, Any]) -> None:
@@ -87,21 +113,14 @@ def save_config(config: dict[str, Any]) -> None:
             suggestion="Use environment variables (LC_OID, LC_API_KEY) instead of config files.",
         )
 
+    global _cached_config, _config_loaded
     path = _get_config_path()
     content = yaml.safe_dump(config, default_flow_style=False).encode()
-
-    fd, tmp_path = tempfile.mkstemp()
-    try:
-        os.chown(tmp_path, os.getuid(), os.getgid())
-        os.chmod(tmp_path, stat.S_IWUSR | stat.S_IRUSR)  # 0o600
-        try:
-            os.write(fd, content)
-        finally:
-            os.close(fd)
-        shutil.move(tmp_path, path)
-    finally:
-        if os.path.isfile(tmp_path):
-            os.unlink(tmp_path)
+    atomic_write(path, content)
+    # Update the per-process cache so subsequent load_config() calls
+    # see the new data without re-reading from disk.
+    _cached_config = config
+    _config_loaded = True
 
 
 def get_environment_creds(name: str = "default") -> Credentials:
@@ -216,7 +235,9 @@ def write_credentials(environment: str | None, oid: str | None, api_key: str | N
         uid: user ID (empty string to clear).
         oauth_creds: OAuth credentials dict.
     """
-    config = load_config() or {}
+    # Deep copy so mutations below don't corrupt the per-process
+    # config cache if save_config() later fails.
+    config = copy.deepcopy(load_config() or {})
 
     if environment == "default" or environment is None:
         if oid is not None:

--- a/limacharlie/file_utils.py
+++ b/limacharlie/file_utils.py
@@ -1,0 +1,145 @@
+"""Cross-platform file security and atomic write utilities.
+
+Provides secure file permission management and atomic write operations
+that work across Unix (Linux/macOS) and Windows. Used by config.py and
+jwt_cache.py to safely persist sensitive credential data.
+
+Key invariants:
+- Files written via atomic_write() are never partially written (readers
+  see either the old content or the new content, never a partial state).
+- File permissions are restricted to owner-only access (0o600 on Unix).
+- Symlinks are rejected on read and write paths to prevent symlink attacks
+  where an attacker places a symlink at the expected path to redirect
+  writes to an arbitrary file (e.g. overwriting ~/.ssh/authorized_keys).
+
+Security model:
+- atomic_write() refuses to write through symlinks at the target path.
+- safe_open_read() refuses to read through symlinks.
+- secure_file_permissions() restricts access to owner-only.
+- These mitigations protect against local attackers who can create symlinks
+  in directories writable by the current user (e.g. shared /tmp mounts,
+  misconfigured home directories). They do NOT protect against root-level
+  attackers who can modify the filesystem arbitrarily.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import tempfile
+
+
+def _reject_symlink(path: str) -> None:
+    """Raise if path is a symlink or contains symlinks in parent components.
+
+    Prevents symlink-based attacks where an attacker places a symlink at the
+    expected path to redirect reads/writes to an arbitrary file.
+
+    Only checks the final component and one level of parent. We don't
+    walk the entire path since we trust the OS home directory root.
+
+    Args:
+        path: file path to check.
+
+    Raises:
+        OSError: if path or its immediate parent is a symlink.
+    """
+    if os.path.islink(path):
+        raise OSError(f"Refusing to operate on symlink: {path}")
+    parent = os.path.dirname(path)
+    if parent and os.path.islink(parent):
+        raise OSError(f"Refusing to operate through symlinked directory: {parent}")
+
+
+def secure_file_permissions(path: str) -> None:
+    """Restrict file permissions to owner-only read/write access.
+
+    On Unix: sets mode to 0o600 and chowns to current user/group.
+    On Windows: sets user read/write via os.chmod (limited but functional -
+    Windows home directories are already ACL-restricted by default).
+
+    Args:
+        path: absolute path to the file to secure.
+    """
+    os.chmod(path, stat.S_IRUSR | stat.S_IWUSR)
+    if os.name != "nt":
+        os.chown(path, os.getuid(), os.getgid())
+
+
+def safe_open_read(path: str) -> bytes:
+    """Read a file's contents, rejecting symlinks atomically.
+
+    On Unix, uses O_NOFOLLOW to atomically reject symlinks at open time,
+    preventing TOCTOU races where an attacker swaps a regular file for a
+    symlink between the check and the open. On Windows, falls back to a
+    pre-check (symlinks require admin privileges on Windows, so the
+    TOCTOU window is not exploitable in practice).
+
+    Args:
+        path: absolute path to the file to read.
+
+    Returns:
+        File contents as bytes.
+
+    Raises:
+        OSError: if path is a symlink or doesn't exist.
+    """
+    _reject_symlink(path)
+    if os.name != "nt" and hasattr(os, "O_NOFOLLOW"):
+        # O_NOFOLLOW makes the kernel reject symlinks atomically,
+        # closing the TOCTOU window between _reject_symlink and open.
+        fd = os.open(path, os.O_RDONLY | os.O_NOFOLLOW)
+        try:
+            # os.fdopen takes ownership of fd on success and will close
+            # it when the file object is closed.
+            with os.fdopen(fd, "rb") as f:
+                return f.read()
+        except Exception:
+            # If os.fdopen fails before taking ownership, close fd manually
+            # to prevent a leak. Use try/except since fd may already be
+            # closed if fdopen partially succeeded.
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+            raise
+    else:
+        with open(path, "rb") as f:
+            return f.read()
+
+
+def atomic_write(path: str, content: bytes) -> None:
+    """Atomically write content to a file with secure permissions.
+
+    Writes to a temporary file in the same directory, sets secure
+    permissions, then atomically moves into place via os.replace().
+    This prevents readers from seeing partial content on all platforms
+    (os.replace is atomic on both POSIX and Windows).
+
+    Refuses to write if the target path is a symlink, to prevent
+    symlink attacks that redirect writes to arbitrary files.
+
+    Args:
+        path: absolute path to the destination file.
+        content: bytes to write.
+
+    Raises:
+        OSError: if path is a symlink.
+    """
+    _reject_symlink(path)
+    parent = os.path.dirname(path) or "."
+    fd, tmp_path = tempfile.mkstemp(dir=parent)
+    try:
+        try:
+            secure_file_permissions(tmp_path)
+            os.write(fd, content)
+        finally:
+            os.close(fd)
+        os.replace(tmp_path, path)
+    finally:
+        # Clean up temp file if it still exists (replace succeeded = gone,
+        # but if an error happened before replace, it may still be here).
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass

--- a/limacharlie/jwt_cache.py
+++ b/limacharlie/jwt_cache.py
@@ -1,0 +1,334 @@
+"""On-disk JWT caching for LimaCharlie CLI.
+
+Caches JWTs to disk so that repeated CLI invocations within the same
+hour reuse a single JWT instead of requesting a new one each time.
+Each invocation is a separate process, so caching must be file-based.
+
+Cache file location:
+- Default: ~/.limacharlie_jwt_cache (sibling to ~/.limacharlie config)
+- Respects LC_CREDS_FILE: if config is at /foo/bar, cache goes to /foo/bar_jwt_cache
+- Respects LC_EPHEMERAL_CREDS: no disk caching when set
+- Respects LC_NO_JWT_CACHE: no disk caching when set
+- Respects no_jwt_cache config option: no disk caching when true
+
+Format: JSON dict keyed by SHA-256 hash of credential identity.
+
+Concurrency model: last-write-wins with atomic writes (tempfile + move).
+No file locking. Worst case on concurrent access is a redundant JWT request.
+
+Expiry buffer: 10 minutes. A cached JWT is only reused if it has more
+than 10 minutes remaining before expiration.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import os
+import time
+from typing import Any
+
+from .config import ENV_CREDS_FILE, ENV_EPHEMERAL_CREDS, ENV_NO_JWT_CACHE, CONFIG_FILE_PATH, load_config
+from .file_utils import atomic_write, safe_open_read
+
+# Cached JWT must have at least this many seconds remaining to be reused.
+_EXPIRY_BUFFER_SECONDS = 600  # 10 minutes
+
+# Per-process cache for the disabled check. Each CLI invocation is a
+# separate process, so evaluating once is sufficient - the config file
+# and env vars won't change mid-process. Avoids repeated YAML parsing.
+_cache_disabled: bool | None = None
+
+
+def _is_cache_disabled() -> bool:
+    """Check if JWT caching is disabled via env var or config file.
+
+    Result is cached for the process lifetime to avoid repeated disk I/O
+    and YAML parsing. Each CLI invocation is a fresh process so
+    re-evaluation is unnecessary.
+
+    Note: load_config() itself is also per-process cached, so even the
+    first call here doesn't cause a redundant YAML parse if
+    resolve_credentials() already loaded the config.
+
+    Caching is disabled when any of:
+    - LC_NO_JWT_CACHE env var is set (any truthy value)
+    - LC_EPHEMERAL_CREDS env var is set
+    - no_jwt_cache: true in the config file
+
+    Returns:
+        True if caching should be skipped.
+    """
+    global _cache_disabled
+    if _cache_disabled is not None:
+        return _cache_disabled
+
+    if os.environ.get(ENV_EPHEMERAL_CREDS):
+        _cache_disabled = True
+        return True
+    if os.environ.get(ENV_NO_JWT_CACHE):
+        _cache_disabled = True
+        return True
+    try:
+        config = load_config()
+        if config and config.get("no_jwt_cache"):
+            _cache_disabled = True
+            return True
+    except Exception:
+        pass
+    _cache_disabled = False
+    return False
+
+
+def _reset_cache_disabled() -> None:
+    """Reset the cached disabled state. For testing only."""
+    global _cache_disabled
+    _cache_disabled = None
+
+
+def _get_cache_path() -> str:
+    """Derive the JWT cache file path from the config file path.
+
+    Returns:
+        Absolute path to the JWT cache file.
+    """
+    config_path = os.environ.get(ENV_CREDS_FILE, CONFIG_FILE_PATH)
+    return config_path + "_jwt_cache"
+
+
+def _compute_cache_key(
+    oid: str | None,
+    api_key: str | None,
+    oauth_creds: dict[str, str] | None,
+    uid: str | None,
+) -> str | None:
+    """Compute a SHA-256 cache key from credential identity.
+
+    Returns None if there is insufficient credential information
+    to form a meaningful cache key.
+
+    Uses null byte as separator to prevent collisions from values
+    containing the delimiter (e.g. oid="a:b" + key="c" vs
+    oid="a" + key="b:c" would collide with ":" but not with "\\0").
+
+    Args:
+        oid: organization ID.
+        api_key: API key (for API key auth path).
+        oauth_creds: OAuth credentials dict (for OAuth auth path).
+        uid: user ID.
+
+    Returns:
+        Hex-encoded SHA-256 hash string, or None.
+    """
+    if oid is None:
+        return None
+
+    # Tag with auth method to prevent collisions between API key and
+    # OAuth paths (e.g. if an api_key UUID happens to equal a
+    # refresh_token UUID, they must not share a cache entry).
+    parts = [oid]
+    if api_key is not None:
+        parts.append("apikey")
+        parts.append(api_key)
+        if uid is not None:
+            parts.append(uid)
+    elif oauth_creds is not None:
+        parts.append("oauth")
+        refresh_token = oauth_creds.get("refresh_token", "")
+        parts.append(refresh_token)
+    else:
+        return None
+
+    return hashlib.sha256("\0".join(parts).encode()).hexdigest()
+
+
+def _decode_jwt_exp(jwt_str: str) -> float | None:
+    """Extract the exp claim from a JWT without signature verification.
+
+    Decodes only the payload (middle segment) via base64url to read
+    the expiration timestamp.
+
+    Args:
+        jwt_str: the JWT string (header.payload.signature).
+
+    Returns:
+        The exp claim as a float, or None if parsing fails.
+    """
+    try:
+        parts = jwt_str.split(".")
+        if len(parts) != 3:
+            return None
+        payload_b64 = parts[1]
+        # Add padding if needed for base64url
+        padding = 4 - len(payload_b64) % 4
+        if padding != 4:
+            payload_b64 += "=" * padding
+        payload_bytes = base64.urlsafe_b64decode(payload_b64)
+        payload = json.loads(payload_bytes)
+        exp = payload.get("exp")
+        if exp is None:
+            return None
+        return float(exp)
+    except Exception:
+        return None
+
+
+def _load_cache() -> dict[str, Any]:
+    """Load the cache file as a dict.
+
+    Uses safe_open_read to reject symlinks at the cache path,
+    preventing symlink attacks that could feed arbitrary data.
+
+    Returns:
+        Cache dict, or empty dict on any error (including symlink rejection).
+    """
+    try:
+        path = _get_cache_path()
+        if not os.path.isfile(path):
+            return {}
+        raw = safe_open_read(path)
+        data = json.loads(raw)
+        if not isinstance(data, dict):
+            return {}
+        return data
+    except Exception:
+        return {}
+
+
+def _save_cache(cache: dict[str, Any]) -> None:
+    """Write the cache dict to disk atomically. Best-effort, never raises.
+
+    Args:
+        cache: the full cache dict to persist.
+    """
+    try:
+        path = _get_cache_path()
+        parent = os.path.dirname(path)
+        if parent and not os.path.isdir(parent):
+            os.makedirs(parent, exist_ok=True)
+        content = json.dumps(cache).encode()
+        atomic_write(path, content)
+    except Exception:
+        pass
+
+
+def get_cached_jwt(
+    oid: str | None,
+    api_key: str | None,
+    oauth_creds: dict[str, str] | None,
+    uid: str | None,
+) -> str | None:
+    """Return a cached JWT if one exists and is still valid.
+
+    A JWT is considered valid if it has more than 10 minutes remaining
+    before expiration (the _EXPIRY_BUFFER_SECONDS constant).
+
+    Args:
+        oid: organization ID.
+        api_key: API key.
+        oauth_creds: OAuth credentials dict.
+        uid: user ID.
+
+    Returns:
+        The cached JWT string, or None if no valid cache entry exists.
+    """
+    if _is_cache_disabled():
+        return None
+
+    cache_key = _compute_cache_key(oid, api_key, oauth_creds, uid)
+    if cache_key is None:
+        return None
+
+    cache = _load_cache()
+    entry = cache.get(cache_key)
+    if not isinstance(entry, dict):
+        return None
+
+    jwt_str = entry.get("jwt")
+    if not isinstance(jwt_str, str):
+        return None
+
+    exp = _decode_jwt_exp(jwt_str)
+    if exp is None:
+        return None
+
+    if time.time() + _EXPIRY_BUFFER_SECONDS >= exp:
+        return None
+
+    return jwt_str
+
+
+def put_cached_jwt(
+    jwt_str: str,
+    oid: str | None,
+    api_key: str | None,
+    oauth_creds: dict[str, str] | None,
+    uid: str | None,
+) -> None:
+    """Write a JWT to the disk cache.
+
+    No-op when caching is disabled (LC_EPHEMERAL_CREDS, LC_NO_JWT_CACHE,
+    or no_jwt_cache config option), when the JWT has no parseable exp
+    claim, or when insufficient credential information is available.
+
+    Args:
+        jwt_str: the JWT string to cache.
+        oid: organization ID.
+        api_key: API key.
+        oauth_creds: OAuth credentials dict.
+        uid: user ID.
+    """
+    if _is_cache_disabled():
+        return
+
+    cache_key = _compute_cache_key(oid, api_key, oauth_creds, uid)
+    if cache_key is None:
+        return
+
+    exp = _decode_jwt_exp(jwt_str)
+    if exp is None:
+        return
+
+    cache = _load_cache()
+    cache[cache_key] = {"jwt": jwt_str}
+    _save_cache(cache)
+
+
+def invalidate_cached_jwt(
+    oid: str | None,
+    api_key: str | None,
+    oauth_creds: dict[str, str] | None,
+    uid: str | None,
+) -> None:
+    """Remove a specific JWT entry from the cache.
+
+    No-op if the entry does not exist or the cache file is missing.
+
+    Args:
+        oid: organization ID.
+        api_key: API key.
+        oauth_creds: OAuth credentials dict.
+        uid: user ID.
+    """
+    cache_key = _compute_cache_key(oid, api_key, oauth_creds, uid)
+    if cache_key is None:
+        return
+
+    cache = _load_cache()
+    if cache_key in cache:
+        del cache[cache_key]
+        _save_cache(cache)
+
+
+def clear_jwt_cache() -> None:
+    """Delete the entire JWT cache file.
+
+    No-op if the file does not exist. Used by 'auth logout'.
+    """
+    try:
+        path = _get_cache_path()
+        if os.path.isfile(path):
+            os.unlink(path)
+    except Exception:
+        pass

--- a/limacharlie/sdk/spout.py
+++ b/limacharlie/sdk/spout.py
@@ -127,6 +127,15 @@ class Spout:
                 self._conn.raw._fp.fp.raw.close()
             except Exception:
                 pass
+            # Close the Response object itself so the iter_lines/iter_content
+            # generator is torn down cleanly.  Without this, GC finalization
+            # of the generator triggers urllib3's _error_catcher which tries
+            # to flush an already-closed socket, causing a ValueError warning
+            # on Python 3.14+.
+            try:
+                self._conn.close()
+            except Exception:
+                pass
             self._conn = None
         for t in self._threads:
             t.join(timeout=2)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
 dev = [
     "pytest==8.3.4",
     "pytest-rerunfailures==15.0",
+    "pytest-benchmark>=5.0.0",
     "tomli>=1.0; python_version < '3.11'",
 ]
 

--- a/tests/integration/test_jwt_cache_end_to_end.py
+++ b/tests/integration/test_jwt_cache_end_to_end.py
@@ -1,0 +1,473 @@
+"""End-to-end integration tests for JWT caching with real files and mock HTTP.
+
+These tests simulate real CLI usage patterns with:
+- Real config files written to temp directories via save_config()
+- Real JWT cache files on disk
+- Real Client() instantiation with full credential resolution
+- Mock HTTP server for jwt.limacharlie.io and api.limacharlie.io
+- Real file permission checks
+- Real atomic write / symlink protection
+
+Each test simulates a multi-command user session as separate process-like
+invocations (new Client per "command", caches reset between "processes").
+
+Run with:
+    pytest tests/integration/test_jwt_cache_end_to_end.py --oid dummy --key dummy -v
+"""
+
+import base64
+import json
+import os
+import stat
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from limacharlie.client import Client
+from limacharlie.config import (
+    save_config,
+    load_config,
+    _reset_config_cache,
+)
+from limacharlie.jwt_cache import (
+    _get_cache_path,
+    _reset_cache_disabled,
+    clear_jwt_cache,
+    get_cached_jwt,
+    put_cached_jwt,
+    invalidate_cached_jwt,
+)
+
+
+def _make_jwt(exp: float, extra: dict | None = None) -> str:
+    """Create a minimal JWT with a given exp claim."""
+    header = base64.urlsafe_b64encode(
+        json.dumps({"alg": "HS256"}).encode()
+    ).rstrip(b"=")
+    payload_data = {"exp": exp}
+    if extra:
+        payload_data.update(extra)
+    payload = base64.urlsafe_b64encode(
+        json.dumps(payload_data).encode()
+    ).rstrip(b"=")
+    sig = base64.urlsafe_b64encode(b"sig").rstrip(b"=")
+    return f"{header.decode()}.{payload.decode()}.{sig.decode()}"
+
+
+class _Handler(BaseHTTPRequestHandler):
+    """Mock HTTP handler tracking call counts per-method."""
+
+    jwt_to_return = ""
+    api_response = {"ok": True}
+    jwt_call_count = 0
+    api_call_count = 0
+    force_401_once = False
+    lock = threading.Lock()
+
+    @classmethod
+    def reset(cls):
+        with cls.lock:
+            cls.jwt_call_count = 0
+            cls.api_call_count = 0
+            cls.force_401_once = False
+
+    def do_POST(self):
+        with self.lock:
+            _Handler.jwt_call_count += 1
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(json.dumps({"jwt": self.jwt_to_return}).encode())
+
+    def do_GET(self):
+        with self.lock:
+            _Handler.api_call_count += 1
+            if _Handler.force_401_once:
+                _Handler.force_401_once = False
+                self.send_error(401, "Unauthorized")
+                return
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(json.dumps(self.api_response).encode())
+
+    def log_message(self, format, *args):
+        pass
+
+
+@pytest.fixture(scope="module")
+def server():
+    """Single mock HTTP server for the module."""
+    srv = HTTPServer(("127.0.0.1", 0), _Handler)
+    port = srv.server_address[1]
+    t = threading.Thread(target=srv.serve_forever, daemon=True)
+    t.start()
+    yield f"http://127.0.0.1:{port}"
+    srv.shutdown()
+
+
+@pytest.fixture(autouse=True)
+def env(monkeypatch, tmp_path):
+    """Fully isolated environment per test."""
+    config_path = str(tmp_path / ".limacharlie")
+    monkeypatch.setattr("limacharlie.jwt_cache.CONFIG_FILE_PATH", config_path)
+    monkeypatch.setattr("limacharlie.config.CONFIG_FILE_PATH", config_path)
+    for var in ("LC_CREDS_FILE", "LC_EPHEMERAL_CREDS", "LC_NO_JWT_CACHE",
+                "LC_OID", "LC_API_KEY", "LC_UID", "LC_CURRENT_ENV"):
+        monkeypatch.delenv(var, raising=False)
+    _reset_cache_disabled()
+    _reset_config_cache()
+    _Handler.reset()
+    yield tmp_path
+    _reset_cache_disabled()
+    _reset_config_cache()
+
+
+def _new_process():
+    """Simulate a new CLI process by resetting per-process caches."""
+    _reset_config_cache()
+    _reset_cache_disabled()
+
+
+# ---------------------------------------------------------------------------
+# Scenario tests: simulate realistic multi-command user sessions
+# ---------------------------------------------------------------------------
+
+
+class TestUserSessionApiKey:
+    """Simulate a user session using API key credentials across multiple
+    CLI commands, each as a separate 'process'."""
+
+    def test_login_then_three_commands(self, server):
+        """auth login -> sensors list -> rules list -> search run.
+
+        First command fetches JWT and caches it.
+        Second and third commands reuse cached JWT (zero HTTP to jwt endpoint).
+        """
+        # Step 1: User logs in (writes config file)
+        save_config({"oid": "my-org", "api_key": "my-key-123"})
+
+        jwt = _make_jwt(time.time() + 3600)
+        _Handler.jwt_to_return = jwt
+
+        # Step 2: First command (e.g. sensors list) - cache miss
+        _new_process()
+        _Handler.reset()
+        with patch("limacharlie.client.JWT_URL", server), \
+             patch("limacharlie.client.ROOT_URL", server):
+            c1 = Client()
+            assert c1._jwt is None  # no cache yet
+            result = c1.request("GET", "sensors")
+            assert result == {"ok": True}
+        assert _Handler.jwt_call_count == 1
+        assert _Handler.api_call_count == 1
+
+        # Step 3: Second command (e.g. rules list) - cache hit
+        _new_process()
+        _Handler.reset()
+        with patch("limacharlie.client.JWT_URL", server), \
+             patch("limacharlie.client.ROOT_URL", server):
+            c2 = Client()
+            assert c2._jwt == jwt  # from cache
+            result = c2.request("GET", "rules")
+            assert result == {"ok": True}
+        assert _Handler.jwt_call_count == 0  # no JWT fetch
+        assert _Handler.api_call_count == 1
+
+        # Step 4: Third command - still cache hit
+        _new_process()
+        _Handler.reset()
+        with patch("limacharlie.client.JWT_URL", server), \
+             patch("limacharlie.client.ROOT_URL", server):
+            c3 = Client()
+            assert c3._jwt == jwt
+            result = c3.request("GET", "search")
+            assert result == {"ok": True}
+        assert _Handler.jwt_call_count == 0
+        assert _Handler.api_call_count == 1
+
+    def test_stale_cached_jwt_401_recovery(self, server):
+        """Cached JWT is valid locally but server rejects it (401).
+
+        Must invalidate cache, fetch fresh JWT, cache it, and succeed.
+        """
+        save_config({"oid": "my-org", "api_key": "my-key-123"})
+
+        stale_jwt = _make_jwt(time.time() + 3600)
+        fresh_jwt = _make_jwt(time.time() + 7200, extra={"v": 2})
+        _Handler.jwt_to_return = stale_jwt
+
+        # Prime cache
+        with patch("limacharlie.client.JWT_URL", server), \
+             patch("limacharlie.client.ROOT_URL", server):
+            Client().request("GET", "test")
+
+        # Simulate server revoking the token
+        _new_process()
+        _Handler.reset()
+        _Handler.jwt_to_return = fresh_jwt
+        _Handler.force_401_once = True
+
+        with patch("limacharlie.client.JWT_URL", server), \
+             patch("limacharlie.client.ROOT_URL", server):
+            c = Client()
+            assert c._jwt == stale_jwt  # from cache
+            result = c.request("GET", "test")
+            assert result == {"ok": True}
+            assert c._jwt == fresh_jwt  # refreshed
+
+        assert _Handler.jwt_call_count == 1  # fetched fresh
+        assert _Handler.api_call_count == 2  # 401 + retry
+
+        # Next command should use the fresh JWT from cache
+        _new_process()
+        _Handler.reset()
+        with patch("limacharlie.client.JWT_URL", server), \
+             patch("limacharlie.client.ROOT_URL", server):
+            c2 = Client()
+            assert c2._jwt == fresh_jwt
+
+    def test_logout_clears_cache(self, server):
+        """auth logout clears the cache, next command must re-authenticate."""
+        save_config({"oid": "my-org", "api_key": "my-key-123"})
+
+        jwt1 = _make_jwt(time.time() + 3600)
+        jwt2 = _make_jwt(time.time() + 7200)
+        _Handler.jwt_to_return = jwt1
+
+        # Login + first command
+        with patch("limacharlie.client.JWT_URL", server), \
+             patch("limacharlie.client.ROOT_URL", server):
+            Client().request("GET", "test")
+
+        # Logout (clear cache)
+        clear_jwt_cache()
+        assert not os.path.isfile(_get_cache_path())
+
+        # Next command: must fetch fresh JWT
+        _new_process()
+        _Handler.reset()
+        _Handler.jwt_to_return = jwt2
+        with patch("limacharlie.client.JWT_URL", server), \
+             patch("limacharlie.client.ROOT_URL", server):
+            c = Client()
+            assert c._jwt is None  # cache cleared
+            c.request("GET", "test")
+        assert _Handler.jwt_call_count == 1
+
+    def test_multiple_environments(self, server):
+        """Different environments get separate cache entries."""
+        save_config({
+            "oid": "default-org",
+            "api_key": "default-key",
+            "env": {
+                "staging": {"oid": "staging-org", "api_key": "staging-key"},
+            },
+        })
+
+        jwt_default = _make_jwt(time.time() + 3600, extra={"env": "default"})
+        jwt_staging = _make_jwt(time.time() + 3600, extra={"env": "staging"})
+
+        # Command in default environment
+        _Handler.jwt_to_return = jwt_default
+        with patch("limacharlie.client.JWT_URL", server), \
+             patch("limacharlie.client.ROOT_URL", server):
+            Client().request("GET", "test")
+
+        # Command in staging environment
+        _new_process()
+        _Handler.jwt_to_return = jwt_staging
+        with patch("limacharlie.client.JWT_URL", server), \
+             patch("limacharlie.client.ROOT_URL", server):
+            Client(environment="staging").request("GET", "test")
+
+        # Both cached independently
+        _new_process()
+        _Handler.reset()
+        with patch("limacharlie.client.JWT_URL", server), \
+             patch("limacharlie.client.ROOT_URL", server):
+            c_default = Client()
+            assert c_default._jwt == jwt_default
+            c_staging = Client(environment="staging")
+            assert c_staging._jwt == jwt_staging
+        assert _Handler.jwt_call_count == 0  # both from cache
+
+
+class TestUserSessionEnvVars:
+    """Simulate a user session using environment variable credentials."""
+
+    def test_env_var_credentials_cached(self, server, monkeypatch):
+        """LC_OID + LC_API_KEY flow uses cache correctly."""
+        monkeypatch.setenv("LC_OID", "env-org")
+        monkeypatch.setenv("LC_API_KEY", "env-key")
+
+        jwt = _make_jwt(time.time() + 3600)
+        _Handler.jwt_to_return = jwt
+
+        # First command: cache miss
+        with patch("limacharlie.client.JWT_URL", server), \
+             patch("limacharlie.client.ROOT_URL", server):
+            c1 = Client()
+            c1.request("GET", "test")
+        assert _Handler.jwt_call_count == 1
+
+        # Second command: cache hit
+        _new_process()
+        _Handler.reset()
+        with patch("limacharlie.client.JWT_URL", server), \
+             patch("limacharlie.client.ROOT_URL", server):
+            c2 = Client()
+            assert c2._jwt == jwt
+            c2.request("GET", "test")
+        assert _Handler.jwt_call_count == 0
+
+
+class TestCacheDisabling:
+    """Verify all cache disabling mechanisms work end-to-end."""
+
+    def test_lc_no_jwt_cache_env_var(self, server, monkeypatch):
+        """LC_NO_JWT_CACHE=1 prevents any cache file from being created."""
+        monkeypatch.setenv("LC_NO_JWT_CACHE", "1")
+        _reset_cache_disabled()
+        save_config({"oid": "my-org", "api_key": "my-key"})
+        _Handler.jwt_to_return = _make_jwt(time.time() + 3600)
+
+        with patch("limacharlie.client.JWT_URL", server), \
+             patch("limacharlie.client.ROOT_URL", server):
+            Client().request("GET", "test")
+
+        assert not os.path.isfile(_get_cache_path())
+
+    def test_no_jwt_cache_config_option(self, server):
+        """no_jwt_cache: true in config prevents caching."""
+        save_config({"oid": "my-org", "api_key": "my-key", "no_jwt_cache": True})
+        _Handler.jwt_to_return = _make_jwt(time.time() + 3600)
+
+        with patch("limacharlie.client.JWT_URL", server), \
+             patch("limacharlie.client.ROOT_URL", server):
+            Client().request("GET", "test")
+
+        assert not os.path.isfile(_get_cache_path())
+
+    def test_lc_ephemeral_creds(self, server, monkeypatch):
+        """LC_EPHEMERAL_CREDS prevents caching (and config loading)."""
+        monkeypatch.setenv("LC_EPHEMERAL_CREDS", "1")
+        monkeypatch.setenv("LC_OID", "eph-org")
+        monkeypatch.setenv("LC_API_KEY", "eph-key")
+        _reset_cache_disabled()
+        _Handler.jwt_to_return = _make_jwt(time.time() + 3600)
+
+        with patch("limacharlie.client.JWT_URL", server), \
+             patch("limacharlie.client.ROOT_URL", server):
+            Client().request("GET", "test")
+
+        assert not os.path.isfile(_get_cache_path())
+
+
+class TestSearchTokenReuse:
+    """End-to-end tests for the search command token reuse optimization."""
+
+    def test_two_search_runs_reuse_long_lived_jwt(self, server):
+        """First search run generates 4h JWT, second reuses it."""
+        save_config({"oid": "my-org", "api_key": "my-key"})
+        long_jwt = _make_jwt(time.time() + 5 * 3600)
+        _Handler.jwt_to_return = long_jwt
+
+        # First search run: get_jwt(4h) - must fetch
+        with patch("limacharlie.client.JWT_URL", server), \
+             patch("limacharlie.client.ROOT_URL", server):
+            c1 = Client()
+            result1 = c1.get_jwt(expiry_hours=4.0)
+            assert result1 == long_jwt
+        assert _Handler.jwt_call_count == 1
+
+        # Second search run (new process): get_jwt(4h) - should reuse
+        _new_process()
+        _Handler.reset()
+        with patch("limacharlie.client.JWT_URL", server), \
+             patch("limacharlie.client.ROOT_URL", server):
+            c2 = Client()
+            result2 = c2.get_jwt(expiry_hours=4.0)
+            assert result2 == long_jwt
+        assert _Handler.jwt_call_count == 0  # reused from cache
+
+    def test_search_after_regular_command_fetches_longer_jwt(self, server):
+        """Regular command caches 1h JWT, search needs 4h so fetches new one."""
+        save_config({"oid": "my-org", "api_key": "my-key"})
+        short_jwt = _make_jwt(time.time() + 3600)  # 1h
+        long_jwt = _make_jwt(time.time() + 5 * 3600)  # 5h
+
+        # Regular command: caches 1h JWT
+        _Handler.jwt_to_return = short_jwt
+        with patch("limacharlie.client.JWT_URL", server), \
+             patch("limacharlie.client.ROOT_URL", server):
+            Client().request("GET", "sensors")
+
+        # Search run: needs 4h, cached has only 1h, must fetch new
+        _new_process()
+        _Handler.reset()
+        _Handler.jwt_to_return = long_jwt
+        with patch("limacharlie.client.JWT_URL", server), \
+             patch("limacharlie.client.ROOT_URL", server):
+            c = Client()
+            assert c._jwt == short_jwt  # loaded from cache
+            result = c.get_jwt(expiry_hours=4.0)
+            assert result == long_jwt  # fetched new
+        assert _Handler.jwt_call_count == 1
+
+        # Subsequent regular command uses the long-lived JWT from cache
+        _new_process()
+        _Handler.reset()
+        with patch("limacharlie.client.JWT_URL", server), \
+             patch("limacharlie.client.ROOT_URL", server):
+            c2 = Client()
+            assert c2._jwt == long_jwt
+        assert _Handler.jwt_call_count == 0
+
+
+class TestFileSecurityE2E:
+    """Verify file security properties in realistic usage."""
+
+    def test_cache_file_permissions_after_request(self, server):
+        save_config({"oid": "my-org", "api_key": "my-key"})
+        _Handler.jwt_to_return = _make_jwt(time.time() + 3600)
+
+        with patch("limacharlie.client.JWT_URL", server), \
+             patch("limacharlie.client.ROOT_URL", server):
+            Client().request("GET", "test")
+
+        path = _get_cache_path()
+        assert os.path.isfile(path)
+        mode = os.stat(path).st_mode
+        assert mode & 0o777 == 0o600
+
+    def test_config_file_permissions_after_save(self):
+        save_config({"oid": "test"})
+        from limacharlie.config import _get_config_path
+        mode = os.stat(_get_config_path()).st_mode
+        assert mode & 0o777 == 0o600
+
+    @pytest.mark.skipif(os.name == "nt", reason="Unix-only symlink test")
+    def test_symlink_at_cache_path_rejected(self, server, tmp_path):
+        """Attacker places symlink at cache path. Write must not follow it."""
+        save_config({"oid": "my-org", "api_key": "my-key"})
+        _Handler.jwt_to_return = _make_jwt(time.time() + 3600)
+
+        target = str(tmp_path / "attacker_target")
+        with open(target, "w") as f:
+            f.write("original")
+
+        cache_path = _get_cache_path()
+        os.symlink(target, cache_path)
+
+        with patch("limacharlie.client.JWT_URL", server), \
+             patch("limacharlie.client.ROOT_URL", server):
+            Client().request("GET", "test")
+
+        # Target file must NOT have been overwritten
+        with open(target, "r") as f:
+            assert f.read() == "original"

--- a/tests/integration/test_jwt_cache_integration.py
+++ b/tests/integration/test_jwt_cache_integration.py
@@ -1,0 +1,453 @@
+"""Integration tests for JWT disk caching with mock JWT and API servers.
+
+Spins up a local HTTP server that mocks both the JWT endpoint
+(jwt.limacharlie.io) and the API endpoint (api.limacharlie.io).
+Verifies the full Client lifecycle: cache miss -> JWT fetch -> cache write
+-> subsequent Client uses cached JWT -> 401 invalidates cache, etc.
+
+These tests exercise the real code path end-to-end (Client, jwt_cache,
+file_utils, config) with only the HTTP endpoints mocked.
+"""
+
+import base64
+import json
+import os
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from unittest.mock import patch
+
+import pytest
+
+from limacharlie.client import Client
+from limacharlie.jwt_cache import (
+    _get_cache_path,
+    _reset_cache_disabled,
+    clear_jwt_cache,
+    get_cached_jwt,
+)
+
+
+def _make_jwt(exp: float, oid: str = "test-oid") -> str:
+    """Create a minimal JWT with exp claim."""
+    header = base64.urlsafe_b64encode(
+        json.dumps({"alg": "HS256"}).encode()
+    ).rstrip(b"=")
+    payload = base64.urlsafe_b64encode(
+        json.dumps({"exp": exp, "oid": oid}).encode()
+    ).rstrip(b"=")
+    sig = base64.urlsafe_b64encode(b"sig").rstrip(b"=")
+    return f"{header.decode()}.{payload.decode()}.{sig.decode()}"
+
+
+class MockHandler(BaseHTTPRequestHandler):
+    """HTTP handler that mocks JWT and API endpoints.
+
+    Class-level attributes control behavior:
+    - jwt_to_return: JWT string to return from POST /
+    - api_response: dict to return from API calls
+    - jwt_call_count: number of JWT requests received
+    - api_call_count: number of API requests received
+    - force_401_once: if True, return 401 on next API call then reset
+    """
+
+    jwt_to_return = ""
+    api_response = {"ok": True}
+    jwt_call_count = 0
+    api_call_count = 0
+    force_401_once = False
+    lock = threading.Lock()
+
+    def do_POST(self):
+        """Handle JWT endpoint (POST /)."""
+        with self.lock:
+            MockHandler.jwt_call_count += 1
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(json.dumps({"jwt": self.jwt_to_return}).encode())
+
+    def do_GET(self):
+        """Handle API endpoint (GET /v1/...)."""
+        with self.lock:
+            MockHandler.api_call_count += 1
+            if MockHandler.force_401_once:
+                MockHandler.force_401_once = False
+                self.send_error(401, "Unauthorized")
+                return
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(json.dumps(self.api_response).encode())
+
+    def log_message(self, format, *args):
+        """Suppress request logging noise in test output."""
+        pass
+
+
+@pytest.fixture
+def mock_server():
+    """Start a mock HTTP server on a random port."""
+    server = HTTPServer(("127.0.0.1", 0), MockHandler)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    yield f"http://127.0.0.1:{port}"
+    server.shutdown()
+
+
+@pytest.fixture
+def cache_env(monkeypatch, tmp_path):
+    """Set up isolated cache environment with fresh temp paths."""
+    from limacharlie.config import _reset_config_cache
+    config_path = str(tmp_path / ".limacharlie")
+    monkeypatch.setattr("limacharlie.jwt_cache.CONFIG_FILE_PATH", config_path)
+    monkeypatch.setattr("limacharlie.config.CONFIG_FILE_PATH", config_path)
+    monkeypatch.delenv("LC_CREDS_FILE", raising=False)
+    monkeypatch.delenv("LC_EPHEMERAL_CREDS", raising=False)
+    monkeypatch.delenv("LC_NO_JWT_CACHE", raising=False)
+    _reset_cache_disabled()
+    _reset_config_cache()
+    yield tmp_path
+    _reset_cache_disabled()
+    _reset_config_cache()
+
+
+class TestJwtCacheE2E:
+    """End-to-end tests: real Client + real cache + mock HTTP server."""
+
+    def test_first_request_fetches_jwt_second_uses_cache(self, mock_server, cache_env):
+        """First Client fetches JWT from server, second reuses from cache."""
+        jwt = _make_jwt(time.time() + 3600)
+        MockHandler.jwt_to_return = jwt
+        MockHandler.jwt_call_count = 0
+        MockHandler.api_call_count = 0
+
+        # First client: no cache, must fetch JWT
+        with patch("limacharlie.client.JWT_URL", mock_server), \
+             patch("limacharlie.client.ROOT_URL", mock_server):
+            c1 = Client(oid="test-oid", api_key="test-key")
+            result = c1.request("GET", "sensors")
+
+        assert result == {"ok": True}
+        assert MockHandler.jwt_call_count == 1
+        assert MockHandler.api_call_count == 1
+
+        # Second client: should find cached JWT, no JWT endpoint call
+        MockHandler.jwt_call_count = 0
+        MockHandler.api_call_count = 0
+
+        with patch("limacharlie.client.JWT_URL", mock_server), \
+             patch("limacharlie.client.ROOT_URL", mock_server):
+            c2 = Client(oid="test-oid", api_key="test-key")
+            assert c2._jwt == jwt  # loaded from cache
+            result = c2.request("GET", "sensors")
+
+        assert result == {"ok": True}
+        assert MockHandler.jwt_call_count == 0  # no JWT fetch
+        assert MockHandler.api_call_count == 1
+
+    def test_expired_cache_triggers_fresh_jwt_fetch(self, mock_server, cache_env):
+        """Expired cached JWT is not used; triggers a fresh fetch."""
+        expired_jwt = _make_jwt(time.time() + 300)  # 5 min, within 10-min buffer
+        fresh_jwt = _make_jwt(time.time() + 3600)
+        MockHandler.jwt_to_return = fresh_jwt
+        MockHandler.jwt_call_count = 0
+
+        # Manually write an about-to-expire JWT to cache
+        from limacharlie.jwt_cache import put_cached_jwt
+        # Need a jwt with enough exp to be writable but not readable
+        writable_jwt = _make_jwt(time.time() + 300)
+        # Directly write to cache file (bypass put_cached_jwt exp check)
+        from limacharlie.jwt_cache import _compute_cache_key, _save_cache
+        key = _compute_cache_key("test-oid", "test-key", None, None)
+        _save_cache({key: {"jwt": writable_jwt}})
+
+        with patch("limacharlie.client.JWT_URL", mock_server), \
+             patch("limacharlie.client.ROOT_URL", mock_server):
+            c = Client(oid="test-oid", api_key="test-key")
+            assert c._jwt is None  # cache miss (within expiry buffer)
+            c.request("GET", "sensors")
+
+        assert MockHandler.jwt_call_count == 1  # had to fetch fresh
+
+    def test_401_invalidates_cache_and_refetches(self, mock_server, cache_env):
+        """On 401, cached JWT is invalidated, fresh one is fetched."""
+        stale_jwt = _make_jwt(time.time() + 3600)
+        fresh_jwt = _make_jwt(time.time() + 7200)
+
+        # Pre-populate cache with a JWT the server will reject (401)
+        MockHandler.jwt_to_return = stale_jwt
+        MockHandler.jwt_call_count = 0
+
+        with patch("limacharlie.client.JWT_URL", mock_server), \
+             patch("limacharlie.client.ROOT_URL", mock_server):
+            c1 = Client(oid="test-oid", api_key="test-key")
+            c1.request("GET", "sensors")
+
+        assert MockHandler.jwt_call_count == 1
+        # Cache now has stale_jwt
+
+        # Now make the API return 401 once, then succeed
+        MockHandler.force_401_once = True
+        MockHandler.jwt_to_return = fresh_jwt
+        MockHandler.jwt_call_count = 0
+        MockHandler.api_call_count = 0
+
+        with patch("limacharlie.client.JWT_URL", mock_server), \
+             patch("limacharlie.client.ROOT_URL", mock_server):
+            c2 = Client(oid="test-oid", api_key="test-key")
+            assert c2._jwt == stale_jwt  # from cache
+            result = c2.request("GET", "sensors")
+
+        assert result == {"ok": True}
+        assert MockHandler.jwt_call_count == 1  # refreshed after 401
+        assert MockHandler.api_call_count == 2  # 401 + retry
+
+        # Cache should now have fresh_jwt
+        cached = get_cached_jwt("test-oid", "test-key", None, None)
+        assert cached == fresh_jwt
+
+    def test_different_credentials_get_separate_cache_entries(self, mock_server, cache_env):
+        """Two different API keys produce independent cache entries."""
+        jwt_a = _make_jwt(time.time() + 3600, oid="oid-a")
+        jwt_b = _make_jwt(time.time() + 3600, oid="oid-b")
+
+        MockHandler.jwt_to_return = jwt_a
+        with patch("limacharlie.client.JWT_URL", mock_server), \
+             patch("limacharlie.client.ROOT_URL", mock_server):
+            Client(oid="oid-a", api_key="key-a").request("GET", "test")
+
+        MockHandler.jwt_to_return = jwt_b
+        with patch("limacharlie.client.JWT_URL", mock_server), \
+             patch("limacharlie.client.ROOT_URL", mock_server):
+            Client(oid="oid-b", api_key="key-b").request("GET", "test")
+
+        # Both should be cached independently
+        assert get_cached_jwt("oid-a", "key-a", None, None) == jwt_a
+        assert get_cached_jwt("oid-b", "key-b", None, None) == jwt_b
+
+    def test_clear_cache_forces_refetch(self, mock_server, cache_env):
+        """clear_jwt_cache() forces next Client to fetch a fresh JWT."""
+        jwt1 = _make_jwt(time.time() + 3600)
+        jwt2 = _make_jwt(time.time() + 7200)
+
+        MockHandler.jwt_to_return = jwt1
+        with patch("limacharlie.client.JWT_URL", mock_server), \
+             patch("limacharlie.client.ROOT_URL", mock_server):
+            Client(oid="test-oid", api_key="test-key").request("GET", "test")
+
+        clear_jwt_cache()
+        assert get_cached_jwt("test-oid", "test-key", None, None) is None
+
+        MockHandler.jwt_to_return = jwt2
+        MockHandler.jwt_call_count = 0
+        with patch("limacharlie.client.JWT_URL", mock_server), \
+             patch("limacharlie.client.ROOT_URL", mock_server):
+            c = Client(oid="test-oid", api_key="test-key")
+            assert c._jwt is None  # cache cleared
+            c.request("GET", "test")
+
+        assert MockHandler.jwt_call_count == 1
+
+    def test_cache_disabled_via_env_var(self, mock_server, cache_env, monkeypatch):
+        """LC_NO_JWT_CACHE prevents caching."""
+        monkeypatch.setenv("LC_NO_JWT_CACHE", "1")
+        _reset_cache_disabled()
+
+        jwt = _make_jwt(time.time() + 3600)
+        MockHandler.jwt_to_return = jwt
+        MockHandler.jwt_call_count = 0
+
+        with patch("limacharlie.client.JWT_URL", mock_server), \
+             patch("limacharlie.client.ROOT_URL", mock_server):
+            Client(oid="test-oid", api_key="test-key").request("GET", "test")
+
+        assert MockHandler.jwt_call_count == 1
+        # No cache file should exist
+        assert not os.path.isfile(_get_cache_path())
+
+        # Second client must also fetch (no cache)
+        MockHandler.jwt_call_count = 0
+        with patch("limacharlie.client.JWT_URL", mock_server), \
+             patch("limacharlie.client.ROOT_URL", mock_server):
+            Client(oid="test-oid", api_key="test-key").request("GET", "test")
+
+        assert MockHandler.jwt_call_count == 1
+
+    def test_pre_generated_jwt_bypasses_cache_entirely(self, mock_server, cache_env):
+        """Client(jwt=...) uses the provided JWT, no cache interaction."""
+        pre_jwt = _make_jwt(time.time() + 3600)
+        MockHandler.jwt_call_count = 0
+
+        with patch("limacharlie.client.JWT_URL", mock_server), \
+             patch("limacharlie.client.ROOT_URL", mock_server):
+            c = Client(oid="test-oid", jwt=pre_jwt)
+            result = c.request("GET", "test")
+
+        assert result == {"ok": True}
+        assert MockHandler.jwt_call_count == 0
+        # Nothing should be cached
+        assert get_cached_jwt("test-oid", "test-key", None, None) is None
+
+    def test_cache_file_permissions(self, mock_server, cache_env):
+        """Cache file should have owner-only permissions after write."""
+        jwt = _make_jwt(time.time() + 3600)
+        MockHandler.jwt_to_return = jwt
+
+        with patch("limacharlie.client.JWT_URL", mock_server), \
+             patch("limacharlie.client.ROOT_URL", mock_server):
+            Client(oid="test-oid", api_key="test-key").request("GET", "test")
+
+        cache_path = _get_cache_path()
+        assert os.path.isfile(cache_path)
+        mode = os.stat(cache_path).st_mode
+        assert mode & 0o777 == 0o600
+
+    def test_rapid_sequential_clients_share_cache(self, mock_server, cache_env):
+        """Simulate rapid CLI invocations - only the first fetches JWT."""
+        jwt = _make_jwt(time.time() + 3600)
+        MockHandler.jwt_to_return = jwt
+        MockHandler.jwt_call_count = 0
+
+        for i in range(10):
+            with patch("limacharlie.client.JWT_URL", mock_server), \
+                 patch("limacharlie.client.ROOT_URL", mock_server):
+                Client(oid="test-oid", api_key="test-key").request("GET", "test")
+
+        # Only the first should have fetched a JWT
+        assert MockHandler.jwt_call_count == 1
+
+    def test_get_jwt_reuses_cached_token_with_sufficient_ttl(self, mock_server, cache_env):
+        """get_jwt(expiry_hours=4) reuses cached JWT if it has >= 4h remaining.
+
+        Simulates the search command flow: first `search run` fetches a 4h JWT,
+        second `search run` reuses it instead of generating another.
+        """
+        # JWT with 5 hours remaining
+        long_jwt = _make_jwt(time.time() + 5 * 3600)
+        MockHandler.jwt_to_return = long_jwt
+        MockHandler.jwt_call_count = 0
+
+        with patch("limacharlie.client.JWT_URL", mock_server), \
+             patch("limacharlie.client.ROOT_URL", mock_server):
+            c1 = Client(oid="test-oid", api_key="test-key")
+            # First search: fetches a long-lived JWT
+            result1 = c1.get_jwt(expiry_hours=4.0)
+            assert result1 == long_jwt
+
+        assert MockHandler.jwt_call_count == 1
+
+        # Second invocation (new Client, simulating separate CLI process)
+        MockHandler.jwt_call_count = 0
+        with patch("limacharlie.client.JWT_URL", mock_server), \
+             patch("limacharlie.client.ROOT_URL", mock_server):
+            c2 = Client(oid="test-oid", api_key="test-key")
+            # Cached JWT has ~5h remaining, requesting 4h - should reuse
+            result2 = c2.get_jwt(expiry_hours=4.0)
+            assert result2 == long_jwt
+
+        # No JWT endpoint call - reused from cache
+        assert MockHandler.jwt_call_count == 0
+
+    def test_get_jwt_fetches_new_when_cached_ttl_insufficient(self, mock_server, cache_env):
+        """get_jwt(expiry_hours=4) fetches new JWT if cached one has < 4h left."""
+        # JWT with only 2 hours remaining
+        short_jwt = _make_jwt(time.time() + 2 * 3600)
+        long_jwt = _make_jwt(time.time() + 5 * 3600)
+
+        # Prime cache with the short-lived JWT
+        MockHandler.jwt_to_return = short_jwt
+        with patch("limacharlie.client.JWT_URL", mock_server), \
+             patch("limacharlie.client.ROOT_URL", mock_server):
+            c1 = Client(oid="test-oid", api_key="test-key")
+            c1.request("GET", "test")  # caches the 2h JWT
+
+        # Now request 4h - cached has only 2h, must fetch new
+        MockHandler.jwt_to_return = long_jwt
+        MockHandler.jwt_call_count = 0
+        with patch("limacharlie.client.JWT_URL", mock_server), \
+             patch("limacharlie.client.ROOT_URL", mock_server):
+            c2 = Client(oid="test-oid", api_key="test-key")
+            result = c2.get_jwt(expiry_hours=4.0)
+            assert result == long_jwt
+
+        # Had to fetch a new JWT
+        assert MockHandler.jwt_call_count == 1
+
+        # The new long-lived JWT should now be cached
+        cached = get_cached_jwt("test-oid", "test-key", None, None)
+        assert cached == long_jwt
+
+
+class TestOAuthCacheE2E:
+    """End-to-end tests for OAuth authentication path caching."""
+
+    def test_oauth_first_request_caches_second_reuses(self, mock_server, cache_env):
+        """OAuth path: first Client fetches JWT, second reuses from cache."""
+        jwt = _make_jwt(time.time() + 3600)
+        MockHandler.jwt_to_return = jwt
+        MockHandler.jwt_call_count = 0
+        MockHandler.api_call_count = 0
+
+        oauth_creds = {"id_token": "id-tok", "refresh_token": "ref-tok"}
+
+        # First client: OAuth credentials, no cache
+        with patch("limacharlie.client.JWT_URL", mock_server), \
+             patch("limacharlie.client.ROOT_URL", mock_server), \
+             patch("limacharlie.client.resolve_credentials", return_value={
+                 "oid": "test-oid", "uid": None, "api_key": None, "oauth": oauth_creds,
+             }), \
+             patch("limacharlie.client.Client._refresh_jwt_oauth") as mock_oauth:
+            # Simulate what _refresh_jwt_oauth does: call JWT endpoint, cache result
+            def oauth_side_effect(effective_oid, expiry, oid_override=None):
+                from limacharlie.jwt_cache import put_cached_jwt
+                c1._jwt = jwt
+                if expiry is None and oid_override is None:
+                    put_cached_jwt(jwt, effective_oid, None, oauth_creds, None)
+            mock_oauth.side_effect = oauth_side_effect
+
+            c1 = Client(oid="test-oid")
+            assert c1._jwt is None  # cache miss
+            c1.refresh_jwt()
+
+        # Second client: should find cached JWT
+        with patch("limacharlie.client.resolve_credentials", return_value={
+                 "oid": "test-oid", "uid": None, "api_key": None, "oauth": oauth_creds,
+             }):
+            c2 = Client(oid="test-oid")
+            assert c2._jwt == jwt  # cache hit
+
+    def test_oauth_and_api_key_have_separate_cache_entries(self, mock_server, cache_env):
+        """OAuth and API key for same OID don't interfere with each other."""
+        jwt_api = _make_jwt(time.time() + 3600)
+        jwt_oauth = _make_jwt(time.time() + 3601)
+        oauth_creds = {"id_token": "id-tok", "refresh_token": "ref-tok"}
+
+        # Cache an API key JWT
+        MockHandler.jwt_to_return = jwt_api
+        with patch("limacharlie.client.JWT_URL", mock_server), \
+             patch("limacharlie.client.ROOT_URL", mock_server):
+            c_api = Client(oid="test-oid", api_key="test-key")
+            c_api.request("GET", "test")
+
+        # Cache an OAuth JWT (manually, simulating the OAuth flow)
+        from limacharlie.jwt_cache import put_cached_jwt
+        put_cached_jwt(jwt_oauth, "test-oid", None, oauth_creds, None)
+
+        # Verify both are independently cached
+        assert get_cached_jwt("test-oid", "test-key", None, None) == jwt_api
+        assert get_cached_jwt("test-oid", None, oauth_creds, None) == jwt_oauth
+
+        # New API key client gets the API JWT, not the OAuth one
+        with patch("limacharlie.client.JWT_URL", mock_server), \
+             patch("limacharlie.client.ROOT_URL", mock_server):
+            c_api2 = Client(oid="test-oid", api_key="test-key")
+            assert c_api2._jwt == jwt_api
+
+        # New OAuth client gets the OAuth JWT, not the API one
+        with patch("limacharlie.client.resolve_credentials", return_value={
+                 "oid": "test-oid", "uid": None, "api_key": None, "oauth": oauth_creds,
+             }):
+            c_oauth2 = Client(oid="test-oid")
+            assert c_oauth2._jwt == jwt_oauth

--- a/tests/microbenchmarks/conftest.py
+++ b/tests/microbenchmarks/conftest.py
@@ -1,0 +1,7 @@
+import os
+import sys
+
+current_dir = os.path.dirname(os.path.abspath(__file__))
+project_root = os.path.abspath(os.path.join(current_dir, '../../'))
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)

--- a/tests/microbenchmarks/test_end_to_end_microbenchmark.py
+++ b/tests/microbenchmarks/test_end_to_end_microbenchmark.py
@@ -1,0 +1,292 @@
+"""End-to-end microbenchmarks for JWT caching with real Client + mock HTTP.
+
+Unlike the component-level microbenchmarks in test_jwt_cache_microbenchmark.py,
+these benchmarks exercise the full realistic path that a CLI invocation takes:
+
+1. Real config file on disk (written with save_config)
+2. Real Client() instantiation (resolve_credentials + cache lookup)
+3. Real HTTP mock server (jwt.limacharlie.io + api.limacharlie.io)
+4. Real cache file I/O (put/get/invalidate)
+5. Real file permissions and symlink checks
+
+This measures what the user actually experiences, end to end.
+
+Run with: pytest tests/microbenchmarks/test_end_to_end_microbenchmark.py -v --benchmark-only
+"""
+
+import base64
+import json
+import os
+import stat
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from limacharlie.client import Client
+from limacharlie.config import save_config, load_config, _reset_config_cache
+from limacharlie.jwt_cache import (
+    _get_cache_path,
+    _reset_cache_disabled,
+    clear_jwt_cache,
+    get_cached_jwt,
+    put_cached_jwt,
+)
+
+
+def _make_jwt(exp: float) -> str:
+    """Create a minimal JWT with a given exp claim."""
+    header = base64.urlsafe_b64encode(
+        json.dumps({"alg": "HS256"}).encode()
+    ).rstrip(b"=")
+    payload = base64.urlsafe_b64encode(
+        json.dumps({"exp": exp}).encode()
+    ).rstrip(b"=")
+    sig = base64.urlsafe_b64encode(b"fakesig").rstrip(b"=")
+    return f"{header.decode()}.{payload.decode()}.{sig.decode()}"
+
+
+class _MockHandler(BaseHTTPRequestHandler):
+    """Minimal HTTP handler for JWT + API endpoints."""
+
+    jwt_to_return = ""
+    lock = threading.Lock()
+
+    def do_POST(self):
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(json.dumps({"jwt": self.jwt_to_return}).encode())
+
+    def do_GET(self):
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(json.dumps({"ok": True}).encode())
+
+    def log_message(self, format, *args):
+        pass
+
+
+@pytest.fixture(scope="module")
+def mock_server():
+    """Start a mock HTTP server once for the entire module."""
+    server = HTTPServer(("127.0.0.1", 0), _MockHandler)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    yield f"http://127.0.0.1:{port}"
+    server.shutdown()
+
+
+@pytest.fixture(autouse=True)
+def isolated_env(monkeypatch, tmp_path):
+    """Fully isolated environment with real config + cache files."""
+    config_path = str(tmp_path / ".limacharlie")
+    monkeypatch.setattr("limacharlie.jwt_cache.CONFIG_FILE_PATH", config_path)
+    monkeypatch.setattr("limacharlie.config.CONFIG_FILE_PATH", config_path)
+    monkeypatch.delenv("LC_CREDS_FILE", raising=False)
+    monkeypatch.delenv("LC_EPHEMERAL_CREDS", raising=False)
+    monkeypatch.delenv("LC_NO_JWT_CACHE", raising=False)
+    monkeypatch.delenv("LC_OID", raising=False)
+    monkeypatch.delenv("LC_API_KEY", raising=False)
+    monkeypatch.delenv("LC_UID", raising=False)
+    monkeypatch.delenv("LC_CURRENT_ENV", raising=False)
+    _reset_cache_disabled()
+    _reset_config_cache()
+    yield tmp_path
+    _reset_cache_disabled()
+    _reset_config_cache()
+
+
+class TestClientInitCacheHit:
+    """Benchmark Client() construction when cache has a valid JWT.
+
+    This is the hot path for every CLI command after the first.
+    Measures: config resolve + cache file read + JSON parse + JWT decode.
+    """
+
+    def test_client_init_cache_hit_with_config_file(self, benchmark, mock_server):
+        """Real config file + real cache file + Client() construction."""
+        save_config({"oid": "bench-oid", "api_key": "bench-key"})
+        jwt = _make_jwt(time.time() + 3600)
+        put_cached_jwt(jwt, "bench-oid", "bench-key", None, None)
+
+        def create_client():
+            _reset_config_cache()
+            with patch("limacharlie.client.JWT_URL", mock_server), \
+                 patch("limacharlie.client.ROOT_URL", mock_server):
+                c = Client()
+                assert c._jwt == jwt
+        benchmark(create_client)
+
+    def test_client_init_cache_hit_env_vars(self, benchmark, monkeypatch, mock_server):
+        """Env var credentials + real cache file + Client() construction.
+
+        Faster than config file path because no YAML parse needed.
+        """
+        monkeypatch.setenv("LC_OID", "bench-oid")
+        monkeypatch.setenv("LC_API_KEY", "bench-key")
+        _reset_config_cache()
+        jwt = _make_jwt(time.time() + 3600)
+        put_cached_jwt(jwt, "bench-oid", "bench-key", None, None)
+
+        def create_client():
+            with patch("limacharlie.client.JWT_URL", mock_server), \
+                 patch("limacharlie.client.ROOT_URL", mock_server):
+                c = Client()
+                assert c._jwt == jwt
+        benchmark(create_client)
+
+
+class TestClientInitCacheMiss:
+    """Benchmark Client() + first request when cache is empty.
+
+    Measures: config resolve + cache miss + JWT HTTP fetch + cache write.
+    """
+
+    def test_client_init_and_request_cold(self, benchmark, mock_server):
+        """No cache. Client must fetch JWT from server then cache it."""
+        save_config({"oid": "bench-oid", "api_key": "bench-key"})
+        jwt = _make_jwt(time.time() + 3600)
+        _MockHandler.jwt_to_return = jwt
+
+        def cold_request():
+            _reset_config_cache()
+            clear_jwt_cache()
+            with patch("limacharlie.client.JWT_URL", mock_server), \
+                 patch("limacharlie.client.ROOT_URL", mock_server):
+                c = Client()
+                assert c._jwt is None
+                c.request("GET", "test")
+                assert c._jwt == jwt
+        benchmark(cold_request)
+
+
+class TestFullRequestCacheHit:
+    """Benchmark the full path: Client() + request() with cached JWT.
+
+    The most common real-world scenario: user runs a CLI command,
+    JWT is in cache, request goes through directly.
+    """
+
+    def test_client_request_with_cached_jwt(self, benchmark, mock_server):
+        """Complete CLI command: Client() + one API request, JWT cached."""
+        save_config({"oid": "bench-oid", "api_key": "bench-key"})
+        jwt = _make_jwt(time.time() + 3600)
+        put_cached_jwt(jwt, "bench-oid", "bench-key", None, None)
+
+        def full_request():
+            _reset_config_cache()
+            with patch("limacharlie.client.JWT_URL", mock_server), \
+                 patch("limacharlie.client.ROOT_URL", mock_server):
+                c = Client()
+                result = c.request("GET", "test")
+                assert result == {"ok": True}
+        benchmark(full_request)
+
+
+class TestSearchTokenReuse:
+    """Benchmark get_jwt() reuse vs fresh fetch for search commands."""
+
+    def test_get_jwt_reuse_cached_long_lived(self, benchmark, mock_server):
+        """get_jwt(4h) when cached JWT has 5h remaining - pure reuse."""
+        save_config({"oid": "bench-oid", "api_key": "bench-key"})
+        jwt = _make_jwt(time.time() + 5 * 3600)
+        _MockHandler.jwt_to_return = jwt
+
+        # Prime the cache with a long-lived JWT
+        with patch("limacharlie.client.JWT_URL", mock_server), \
+             patch("limacharlie.client.ROOT_URL", mock_server):
+            c = Client()
+            c.request("GET", "prime")
+
+        def reuse():
+            _reset_config_cache()
+            with patch("limacharlie.client.JWT_URL", mock_server), \
+                 patch("limacharlie.client.ROOT_URL", mock_server):
+                c = Client()
+                result = c.get_jwt(expiry_hours=4.0)
+                assert result == jwt
+        benchmark(reuse)
+
+
+class TestConfigLoadPerformance:
+    """Benchmark config file operations in realistic scenarios."""
+
+    def test_save_then_load_config(self, benchmark):
+        """Write config then read it back (what 'auth login' does)."""
+        data = {"oid": "my-oid", "api_key": "my-key", "uid": "my-uid"}
+
+        def save_and_load():
+            _reset_config_cache()
+            save_config(data)
+            result = load_config()
+            assert result["oid"] == "my-oid"
+        benchmark(save_and_load)
+
+    def test_load_config_with_environments(self, benchmark):
+        """Load a config file with multiple environments."""
+        data = {
+            "oid": "default-oid",
+            "api_key": "default-key",
+            "env": {
+                f"env-{i}": {"oid": f"oid-{i}", "api_key": f"key-{i}"}
+                for i in range(10)
+            },
+        }
+        save_config(data)
+
+        def load():
+            _reset_config_cache()
+            result = load_config()
+            assert len(result["env"]) == 10
+        benchmark(load)
+
+
+class TestCacheFileGrowth:
+    """Benchmark cache performance as the cache file grows."""
+
+    def test_cache_hit_with_1_entry(self, benchmark):
+        jwt = _make_jwt(time.time() + 3600)
+        put_cached_jwt(jwt, "oid-0", "key-0", None, None)
+
+        benchmark(get_cached_jwt, "oid-0", "key-0", None, None)
+
+    def test_cache_hit_with_10_entries(self, benchmark):
+        jwt = _make_jwt(time.time() + 3600)
+        for i in range(10):
+            put_cached_jwt(_make_jwt(time.time() + 3600), f"oid-{i}", f"key-{i}", None, None)
+        put_cached_jwt(jwt, "target", "target-key", None, None)
+
+        benchmark(get_cached_jwt, "target", "target-key", None, None)
+
+    def test_cache_hit_with_50_entries(self, benchmark):
+        jwt = _make_jwt(time.time() + 3600)
+        for i in range(50):
+            put_cached_jwt(_make_jwt(time.time() + 3600), f"oid-{i}", f"key-{i}", None, None)
+        put_cached_jwt(jwt, "target", "target-key", None, None)
+
+        benchmark(get_cached_jwt, "target", "target-key", None, None)
+
+
+class TestOAuthPath:
+    """Benchmark cache operations for the OAuth authentication path."""
+
+    def test_oauth_cache_hit(self, benchmark):
+        jwt = _make_jwt(time.time() + 3600)
+        oauth = {"id_token": "id-tok", "refresh_token": "ref-tok"}
+        put_cached_jwt(jwt, "oid", None, oauth, None)
+
+        benchmark(get_cached_jwt, "oid", None, oauth, None)
+
+    def test_oauth_cache_put(self, benchmark):
+        jwt = _make_jwt(time.time() + 3600)
+        oauth = {"id_token": "id-tok", "refresh_token": "ref-tok"}
+
+        def put():
+            put_cached_jwt(jwt, "oid", None, oauth, None)
+        benchmark(put)

--- a/tests/microbenchmarks/test_jwt_cache_microbenchmark.py
+++ b/tests/microbenchmarks/test_jwt_cache_microbenchmark.py
@@ -1,0 +1,296 @@
+"""Microbenchmarks for JWT cache operations.
+
+Measures the performance of the critical hot path: cache lookup, cache write,
+config loading, cache key computation, JWT expiry decoding, and atomic writes.
+
+Run with: pytest tests/microbenchmarks/test_jwt_cache_microbenchmark.py -v
+"""
+
+import base64
+import json
+import os
+import time
+
+import pytest
+import yaml
+
+from limacharlie.file_utils import atomic_write, safe_open_read, secure_file_permissions
+from limacharlie.jwt_cache import (
+    _compute_cache_key,
+    _decode_jwt_exp,
+    _get_cache_path,
+    _is_cache_disabled,
+    _reset_cache_disabled,
+    get_cached_jwt,
+    invalidate_cached_jwt,
+    put_cached_jwt,
+)
+
+
+def _make_jwt(exp: float) -> str:
+    """Create a minimal JWT with a given exp claim."""
+    header = base64.urlsafe_b64encode(
+        json.dumps({"alg": "HS256"}).encode()
+    ).rstrip(b"=")
+    payload = base64.urlsafe_b64encode(
+        json.dumps({"exp": exp}).encode()
+    ).rstrip(b"=")
+    sig = base64.urlsafe_b64encode(b"fakesig").rstrip(b"=")
+    return f"{header.decode()}.{payload.decode()}.{sig.decode()}"
+
+
+@pytest.fixture(autouse=True)
+def cache_env(monkeypatch, tmp_path):
+    """Isolate all benchmarks to a temp directory."""
+    from limacharlie.config import _reset_config_cache
+    config_path = str(tmp_path / ".limacharlie")
+    monkeypatch.setattr("limacharlie.jwt_cache.CONFIG_FILE_PATH", config_path)
+    monkeypatch.setattr("limacharlie.config.CONFIG_FILE_PATH", config_path)
+    monkeypatch.delenv("LC_CREDS_FILE", raising=False)
+    monkeypatch.delenv("LC_EPHEMERAL_CREDS", raising=False)
+    monkeypatch.delenv("LC_NO_JWT_CACHE", raising=False)
+    _reset_cache_disabled()
+    _reset_config_cache()
+    yield tmp_path
+    _reset_cache_disabled()
+    _reset_config_cache()
+
+
+class TestCacheKeyComputation:
+    """Benchmark _compute_cache_key - called on every cache lookup/write."""
+
+    def test_compute_cache_key_api_key(self, benchmark):
+        benchmark(_compute_cache_key, "oid-value", "api-key-value", None, None)
+
+    def test_compute_cache_key_api_key_with_uid(self, benchmark):
+        benchmark(_compute_cache_key, "oid-value", "api-key-value", None, "uid-value")
+
+    def test_compute_cache_key_oauth(self, benchmark):
+        benchmark(
+            _compute_cache_key,
+            "oid-value",
+            None,
+            {"refresh_token": "rt-value"},
+            None,
+        )
+
+
+class TestJwtExpDecoding:
+    """Benchmark _decode_jwt_exp - called on every cache read and write."""
+
+    def test_decode_jwt_exp(self, benchmark):
+        jwt = _make_jwt(time.time() + 3600)
+        benchmark(_decode_jwt_exp, jwt)
+
+    def test_decode_jwt_exp_long_payload(self, benchmark):
+        """JWT with larger payload (more claims)."""
+        header = base64.urlsafe_b64encode(
+            json.dumps({"alg": "HS256"}).encode()
+        ).rstrip(b"=")
+        payload = base64.urlsafe_b64encode(
+            json.dumps({
+                "exp": time.time() + 3600,
+                "oid": "a" * 36,
+                "uid": "b" * 36,
+                "perms": ["org.get", "sensor.list", "sensor.task"] * 10,
+            }).encode()
+        ).rstrip(b"=")
+        sig = base64.urlsafe_b64encode(b"sig").rstrip(b"=")
+        jwt = f"{header.decode()}.{payload.decode()}.{sig.decode()}"
+        benchmark(_decode_jwt_exp, jwt)
+
+
+class TestIsCacheDisabled:
+    """Benchmark _is_cache_disabled - called on every get/put.
+
+    After first call the result is memoized, so this benchmarks the
+    fast path (cached bool check).
+    """
+
+    def test_is_cache_disabled_memoized(self, benchmark):
+        _is_cache_disabled()  # prime the memoization
+        benchmark(_is_cache_disabled)
+
+    def test_is_cache_disabled_cold_env_vars_only(self, benchmark):
+        """Cold path when no config file exists (env var check only)."""
+        def cold_check():
+            _reset_cache_disabled()
+            return _is_cache_disabled()
+        benchmark(cold_check)
+
+    def test_is_cache_disabled_cold_with_config_file(self, benchmark, tmp_path):
+        """Cold path when config file exists (YAML parse required)."""
+        config_path = str(tmp_path / ".limacharlie")
+        with open(config_path, "w") as f:
+            yaml.safe_dump({"oid": "test-oid", "api_key": "test-key"}, f)
+
+        def cold_check():
+            _reset_cache_disabled()
+            return _is_cache_disabled()
+        benchmark(cold_check)
+
+
+class TestGetCachedJwt:
+    """Benchmark get_cached_jwt - the critical hot path on every CLI invocation."""
+
+    def test_cache_hit(self, benchmark):
+        """Best case: valid JWT in cache, returned immediately."""
+        exp = time.time() + 3600
+        jwt = _make_jwt(exp)
+        put_cached_jwt(jwt, "oid", "key", None, None)
+
+        benchmark(get_cached_jwt, "oid", "key", None, None)
+
+    def test_cache_miss_empty(self, benchmark):
+        """Cache file doesn't exist yet."""
+        benchmark(get_cached_jwt, "oid", "key", None, None)
+
+    def test_cache_miss_wrong_key(self, benchmark):
+        """Cache file exists but no matching entry."""
+        exp = time.time() + 3600
+        put_cached_jwt(_make_jwt(exp), "other-oid", "other-key", None, None)
+
+        benchmark(get_cached_jwt, "oid", "key", None, None)
+
+    def test_cache_hit_with_many_entries(self, benchmark):
+        """Cache file has many entries - measures JSON parse overhead."""
+        exp = time.time() + 3600
+        for i in range(50):
+            put_cached_jwt(_make_jwt(exp), f"oid-{i}", f"key-{i}", None, None)
+        put_cached_jwt(_make_jwt(exp), "target-oid", "target-key", None, None)
+
+        benchmark(get_cached_jwt, "target-oid", "target-key", None, None)
+
+
+class TestPutCachedJwt:
+    """Benchmark put_cached_jwt - called after each fresh JWT fetch."""
+
+    def test_put_new_entry(self, benchmark):
+        """Write a new entry to empty cache."""
+        exp = time.time() + 3600
+        jwt = _make_jwt(exp)
+
+        def put():
+            put_cached_jwt(jwt, "oid", "key", None, None)
+        benchmark(put)
+
+    def test_put_overwrite(self, benchmark):
+        """Overwrite existing entry (read-modify-write cycle)."""
+        exp = time.time() + 3600
+        jwt = _make_jwt(exp)
+        put_cached_jwt(jwt, "oid", "key", None, None)
+
+        new_jwt = _make_jwt(exp + 3600)
+
+        def put():
+            put_cached_jwt(new_jwt, "oid", "key", None, None)
+        benchmark(put)
+
+
+class TestInvalidateCachedJwt:
+    """Benchmark invalidate_cached_jwt - called on 401."""
+
+    def test_invalidate_existing(self, benchmark):
+        exp = time.time() + 3600
+        put_cached_jwt(_make_jwt(exp), "oid", "key", None, None)
+
+        def invalidate():
+            # Re-populate so each iteration has something to invalidate
+            put_cached_jwt(_make_jwt(exp), "oid", "key", None, None)
+            invalidate_cached_jwt("oid", "key", None, None)
+        benchmark(invalidate)
+
+    def test_invalidate_missing(self, benchmark):
+        """Invalidate when entry doesn't exist (no-op path)."""
+        benchmark(invalidate_cached_jwt, "oid", "key", None, None)
+
+
+class TestAtomicWrite:
+    """Benchmark atomic_write - underlies all cache writes."""
+
+    def test_small_payload(self, benchmark, tmp_path):
+        path = str(tmp_path / "bench_small")
+        data = b'{"key": "value"}'
+        benchmark(atomic_write, path, data)
+
+    def test_typical_cache_payload(self, benchmark, tmp_path):
+        """Typical cache file size (~500 bytes with a few entries)."""
+        path = str(tmp_path / "bench_typical")
+        entries = {}
+        for i in range(5):
+            k = _compute_cache_key(f"oid-{i}", f"key-{i}", None, None)
+            entries[k] = {"jwt": _make_jwt(time.time() + 3600)}
+        data = json.dumps(entries).encode()
+        benchmark(atomic_write, path, data)
+
+
+class TestSafeOpenRead:
+    """Benchmark safe_open_read - underlies all cache reads."""
+
+    def test_small_file(self, benchmark, tmp_path):
+        path = str(tmp_path / "bench_read")
+        with open(path, "wb") as f:
+            f.write(b'{"key": "value"}')
+        os.chmod(path, 0o600)
+        benchmark(safe_open_read, path)
+
+    def test_typical_cache_file(self, benchmark, tmp_path):
+        path = str(tmp_path / "bench_read_typical")
+        entries = {}
+        for i in range(5):
+            k = _compute_cache_key(f"oid-{i}", f"key-{i}", None, None)
+            entries[k] = {"jwt": _make_jwt(time.time() + 3600)}
+        with open(path, "wb") as f:
+            f.write(json.dumps(entries).encode())
+        os.chmod(path, 0o600)
+        benchmark(safe_open_read, path)
+
+
+class TestSecureFilePermissions:
+    """Benchmark secure_file_permissions - called on every atomic write."""
+
+    def test_chmod_existing_file(self, benchmark, tmp_path):
+        path = str(tmp_path / "bench_perm")
+        with open(path, "w") as f:
+            f.write("data")
+        benchmark(secure_file_permissions, path)
+
+
+class TestEndToEnd:
+    """Benchmark the full cache lifecycle as experienced by a CLI invocation."""
+
+    def test_full_cache_hit_path(self, benchmark):
+        """Simulate the hot path: Client.__init__ cache lookup (cache hit).
+
+        This is what every CLI invocation pays when a valid JWT is cached.
+        Includes: _is_cache_disabled check, cache key computation,
+        file read, JSON parse, JWT exp decode, expiry comparison.
+        """
+        exp = time.time() + 3600
+        jwt = _make_jwt(exp)
+        put_cached_jwt(jwt, "oid", "key", None, None)
+
+        def full_hit():
+            result = get_cached_jwt("oid", "key", None, None)
+            assert result == jwt
+        benchmark(full_hit)
+
+    def test_full_cache_miss_then_put(self, benchmark):
+        """Simulate cold path: cache miss + JWT fetch + cache write.
+
+        The JWT fetch itself is network I/O (not benchmarked here).
+        This measures the cache overhead around it. Uses a unique key
+        per iteration to ensure each lookup is a genuine miss.
+        """
+        exp = time.time() + 3600
+        jwt = _make_jwt(exp)
+        counter = [0]
+
+        def miss_then_put():
+            counter[0] += 1
+            oid = f"oid-miss-{counter[0]}"
+            key = f"key-miss-{counter[0]}"
+            result = get_cached_jwt(oid, key, None, None)
+            assert result is None
+            put_cached_jwt(jwt, oid, key, None, None)
+        benchmark(miss_then_put)

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -13,6 +13,28 @@ from limacharlie.errors import (
 )
 
 
+@pytest.fixture(autouse=True)
+def _isolate_caches(monkeypatch, tmp_path):
+    """Isolate JWT cache and config cache for every client test.
+
+    Without this, cached config/JWTs from one test leak into the next.
+    """
+    from limacharlie.config import _reset_config_cache
+    from limacharlie.jwt_cache import _reset_cache_disabled
+
+    config_path = str(tmp_path / ".limacharlie")
+    monkeypatch.setattr("limacharlie.jwt_cache.CONFIG_FILE_PATH", config_path)
+    monkeypatch.setattr("limacharlie.config.CONFIG_FILE_PATH", config_path)
+    monkeypatch.delenv("LC_CREDS_FILE", raising=False)
+    monkeypatch.delenv("LC_EPHEMERAL_CREDS", raising=False)
+    monkeypatch.delenv("LC_NO_JWT_CACHE", raising=False)
+    _reset_config_cache()
+    _reset_cache_disabled()
+    yield
+    _reset_config_cache()
+    _reset_cache_disabled()
+
+
 class TestClientInit:
     def test_creates_with_explicit_creds(self):
         client = Client(oid="test-oid", api_key="test-key")
@@ -287,6 +309,415 @@ class TestRefreshAuthCallback:
 
         callback.assert_called_with(client)
         assert result == {"ok": True}
+
+
+class TestJwtCacheIntegration:
+    """Tests for JWT disk cache integration in Client."""
+
+    @patch("limacharlie.jwt_cache.get_cached_jwt")
+    @patch("limacharlie.client.urlopen")
+    def test_cached_jwt_skips_refresh(self, mock_urlopen, mock_get_cached):
+        """Client with a valid cached JWT should not call refresh_jwt."""
+        mock_get_cached.return_value = "cached-jwt-token"
+
+        # Mock API response (no JWT endpoint call should happen)
+        api_response = MagicMock()
+        api_response.read.return_value = json.dumps({"ok": True}).encode()
+        api_response.close = MagicMock()
+        api_response.getheaders.return_value = []
+        mock_urlopen.return_value = api_response
+
+        client = Client(oid="test-oid", api_key="test-key")
+        assert client._jwt == "cached-jwt-token"
+        result = client.request("GET", "test")
+
+        assert result == {"ok": True}
+        # Only 1 call (the API request), not 2 (JWT + API)
+        assert mock_urlopen.call_count == 1
+
+    @patch("limacharlie.jwt_cache.get_cached_jwt")
+    @patch("limacharlie.client.urlopen")
+    def test_expired_cached_jwt_triggers_refresh(self, mock_urlopen, mock_get_cached):
+        """Client with no cached JWT should call refresh_jwt normally."""
+        mock_get_cached.return_value = None
+
+        jwt_response = MagicMock()
+        jwt_response.read.return_value = json.dumps({"jwt": "fresh-jwt"}).encode()
+        jwt_response.close = MagicMock()
+
+        api_response = MagicMock()
+        api_response.read.return_value = json.dumps({"ok": True}).encode()
+        api_response.close = MagicMock()
+        api_response.getheaders.return_value = []
+
+        mock_urlopen.side_effect = [jwt_response, api_response]
+
+        client = Client(oid="test-oid", api_key="test-key")
+        assert client._jwt is None
+        result = client.request("GET", "test")
+        assert result == {"ok": True}
+        # 2 calls: JWT endpoint + API request
+        assert mock_urlopen.call_count == 2
+
+    @patch("limacharlie.jwt_cache.put_cached_jwt")
+    @patch("limacharlie.jwt_cache.get_cached_jwt", return_value=None)
+    @patch("limacharlie.client.urlopen")
+    def test_refresh_jwt_writes_to_cache(self, mock_urlopen, mock_get_cached, mock_put):
+        """After refresh_jwt(), the new JWT should be written to cache."""
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps({"jwt": "new-jwt"}).encode()
+        mock_response.close = MagicMock()
+        mock_urlopen.return_value = mock_response
+
+        client = Client(oid="test-oid", api_key="test-key")
+        client.refresh_jwt()
+
+        mock_put.assert_called_once_with("new-jwt", "test-oid", "test-key", None, None)
+
+    @patch("limacharlie.jwt_cache.invalidate_cached_jwt")
+    @patch("limacharlie.jwt_cache.get_cached_jwt", return_value="stale-jwt")
+    @patch("limacharlie.client.urlopen")
+    def test_401_invalidates_cache_before_refresh(self, mock_urlopen, mock_get_cached, mock_invalidate):
+        """On 401 retry, the cached JWT should be invalidated before refresh."""
+        from urllib.error import HTTPError
+        import io
+
+        http_401 = HTTPError(
+            "https://api.limacharlie.io/v1/test", 401, "Unauthorized",
+            {}, io.BytesIO(b'{"error": "expired"}')
+        )
+        jwt_response = MagicMock()
+        jwt_response.read.return_value = json.dumps({"jwt": "refreshed-jwt"}).encode()
+        jwt_response.close = MagicMock()
+        api_response = MagicMock()
+        api_response.read.return_value = json.dumps({"ok": True}).encode()
+        api_response.close = MagicMock()
+        api_response.getheaders.return_value = []
+
+        mock_urlopen.side_effect = [http_401, jwt_response, api_response]
+
+        client = Client(oid="test-oid", api_key="test-key")
+        result = client.request("GET", "test")
+
+        assert result == {"ok": True}
+        mock_invalidate.assert_called_once_with("test-oid", "test-key", None, None)
+
+    @patch("limacharlie.jwt_cache.get_cached_jwt")
+    def test_pre_generated_jwt_does_not_consult_cache(self, mock_get_cached):
+        """When jwt= param is passed, cache should not be consulted."""
+        client = Client(oid="test-oid", jwt="pre-gen-jwt")
+        assert client._jwt == "pre-gen-jwt"
+        mock_get_cached.assert_not_called()
+
+    @patch("limacharlie.jwt_cache.put_cached_jwt")
+    @patch("limacharlie.jwt_cache.get_cached_jwt", return_value=None)
+    @patch("limacharlie.client.urlopen")
+    def test_refresh_jwt_with_expiry_does_not_cache(self, mock_urlopen, mock_get_cached, mock_put):
+        """refresh_jwt(expiry=300) should not write to cache."""
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps({"jwt": "short-jwt"}).encode()
+        mock_response.close = MagicMock()
+        mock_urlopen.return_value = mock_response
+
+        client = Client(oid="test-oid", api_key="test-key")
+        client.refresh_jwt(expiry=300)
+        mock_put.assert_not_called()
+
+    @patch("limacharlie.jwt_cache.put_cached_jwt")
+    @patch("limacharlie.jwt_cache.get_cached_jwt", return_value=None)
+    @patch("limacharlie.client.urlopen")
+    def test_refresh_jwt_with_oid_override_does_not_cache(self, mock_urlopen, mock_get_cached, mock_put):
+        """refresh_jwt(oid_override='-') should not write to cache."""
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps({"jwt": "override-jwt"}).encode()
+        mock_response.close = MagicMock()
+        mock_urlopen.return_value = mock_response
+
+        client = Client(oid="test-oid", api_key="test-key")
+        client.refresh_jwt(oid_override="-")
+        mock_put.assert_not_called()
+
+    @patch("limacharlie.jwt_cache.invalidate_cached_jwt")
+    @patch("limacharlie.jwt_cache.get_cached_jwt", return_value="stale-jwt")
+    @patch("limacharlie.client.urlopen")
+    def test_raw_request_401_invalidates_cache(self, mock_urlopen, mock_get_cached, mock_invalidate):
+        """raw_request 401 retry should also invalidate the cache."""
+        from urllib.error import HTTPError
+        import io
+
+        http_401 = HTTPError(
+            "https://api.limacharlie.io/v1/test", 401, "Unauthorized",
+            {}, io.BytesIO(b'{"error": "expired"}')
+        )
+        jwt_response = MagicMock()
+        jwt_response.read.return_value = json.dumps({"jwt": "refreshed-jwt"}).encode()
+        jwt_response.close = MagicMock()
+        api_response = MagicMock()
+        api_response.read.return_value = json.dumps({"ok": True}).encode()
+        api_response.close = MagicMock()
+        api_response.getheaders.return_value = []
+
+        mock_urlopen.side_effect = [http_401, jwt_response, api_response]
+
+        client = Client(oid="test-oid", api_key="test-key")
+        code, data = client.raw_request("GET", "test")
+
+        assert code == 200
+        assert data == {"ok": True}
+        mock_invalidate.assert_called_once_with("test-oid", "test-key", None, None)
+
+
+class TestDualCredsAuthPathSelection:
+    """Tests for cache key correctness when both api_key and oauth_creds are set.
+
+    When config has both api_key and oauth credentials, OAuth takes priority
+    for auth. The cache lookup/write/invalidation must all use the OAuth
+    cache key, not the api_key key.
+    """
+
+    @patch("limacharlie.jwt_cache.get_cached_jwt")
+    @patch("limacharlie.client.resolve_credentials", return_value={
+        "oid": "test-oid", "uid": None,
+        "api_key": "test-key",
+        "oauth": {"id_token": "id", "refresh_token": "ref"},
+    })
+    def test_init_uses_oauth_cache_key_when_both_set(self, mock_creds, mock_get_cached):
+        """When both api_key and oauth_creds are resolved, init should
+        look up cache using OAuth credentials (api_key=None)."""
+        mock_get_cached.return_value = None
+        Client(oid="test-oid")
+        mock_get_cached.assert_called_once_with("test-oid", None,
+            {"id_token": "id", "refresh_token": "ref"}, None)
+
+    @patch("limacharlie.jwt_cache.invalidate_cached_jwt")
+    @patch("limacharlie.jwt_cache.get_cached_jwt", return_value="stale")
+    @patch("limacharlie.client.resolve_credentials", return_value={
+        "oid": "test-oid", "uid": None,
+        "api_key": "test-key",
+        "oauth": {"id_token": "id", "refresh_token": "ref"},
+    })
+    @patch("limacharlie.client.urlopen")
+    def test_401_invalidates_oauth_cache_key_when_both_set(
+        self, mock_urlopen, mock_creds, mock_get_cached, mock_invalidate
+    ):
+        """401 invalidation should use OAuth cache key when both are set."""
+        from urllib.error import HTTPError
+        import io
+
+        http_401 = HTTPError("url", 401, "Unauthorized", {}, io.BytesIO(b"{}"))
+        jwt_resp = MagicMock()
+        jwt_resp.read.return_value = json.dumps({"jwt": "new"}).encode()
+        jwt_resp.close = MagicMock()
+        api_resp = MagicMock()
+        api_resp.read.return_value = json.dumps({"ok": True}).encode()
+        api_resp.close = MagicMock()
+        api_resp.getheaders.return_value = []
+
+        # Need to mock OAuth manager since oauth path is taken
+        with patch("limacharlie.client.Client._refresh_jwt_oauth") as mock_oauth:
+            def set_jwt(oid, expiry, oid_override=None):
+                # Simulate _refresh_jwt_oauth setting the JWT
+                pass
+            mock_oauth.side_effect = set_jwt
+
+            mock_urlopen.side_effect = [http_401, api_resp]
+            client = Client(oid="test-oid")
+            client._jwt = "stale"  # force a value so request proceeds
+            try:
+                client.request("GET", "test")
+            except Exception:
+                pass  # may fail since mock_oauth doesn't set jwt
+
+        mock_invalidate.assert_called_once_with(
+            "test-oid", None,
+            {"id_token": "id", "refresh_token": "ref"}, None
+        )
+
+
+class TestGetJwtCacheReuse:
+    """Tests for get_jwt() reusing cached JWTs when TTL is sufficient."""
+
+    @staticmethod
+    def _make_jwt(exp):
+        """Create a minimal JWT with a given exp for testing."""
+        import base64
+        header = base64.urlsafe_b64encode(json.dumps({"alg": "HS256"}).encode()).rstrip(b"=")
+        payload = base64.urlsafe_b64encode(json.dumps({"exp": exp}).encode()).rstrip(b"=")
+        sig = base64.urlsafe_b64encode(b"sig").rstrip(b"=")
+        return f"{header.decode()}.{payload.decode()}.{sig.decode()}"
+
+    @patch("limacharlie.jwt_cache.get_cached_jwt")
+    @patch("limacharlie.client.urlopen")
+    def test_get_jwt_reuses_token_with_sufficient_ttl(self, mock_urlopen, mock_get_cached):
+        """If cached JWT has >= requested hours remaining, reuse it."""
+        import time
+        # Cached JWT expires in 5 hours
+        cached_jwt = self._make_jwt(time.time() + 5 * 3600)
+        mock_get_cached.return_value = cached_jwt
+
+        client = Client(oid="test-oid", api_key="test-key")
+        assert client._jwt == cached_jwt
+
+        # Request 4 hours - cached has 5h remaining, should reuse
+        result = client.get_jwt(expiry_hours=4.0)
+        assert result == cached_jwt
+        # No HTTP call should have been made
+        mock_urlopen.assert_not_called()
+
+    @patch("limacharlie.jwt_cache.get_cached_jwt")
+    @patch("limacharlie.client.urlopen")
+    def test_get_jwt_fetches_new_when_ttl_insufficient(self, mock_urlopen, mock_get_cached):
+        """If cached JWT has < requested hours remaining, fetch new one."""
+        import time
+        # Cached JWT expires in 2 hours
+        cached_jwt = self._make_jwt(time.time() + 2 * 3600)
+        mock_get_cached.return_value = cached_jwt
+
+        fresh_jwt = self._make_jwt(time.time() + 5 * 3600)
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps({"jwt": fresh_jwt}).encode()
+        mock_response.close = MagicMock()
+        mock_urlopen.return_value = mock_response
+
+        client = Client(oid="test-oid", api_key="test-key")
+        # Request 4 hours - cached has only 2h, must fetch new
+        result = client.get_jwt(expiry_hours=4.0)
+        assert result == fresh_jwt
+        mock_urlopen.assert_called_once()
+
+    @patch("limacharlie.jwt_cache.put_cached_jwt")
+    @patch("limacharlie.jwt_cache.get_cached_jwt", return_value=None)
+    @patch("limacharlie.client.urlopen")
+    def test_get_jwt_caches_long_lived_token(self, mock_urlopen, mock_get_cached, mock_put):
+        """get_jwt with expiry_hours should cache the resulting long-lived JWT."""
+        import time
+        fresh_jwt = self._make_jwt(time.time() + 4 * 3600)
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps({"jwt": fresh_jwt}).encode()
+        mock_response.close = MagicMock()
+        mock_urlopen.return_value = mock_response
+
+        client = Client(oid="test-oid", api_key="test-key")
+        client.get_jwt(expiry_hours=4.0)
+
+        # Should have cached the long-lived JWT
+        mock_put.assert_called_once_with(
+            fresh_jwt, "test-oid", "test-key", None, None
+        )
+
+    @patch("limacharlie.jwt_cache.get_cached_jwt")
+    @patch("limacharlie.client.urlopen")
+    def test_get_jwt_no_expiry_hours_does_not_check_ttl(self, mock_urlopen, mock_get_cached):
+        """get_jwt() with no expiry_hours uses default refresh path."""
+        import time
+        cached_jwt = self._make_jwt(time.time() + 3600)
+        mock_get_cached.return_value = cached_jwt
+
+        fresh_jwt = self._make_jwt(time.time() + 3600)
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps({"jwt": fresh_jwt}).encode()
+        mock_response.close = MagicMock()
+        mock_urlopen.return_value = mock_response
+
+        client = Client(oid="test-oid", api_key="test-key")
+        # No expiry_hours - goes through refresh_jwt(expiry=None) which
+        # writes to cache via the normal path
+        result = client.get_jwt()
+        assert result == fresh_jwt
+        mock_urlopen.assert_called_once()
+
+
+class TestGetJwtValidation:
+    """Tests for get_jwt() input validation and edge cases."""
+
+    @staticmethod
+    def _make_jwt(exp):
+        """Create a minimal JWT with a given exp for testing."""
+        import base64
+        header = base64.urlsafe_b64encode(json.dumps({"alg": "HS256"}).encode()).rstrip(b"=")
+        payload = base64.urlsafe_b64encode(json.dumps({"exp": exp}).encode()).rstrip(b"=")
+        sig = base64.urlsafe_b64encode(b"sig").rstrip(b"=")
+        return f"{header.decode()}.{payload.decode()}.{sig.decode()}"
+
+    @patch("limacharlie.jwt_cache.get_cached_jwt", return_value=None)
+    def test_get_jwt_zero_expiry_raises_validation_error(self, mock_get_cached):
+        """get_jwt(expiry_hours=0) should raise ValidationError."""
+        from limacharlie.errors import ValidationError
+
+        client = Client(oid="test-oid", api_key="test-key")
+        with pytest.raises(ValidationError, match="positive"):
+            client.get_jwt(expiry_hours=0)
+
+    @patch("limacharlie.jwt_cache.get_cached_jwt", return_value=None)
+    def test_get_jwt_negative_expiry_raises_validation_error(self, mock_get_cached):
+        """get_jwt(expiry_hours=-1) should raise ValidationError."""
+        from limacharlie.errors import ValidationError
+
+        client = Client(oid="test-oid", api_key="test-key")
+        with pytest.raises(ValidationError, match="positive"):
+            client.get_jwt(expiry_hours=-1)
+
+    @patch("limacharlie.jwt_cache.get_cached_jwt", return_value=None)
+    @patch("limacharlie.client.urlopen")
+    def test_get_jwt_with_unparseable_cached_jwt_fetches_new(self, mock_urlopen, mock_get_cached):
+        """If self._jwt is set to a malformed string (no exp), get_jwt
+        should not crash and should fetch a new JWT instead."""
+        import time as time_module
+
+        fresh_jwt = self._make_jwt(time_module.time() + 5 * 3600)
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps({"jwt": fresh_jwt}).encode()
+        mock_response.close = MagicMock()
+        mock_urlopen.return_value = mock_response
+
+        client = Client(oid="test-oid", api_key="test-key")
+        # Set a malformed JWT that has no parseable exp
+        client._jwt = "not.a.validjwt"
+        result = client.get_jwt(expiry_hours=4.0)
+        assert result == fresh_jwt
+        mock_urlopen.assert_called_once()
+
+
+class TestOnRefreshAuthCacheIntegration:
+    """Tests for on_refresh_auth callback interaction with JWT cache."""
+
+    @staticmethod
+    def _make_jwt(exp):
+        """Create a minimal JWT with a given exp for testing."""
+        import base64
+        header = base64.urlsafe_b64encode(json.dumps({"alg": "HS256"}).encode()).rstrip(b"=")
+        payload = base64.urlsafe_b64encode(json.dumps({"exp": exp}).encode()).rstrip(b"=")
+        sig = base64.urlsafe_b64encode(b"sig").rstrip(b"=")
+        return f"{header.decode()}.{payload.decode()}.{sig.decode()}"
+
+    @patch("limacharlie.jwt_cache.get_cached_jwt")
+    @patch("limacharlie.client.urlopen")
+    def test_on_refresh_auth_not_called_when_cache_hit(self, mock_urlopen, mock_get_cached):
+        """When a valid JWT is loaded from cache, on_refresh_auth should
+        NOT be invoked during request() because no JWT refresh is needed."""
+        import time as time_module
+
+        cached_jwt = self._make_jwt(time_module.time() + 3600)
+        mock_get_cached.return_value = cached_jwt
+
+        callback = MagicMock()
+
+        # Mock API response
+        api_response = MagicMock()
+        api_response.read.return_value = json.dumps({"ok": True}).encode()
+        api_response.close = MagicMock()
+        api_response.getheaders.return_value = []
+        mock_urlopen.return_value = api_response
+
+        client = Client(oid="test-oid", api_key="test-key", on_refresh_auth=callback)
+        assert client._jwt == cached_jwt
+
+        result = client.request("GET", "test")
+        assert result == {"ok": True}
+        # The callback should NOT have been called since JWT was already set
+        callback.assert_not_called()
+        # Only 1 HTTP call (the API request), no JWT endpoint call
+        assert mock_urlopen.call_count == 1
 
 
 class TestBuildUserAgent:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -24,6 +24,7 @@ from limacharlie.errors import ConfigError
 @pytest.fixture
 def tmp_config_file(monkeypatch, tmp_path):
     """Create a temporary config file and point config module to it."""
+    from limacharlie.config import _reset_config_cache
     config_path = str(tmp_path / ".limacharlie")
     monkeypatch.setattr("limacharlie.config.CONFIG_FILE_PATH", config_path)
     monkeypatch.delenv("LC_CREDS_FILE", raising=False)
@@ -32,7 +33,9 @@ def tmp_config_file(monkeypatch, tmp_path):
     monkeypatch.delenv("LC_UID", raising=False)
     monkeypatch.delenv("LC_CURRENT_ENV", raising=False)
     monkeypatch.delenv("LC_EPHEMERAL_CREDS", raising=False)
-    return config_path
+    _reset_config_cache()
+    yield config_path
+    _reset_config_cache()
 
 
 class TestLoadConfig:
@@ -275,6 +278,75 @@ class TestGetConfigValue:
         """Config values can be any YAML type."""
         save_config({"my_key": "hello"})
         assert get_config_value("my_key") == "hello"
+
+
+class TestConfigCaching:
+    """Tests for the per-process config caching behavior."""
+
+    def test_load_config_returns_cached_on_second_call(self, tmp_config_file, monkeypatch):
+        """Call load_config() twice, verify the file is only read once.
+
+        Uses monkeypatch to track calls to safe_open_read. The second
+        call should return the cached result without re-reading the file.
+        """
+        data = {"oid": "cached-test"}
+        with open(tmp_config_file, "w") as f:
+            yaml.safe_dump(data, f)
+
+        call_count = {"n": 0}
+        original_safe_open_read = None
+        import limacharlie.config as config_mod
+        original_safe_open_read = config_mod.safe_open_read
+
+        def tracking_open_read(path):
+            call_count["n"] += 1
+            return original_safe_open_read(path)
+
+        monkeypatch.setattr("limacharlie.config.safe_open_read", tracking_open_read)
+
+        result1 = load_config()
+        result2 = load_config()
+        assert result1 == {"oid": "cached-test"}
+        assert result2 == {"oid": "cached-test"}
+        assert call_count["n"] == 1, "safe_open_read should be called exactly once"
+
+    def test_save_config_updates_cache(self, tmp_config_file):
+        """Call save_config({'oid': 'x'}) then load_config() without resetting.
+
+        load_config() should return {'oid': 'x'} from the in-process
+        cache without needing to read the file again.
+        """
+        save_config({"oid": "x"})
+        result = load_config()
+        assert result == {"oid": "x"}
+
+    def test_write_credentials_does_not_corrupt_cache_on_failure(self, tmp_config_file, monkeypatch):
+        """Set ephemeral mode AFTER writing initial config.
+
+        write_credentials should raise ConfigError (from save_config).
+        After unsetting ephemeral and resetting the cache, load_config()
+        should still return the original data. This verifies that
+        write_credentials uses deepcopy to avoid corrupting the cached
+        config dict when save_config fails.
+        """
+        from limacharlie.config import _reset_config_cache
+
+        # Write initial config
+        save_config({"oid": "original", "api_key": "key1"})
+        # Verify it loads
+        assert load_config() == {"oid": "original", "api_key": "key1"}
+
+        # Now set ephemeral mode so save_config will raise
+        monkeypatch.setenv("LC_EPHEMERAL_CREDS", "1")
+        with pytest.raises(ConfigError):
+            write_credentials("default", "corrupted-oid", "corrupted-key")
+
+        # Unset ephemeral and reset cache to force re-read from disk
+        monkeypatch.delenv("LC_EPHEMERAL_CREDS")
+        _reset_config_cache()
+        result = load_config()
+        assert result["oid"] == "original"
+        assert result["api_key"] == "key1"
 
 
 class TestIsEphemeral:

--- a/tests/unit/test_file_utils.py
+++ b/tests/unit/test_file_utils.py
@@ -1,0 +1,233 @@
+"""Tests for limacharlie.file_utils module."""
+
+import os
+import stat
+
+import pytest
+
+from limacharlie.file_utils import (
+    _reject_symlink,
+    atomic_write,
+    safe_open_read,
+    secure_file_permissions,
+)
+
+
+class TestSecureFilePermissions:
+    def test_sets_owner_only_permissions(self, tmp_path):
+        path = str(tmp_path / "secret")
+        with open(path, "w") as f:
+            f.write("data")
+        secure_file_permissions(path)
+        mode = os.stat(path).st_mode
+        assert mode & 0o777 == 0o600
+
+    @pytest.mark.skipif(os.name == "nt", reason="Unix-only ownership check")
+    def test_sets_ownership_to_current_user(self, tmp_path):
+        path = str(tmp_path / "secret")
+        with open(path, "w") as f:
+            f.write("data")
+        secure_file_permissions(path)
+        st = os.stat(path)
+        assert st.st_uid == os.getuid()
+        assert st.st_gid == os.getgid()
+
+    def test_works_on_existing_file_with_open_permissions(self, tmp_path):
+        path = str(tmp_path / "open_file")
+        with open(path, "w") as f:
+            f.write("data")
+        os.chmod(path, 0o777)
+        secure_file_permissions(path)
+        mode = os.stat(path).st_mode
+        assert mode & 0o777 == 0o600
+
+    def test_nonexistent_file_raises(self, tmp_path):
+        path = str(tmp_path / "nonexistent")
+        with pytest.raises(OSError):
+            secure_file_permissions(path)
+
+
+class TestAtomicWrite:
+    def test_writes_content_correctly(self, tmp_path):
+        path = str(tmp_path / "out")
+        atomic_write(path, b"hello world")
+        with open(path, "rb") as f:
+            assert f.read() == b"hello world"
+
+    def test_file_has_restricted_permissions(self, tmp_path):
+        path = str(tmp_path / "out")
+        atomic_write(path, b"secret")
+        mode = os.stat(path).st_mode
+        assert mode & 0o777 == 0o600
+
+    def test_overwrites_existing_file(self, tmp_path):
+        path = str(tmp_path / "out")
+        with open(path, "w") as f:
+            f.write("old content")
+        atomic_write(path, b"new content")
+        with open(path, "rb") as f:
+            assert f.read() == b"new content"
+
+    def test_temp_file_cleaned_up_on_success(self, tmp_path):
+        path = str(tmp_path / "out")
+        atomic_write(path, b"data")
+        # Only the target file should exist, no temp files
+        files = os.listdir(tmp_path)
+        assert files == ["out"]
+
+    def test_content_must_be_bytes(self, tmp_path):
+        path = str(tmp_path / "out")
+        with pytest.raises(TypeError):
+            atomic_write(path, "not bytes")
+
+    def test_empty_content(self, tmp_path):
+        path = str(tmp_path / "out")
+        atomic_write(path, b"")
+        with open(path, "rb") as f:
+            assert f.read() == b""
+
+    def test_large_content(self, tmp_path):
+        path = str(tmp_path / "out")
+        data = b"x" * (1024 * 1024)  # 1MB
+        atomic_write(path, data)
+        with open(path, "rb") as f:
+            assert f.read() == data
+
+    @pytest.mark.skipif(os.name == "nt", reason="Unix-only symlink test")
+    def test_refuses_to_write_through_symlink(self, tmp_path):
+        """Symlink attack: attacker places symlink at cache path pointing
+        to a sensitive file. atomic_write must refuse."""
+        target = str(tmp_path / "sensitive_file")
+        with open(target, "w") as f:
+            f.write("original")
+        link = str(tmp_path / "symlink_cache")
+        os.symlink(target, link)
+        with pytest.raises(OSError, match="symlink"):
+            atomic_write(link, b"overwritten")
+        # Verify the target file was not modified
+        with open(target, "r") as f:
+            assert f.read() == "original"
+
+    @pytest.mark.skipif(os.name == "nt", reason="Unix-only symlink test")
+    def test_refuses_to_write_through_symlinked_parent(self, tmp_path):
+        """Attacker places symlink as parent directory."""
+        real_dir = str(tmp_path / "real")
+        os.makedirs(real_dir)
+        link_dir = str(tmp_path / "link")
+        os.symlink(real_dir, link_dir)
+        path = os.path.join(link_dir, "file")
+        with pytest.raises(OSError, match="symlink"):
+            atomic_write(path, b"data")
+
+    def test_fd_not_leaked_on_permission_error(self, tmp_path):
+        """If secure_file_permissions raises, fd must still be closed."""
+        path = str(tmp_path / "out")
+        # Write a file first so we can verify no fd leak
+        atomic_write(path, b"first")
+        # Second write should work (fd from first call was properly closed)
+        atomic_write(path, b"second")
+        with open(path, "rb") as f:
+            assert f.read() == b"second"
+
+
+class TestSafeOpenRead:
+    def test_reads_normal_file(self, tmp_path):
+        path = str(tmp_path / "data")
+        with open(path, "wb") as f:
+            f.write(b"hello")
+        assert safe_open_read(path) == b"hello"
+
+    @pytest.mark.skipif(os.name == "nt", reason="Unix-only symlink test")
+    def test_refuses_to_read_symlink(self, tmp_path):
+        """Reading through a symlink could feed attacker-controlled data."""
+        target = str(tmp_path / "real")
+        with open(target, "w") as f:
+            f.write("real data")
+        link = str(tmp_path / "link")
+        os.symlink(target, link)
+        with pytest.raises(OSError, match="symlink"):
+            safe_open_read(link)
+
+    @pytest.mark.skipif(os.name == "nt", reason="Unix-only symlink test")
+    def test_refuses_to_read_through_symlinked_parent(self, tmp_path):
+        real_dir = str(tmp_path / "real")
+        os.makedirs(real_dir)
+        target = os.path.join(real_dir, "file")
+        with open(target, "w") as f:
+            f.write("data")
+        link_dir = str(tmp_path / "link")
+        os.symlink(real_dir, link_dir)
+        with pytest.raises(OSError, match="symlink"):
+            safe_open_read(os.path.join(link_dir, "file"))
+
+    def test_nonexistent_file_raises(self, tmp_path):
+        with pytest.raises(OSError):
+            safe_open_read(str(tmp_path / "nonexistent"))
+
+    @pytest.mark.skipif(os.name == "nt", reason="Unix-only O_NOFOLLOW test")
+    def test_o_nofollow_rejects_symlink_at_kernel_level(self, tmp_path):
+        """Verify the O_NOFOLLOW path works independently of _reject_symlink.
+
+        Even if the pre-check were somehow bypassed, O_NOFOLLOW in the
+        kernel open() call would reject the symlink.
+        """
+        target = str(tmp_path / "secret")
+        with open(target, "w") as f:
+            f.write("secret data")
+        link = str(tmp_path / "link")
+        os.symlink(target, link)
+        # Directly call os.open with O_NOFOLLOW to verify kernel rejects it
+        with pytest.raises(OSError):
+            os.open(link, os.O_RDONLY | os.O_NOFOLLOW)
+
+    @pytest.mark.skipif(os.name == "nt", reason="Unix-only symlink test")
+    def test_safe_open_read_does_not_leak_fd_on_symlink(self, tmp_path):
+        """Verify that fd is properly handled when symlink is detected."""
+        target = str(tmp_path / "target")
+        with open(target, "w") as f:
+            f.write("data")
+        link = str(tmp_path / "link")
+        os.symlink(target, link)
+        # Call multiple times to ensure no fd accumulation
+        for _ in range(10):
+            with pytest.raises(OSError):
+                safe_open_read(link)
+
+
+class TestRejectSymlink:
+    @pytest.mark.skipif(os.name == "nt", reason="Unix-only symlink test")
+    def test_rejects_file_symlink(self, tmp_path):
+        target = str(tmp_path / "target")
+        with open(target, "w") as f:
+            f.write("data")
+        link = str(tmp_path / "link")
+        os.symlink(target, link)
+        with pytest.raises(OSError, match="symlink"):
+            _reject_symlink(link)
+
+    @pytest.mark.skipif(os.name == "nt", reason="Unix-only symlink test")
+    def test_rejects_directory_symlink_parent(self, tmp_path):
+        real_dir = str(tmp_path / "real")
+        os.makedirs(real_dir)
+        link_dir = str(tmp_path / "link")
+        os.symlink(real_dir, link_dir)
+        with pytest.raises(OSError, match="symlink"):
+            _reject_symlink(os.path.join(link_dir, "file"))
+
+    def test_accepts_regular_file(self, tmp_path):
+        path = str(tmp_path / "regular")
+        with open(path, "w") as f:
+            f.write("data")
+        _reject_symlink(path)  # should not raise
+
+    def test_accepts_nonexistent_path(self, tmp_path):
+        # Nonexistent path is not a symlink
+        _reject_symlink(str(tmp_path / "nonexistent"))  # should not raise
+
+    @pytest.mark.skipif(os.name == "nt", reason="Unix-only symlink test")
+    def test_rejects_dangling_symlink(self, tmp_path):
+        """A symlink pointing to nothing is still a symlink."""
+        link = str(tmp_path / "dangling")
+        os.symlink("/nonexistent/target", link)
+        with pytest.raises(OSError, match="symlink"):
+            _reject_symlink(link)

--- a/tests/unit/test_jwt_cache.py
+++ b/tests/unit/test_jwt_cache.py
@@ -1,0 +1,757 @@
+"""Tests for limacharlie.jwt_cache module."""
+
+import base64
+import json
+import os
+import time
+
+import pytest
+
+from limacharlie.jwt_cache import (
+    _compute_cache_key,
+    _decode_jwt_exp,
+    _get_cache_path,
+    _is_cache_disabled,
+    _load_cache,
+    _reset_cache_disabled,
+    _save_cache,
+    clear_jwt_cache,
+    get_cached_jwt,
+    invalidate_cached_jwt,
+    put_cached_jwt,
+)
+
+
+def _make_jwt(exp: float | int) -> str:
+    """Create a minimal JWT with a given exp claim for testing.
+
+    Not cryptographically valid - just valid base64url structure
+    with a parseable payload containing an exp claim.
+    """
+    header = base64.urlsafe_b64encode(json.dumps({"alg": "HS256"}).encode()).rstrip(b"=")
+    payload = base64.urlsafe_b64encode(json.dumps({"exp": exp}).encode()).rstrip(b"=")
+    signature = base64.urlsafe_b64encode(b"fakesig").rstrip(b"=")
+    return f"{header.decode()}.{payload.decode()}.{signature.decode()}"
+
+
+@pytest.fixture(autouse=False)
+def tmp_jwt_cache(monkeypatch, tmp_path):
+    """Point JWT cache to a temp directory and clear relevant env vars."""
+    from limacharlie.config import _reset_config_cache
+
+    config_path = str(tmp_path / ".limacharlie")
+    cache_path = config_path + "_jwt_cache"
+    monkeypatch.setattr("limacharlie.jwt_cache.CONFIG_FILE_PATH", config_path)
+    monkeypatch.setattr("limacharlie.config.CONFIG_FILE_PATH", config_path)
+    monkeypatch.delenv("LC_CREDS_FILE", raising=False)
+    monkeypatch.delenv("LC_EPHEMERAL_CREDS", raising=False)
+    monkeypatch.delenv("LC_NO_JWT_CACHE", raising=False)
+    # Reset per-process caches so each test evaluates fresh
+    _reset_cache_disabled()
+    _reset_config_cache()
+    yield cache_path
+    _reset_cache_disabled()
+    _reset_config_cache()
+
+
+class TestComputeCacheKey:
+    def test_different_oids_produce_different_keys(self):
+        k1 = _compute_cache_key("oid1", "key", None, None)
+        k2 = _compute_cache_key("oid2", "key", None, None)
+        assert k1 != k2
+
+    def test_different_api_keys_produce_different_keys(self):
+        k1 = _compute_cache_key("oid", "key1", None, None)
+        k2 = _compute_cache_key("oid", "key2", None, None)
+        assert k1 != k2
+
+    def test_different_uids_produce_different_keys(self):
+        k1 = _compute_cache_key("oid", "key", None, "uid1")
+        k2 = _compute_cache_key("oid", "key", None, "uid2")
+        assert k1 != k2
+
+    def test_oauth_vs_api_key_produce_different_keys(self):
+        k1 = _compute_cache_key("oid", "key", None, None)
+        k2 = _compute_cache_key("oid", None, {"refresh_token": "rt"}, None)
+        assert k1 != k2
+
+    def test_deterministic(self):
+        k1 = _compute_cache_key("oid", "key", None, "uid")
+        k2 = _compute_cache_key("oid", "key", None, "uid")
+        assert k1 == k2
+
+    def test_none_oid_returns_none(self):
+        assert _compute_cache_key(None, "key", None, None) is None
+
+    def test_no_api_key_and_no_oauth_returns_none(self):
+        assert _compute_cache_key("oid", None, None, None) is None
+
+    def test_empty_string_oid_is_valid(self):
+        k = _compute_cache_key("", "key", None, None)
+        assert k is not None
+
+    def test_oauth_with_no_refresh_token_still_produces_key(self):
+        k = _compute_cache_key("oid", None, {"id_token": "tok"}, None)
+        assert k is not None
+
+    def test_key_is_hex_sha256(self):
+        k = _compute_cache_key("oid", "key", None, None)
+        assert len(k) == 64
+        int(k, 16)  # should not raise
+
+
+class TestDecodeJwtExp:
+    def test_valid_jwt_returns_exp(self):
+        exp = time.time() + 3600
+        jwt = _make_jwt(exp)
+        assert _decode_jwt_exp(jwt) == pytest.approx(exp)
+
+    def test_no_exp_claim_returns_none(self):
+        header = base64.urlsafe_b64encode(json.dumps({"alg": "HS256"}).encode()).rstrip(b"=")
+        payload = base64.urlsafe_b64encode(json.dumps({"sub": "user"}).encode()).rstrip(b"=")
+        sig = base64.urlsafe_b64encode(b"sig").rstrip(b"=")
+        jwt = f"{header.decode()}.{payload.decode()}.{sig.decode()}"
+        assert _decode_jwt_exp(jwt) is None
+
+    def test_malformed_jwt_not_three_segments(self):
+        assert _decode_jwt_exp("only.two") is None
+        assert _decode_jwt_exp("one") is None
+        assert _decode_jwt_exp("a.b.c.d") is None
+
+    def test_invalid_base64_in_payload(self):
+        assert _decode_jwt_exp("a.!!!invalid!!!.c") is None
+
+    def test_non_json_payload(self):
+        header = base64.urlsafe_b64encode(b"header").rstrip(b"=")
+        payload = base64.urlsafe_b64encode(b"not json").rstrip(b"=")
+        sig = base64.urlsafe_b64encode(b"sig").rstrip(b"=")
+        jwt = f"{header.decode()}.{payload.decode()}.{sig.decode()}"
+        assert _decode_jwt_exp(jwt) is None
+
+    def test_base64url_without_padding(self):
+        # Ensure base64url decoding works with payloads that need padding
+        exp = 1700000000
+        jwt = _make_jwt(exp)
+        # Verify no padding in the token
+        assert "=" not in jwt
+        assert _decode_jwt_exp(jwt) == exp
+
+    def test_integer_exp(self):
+        assert _decode_jwt_exp(_make_jwt(1700000000)) == 1700000000.0
+
+    def test_float_exp(self):
+        assert _decode_jwt_exp(_make_jwt(1700000000.5)) == 1700000000.5
+
+    def test_very_large_exp(self):
+        exp = 9999999999
+        assert _decode_jwt_exp(_make_jwt(exp)) == exp
+
+    def test_empty_string(self):
+        assert _decode_jwt_exp("") is None
+
+    def test_negative_exp(self):
+        """JWT with exp: -1 should return -1.0 (valid float, caller handles it)."""
+        assert _decode_jwt_exp(_make_jwt(-1)) == -1.0
+
+    def test_non_numeric_exp(self):
+        """JWT with exp: 'not a number' should return None (float() fails)."""
+        header = base64.urlsafe_b64encode(json.dumps({"alg": "HS256"}).encode()).rstrip(b"=")
+        payload = base64.urlsafe_b64encode(json.dumps({"exp": "not a number"}).encode()).rstrip(b"=")
+        sig = base64.urlsafe_b64encode(b"sig").rstrip(b"=")
+        jwt = f"{header.decode()}.{payload.decode()}.{sig.decode()}"
+        assert _decode_jwt_exp(jwt) is None
+
+    def test_exp_is_dict(self):
+        """JWT with exp: {'nested': 1} should return None."""
+        header = base64.urlsafe_b64encode(json.dumps({"alg": "HS256"}).encode()).rstrip(b"=")
+        payload = base64.urlsafe_b64encode(json.dumps({"exp": {"nested": 1}}).encode()).rstrip(b"=")
+        sig = base64.urlsafe_b64encode(b"sig").rstrip(b"=")
+        jwt = f"{header.decode()}.{payload.decode()}.{sig.decode()}"
+        assert _decode_jwt_exp(jwt) is None
+
+
+class TestGetCachedJwt:
+    def test_returns_cached_jwt_when_valid(self, tmp_jwt_cache):
+        exp = time.time() + 3600  # 1 hour from now
+        jwt = _make_jwt(exp)
+        put_cached_jwt(jwt, "oid", "key", None, None)
+        result = get_cached_jwt("oid", "key", None, None)
+        assert result == jwt
+
+    def test_returns_none_when_cache_empty(self, tmp_jwt_cache):
+        assert get_cached_jwt("oid", "key", None, None) is None
+
+    def test_returns_none_when_key_doesnt_match(self, tmp_jwt_cache):
+        exp = time.time() + 3600
+        put_cached_jwt(_make_jwt(exp), "oid", "key1", None, None)
+        assert get_cached_jwt("oid", "key2", None, None) is None
+
+    def test_returns_none_within_expiry_buffer(self, tmp_jwt_cache):
+        # JWT expires in 5 minutes - within the 10 minute buffer
+        exp = time.time() + 300
+        put_cached_jwt(_make_jwt(exp), "oid", "key", None, None)
+        assert get_cached_jwt("oid", "key", None, None) is None
+
+    def test_returns_none_when_expired(self, tmp_jwt_cache):
+        exp = time.time() - 100  # already expired
+        put_cached_jwt(_make_jwt(exp), "oid", "key", None, None)
+        assert get_cached_jwt("oid", "key", None, None) is None
+
+    def test_returns_none_when_ephemeral(self, tmp_jwt_cache, monkeypatch):
+        exp = time.time() + 3600
+        put_cached_jwt(_make_jwt(exp), "oid", "key", None, None)
+        monkeypatch.setenv("LC_EPHEMERAL_CREDS", "1")
+        _reset_cache_disabled()  # env changed, force re-evaluation
+        assert get_cached_jwt("oid", "key", None, None) is None
+
+    def test_returns_none_when_no_jwt_cache_env(self, tmp_jwt_cache, monkeypatch):
+        exp = time.time() + 3600
+        put_cached_jwt(_make_jwt(exp), "oid", "key", None, None)
+        monkeypatch.setenv("LC_NO_JWT_CACHE", "1")
+        _reset_cache_disabled()  # env changed, force re-evaluation
+        assert get_cached_jwt("oid", "key", None, None) is None
+
+    def test_returns_none_when_no_jwt_cache_config(self, tmp_jwt_cache):
+        exp = time.time() + 3600
+        put_cached_jwt(_make_jwt(exp), "oid", "key", None, None)
+        import yaml
+        config_path = tmp_jwt_cache[: -len("_jwt_cache")]
+        with open(config_path, "w") as f:
+            yaml.safe_dump({"no_jwt_cache": True}, f)
+        _reset_cache_disabled()  # config changed, force re-evaluation
+        from limacharlie.config import _reset_config_cache
+        _reset_config_cache()
+        assert get_cached_jwt("oid", "key", None, None) is None
+
+    def test_returns_none_when_cache_file_missing(self, tmp_jwt_cache):
+        assert get_cached_jwt("oid", "key", None, None) is None
+
+    def test_returns_none_on_invalid_json(self, tmp_jwt_cache):
+        path = _get_cache_path()
+        with open(path, "w") as f:
+            f.write("not json{{{")
+        assert get_cached_jwt("oid", "key", None, None) is None
+
+    def test_returns_none_when_oid_is_none(self, tmp_jwt_cache):
+        assert get_cached_jwt(None, "key", None, None) is None
+
+    def test_returns_none_when_no_creds(self, tmp_jwt_cache):
+        assert get_cached_jwt("oid", None, None, None) is None
+
+    def test_returns_none_at_exact_buffer_boundary(self, tmp_jwt_cache):
+        """JWT with exp exactly at time.time() + 600 should return None.
+
+        The boundary check is >= (time.time() + 600 >= exp), so a JWT
+        expiring exactly at the buffer boundary is considered too close.
+        """
+        exp = time.time() + 600  # exactly at buffer boundary
+        jwt = _make_jwt(exp)
+        put_cached_jwt(jwt, "oid", "key", None, None)
+        assert get_cached_jwt("oid", "key", None, None) is None
+
+    def test_returns_jwt_one_second_past_buffer(self, tmp_jwt_cache):
+        """JWT with exp at time.time() + 601 should be returned.
+
+        One second past the 600-second buffer means the JWT still has
+        enough remaining lifetime to be useful.
+        """
+        exp = time.time() + 601
+        jwt = _make_jwt(exp)
+        put_cached_jwt(jwt, "oid", "key", None, None)
+        assert get_cached_jwt("oid", "key", None, None) == jwt
+
+    def test_returns_none_when_jwt_in_cache_has_unparseable_exp(self, tmp_jwt_cache):
+        """Write a malformed JWT string directly to the cache JSON file,
+        then get should return None because the exp cannot be parsed."""
+        key = _compute_cache_key("oid", "key", None, None)
+        path = _get_cache_path()
+        # Write a JWT-like string with an invalid payload that can't be decoded
+        malformed_jwt = "header.!!!invalidbase64!!!.signature"
+        with open(path, "w") as f:
+            json.dump({key: {"jwt": malformed_jwt}}, f)
+        os.chmod(path, 0o600)
+        assert get_cached_jwt("oid", "key", None, None) is None
+
+
+class TestPutCachedJwt:
+    def test_writes_jwt_to_cache(self, tmp_jwt_cache):
+        exp = time.time() + 3600
+        jwt = _make_jwt(exp)
+        put_cached_jwt(jwt, "oid", "key", None, None)
+        path = _get_cache_path()
+        assert os.path.isfile(path)
+        with open(path, "r") as f:
+            data = json.load(f)
+        assert len(data) == 1
+        entry = list(data.values())[0]
+        assert entry["jwt"] == jwt
+
+    def test_file_has_restricted_permissions(self, tmp_jwt_cache):
+        exp = time.time() + 3600
+        put_cached_jwt(_make_jwt(exp), "oid", "key", None, None)
+        path = _get_cache_path()
+        mode = os.stat(path).st_mode
+        assert mode & 0o777 == 0o600
+
+    def test_preserves_existing_entries(self, tmp_jwt_cache):
+        exp = time.time() + 3600
+        put_cached_jwt(_make_jwt(exp), "oid1", "key1", None, None)
+        put_cached_jwt(_make_jwt(exp), "oid2", "key2", None, None)
+        path = _get_cache_path()
+        with open(path, "r") as f:
+            data = json.load(f)
+        assert len(data) == 2
+
+    def test_overwrites_same_cache_key(self, tmp_jwt_cache):
+        exp1 = time.time() + 3600
+        exp2 = time.time() + 7200
+        jwt1 = _make_jwt(exp1)
+        jwt2 = _make_jwt(exp2)
+        put_cached_jwt(jwt1, "oid", "key", None, None)
+        put_cached_jwt(jwt2, "oid", "key", None, None)
+        result = get_cached_jwt("oid", "key", None, None)
+        assert result == jwt2
+
+    def test_noop_when_ephemeral(self, tmp_jwt_cache, monkeypatch):
+        monkeypatch.setenv("LC_EPHEMERAL_CREDS", "1")
+        exp = time.time() + 3600
+        put_cached_jwt(_make_jwt(exp), "oid", "key", None, None)
+        path = _get_cache_path()
+        assert not os.path.isfile(path)
+
+    def test_noop_when_no_jwt_cache_env(self, tmp_jwt_cache, monkeypatch):
+        monkeypatch.setenv("LC_NO_JWT_CACHE", "1")
+        exp = time.time() + 3600
+        put_cached_jwt(_make_jwt(exp), "oid", "key", None, None)
+        path = _get_cache_path()
+        assert not os.path.isfile(path)
+
+    def test_noop_when_no_jwt_cache_config(self, tmp_jwt_cache):
+        import yaml
+        # Derive config path: cache path minus _jwt_cache suffix
+        config_path = tmp_jwt_cache[: -len("_jwt_cache")]
+        with open(config_path, "w") as f:
+            yaml.safe_dump({"no_jwt_cache": True}, f)
+        exp = time.time() + 3600
+        put_cached_jwt(_make_jwt(exp), "oid", "key", None, None)
+        assert not os.path.isfile(tmp_jwt_cache)
+
+    def test_noop_when_jwt_exp_is_negative(self, tmp_jwt_cache):
+        """JWT with exp=-1 should still be written because put_cached_jwt
+        only checks that _decode_jwt_exp returns non-None, and -1 is a
+        valid float. It does not check whether the JWT is actually expired."""
+        jwt = _make_jwt(-1)
+        put_cached_jwt(jwt, "oid", "key", None, None)
+        path = _get_cache_path()
+        assert os.path.isfile(path)
+        with open(path, "r") as f:
+            data = json.load(f)
+        entry = list(data.values())[0]
+        assert entry["jwt"] == jwt
+
+    def test_noop_when_jwt_has_no_exp(self, tmp_jwt_cache):
+        header = base64.urlsafe_b64encode(json.dumps({"alg": "HS256"}).encode()).rstrip(b"=")
+        payload = base64.urlsafe_b64encode(json.dumps({"sub": "user"}).encode()).rstrip(b"=")
+        sig = base64.urlsafe_b64encode(b"sig").rstrip(b"=")
+        jwt = f"{header.decode()}.{payload.decode()}.{sig.decode()}"
+        put_cached_jwt(jwt, "oid", "key", None, None)
+        path = _get_cache_path()
+        assert not os.path.isfile(path)
+
+    def test_noop_when_oid_is_none(self, tmp_jwt_cache):
+        exp = time.time() + 3600
+        put_cached_jwt(_make_jwt(exp), None, "key", None, None)
+        path = _get_cache_path()
+        assert not os.path.isfile(path)
+
+    def test_creates_parent_dirs(self, tmp_path, monkeypatch):
+        nested_config = str(tmp_path / "deep" / "nested" / ".limacharlie")
+        monkeypatch.setenv("LC_CREDS_FILE", nested_config)
+        monkeypatch.delenv("LC_EPHEMERAL_CREDS", raising=False)
+        exp = time.time() + 3600
+        put_cached_jwt(_make_jwt(exp), "oid", "key", None, None)
+        cache_path = nested_config + "_jwt_cache"
+        assert os.path.isfile(cache_path)
+
+    def test_handles_unwritable_dir_gracefully(self, tmp_path, monkeypatch):
+        unwritable = str(tmp_path / "noperm")
+        os.makedirs(unwritable)
+        os.chmod(unwritable, 0o444)
+        monkeypatch.setenv("LC_CREDS_FILE", str(os.path.join(unwritable, "config")))
+        monkeypatch.delenv("LC_EPHEMERAL_CREDS", raising=False)
+        exp = time.time() + 3600
+        # Should not raise
+        put_cached_jwt(_make_jwt(exp), "oid", "key", None, None)
+        # Restore permissions for cleanup
+        os.chmod(unwritable, 0o755)
+
+
+class TestInvalidateCachedJwt:
+    def test_removes_specific_entry(self, tmp_jwt_cache):
+        exp = time.time() + 3600
+        put_cached_jwt(_make_jwt(exp), "oid1", "key1", None, None)
+        put_cached_jwt(_make_jwt(exp), "oid2", "key2", None, None)
+        invalidate_cached_jwt("oid1", "key1", None, None)
+        assert get_cached_jwt("oid1", "key1", None, None) is None
+        assert get_cached_jwt("oid2", "key2", None, None) is not None
+
+    def test_leaves_other_entries_intact(self, tmp_jwt_cache):
+        exp = time.time() + 3600
+        jwt2 = _make_jwt(exp)
+        put_cached_jwt(_make_jwt(exp), "oid1", "key1", None, None)
+        put_cached_jwt(jwt2, "oid2", "key2", None, None)
+        invalidate_cached_jwt("oid1", "key1", None, None)
+        assert get_cached_jwt("oid2", "key2", None, None) == jwt2
+
+    def test_noop_when_entry_missing(self, tmp_jwt_cache):
+        exp = time.time() + 3600
+        put_cached_jwt(_make_jwt(exp), "oid", "key", None, None)
+        invalidate_cached_jwt("other-oid", "other-key", None, None)
+        assert get_cached_jwt("oid", "key", None, None) is not None
+
+    def test_noop_when_cache_file_missing(self, tmp_jwt_cache):
+        # Should not raise
+        invalidate_cached_jwt("oid", "key", None, None)
+
+
+class TestClearJwtCache:
+    def test_deletes_cache_file(self, tmp_jwt_cache):
+        exp = time.time() + 3600
+        put_cached_jwt(_make_jwt(exp), "oid", "key", None, None)
+        path = _get_cache_path()
+        assert os.path.isfile(path)
+        clear_jwt_cache()
+        assert not os.path.isfile(path)
+
+    def test_noop_when_file_missing(self, tmp_jwt_cache):
+        # Should not raise
+        clear_jwt_cache()
+
+    @pytest.mark.skipif(os.name == "nt", reason="Unix-only symlink test")
+    def test_clear_removes_symlink_itself(self, tmp_jwt_cache, tmp_path):
+        """clear_jwt_cache() should remove the symlink at the cache path,
+        not the target file the symlink points to."""
+        target = str(tmp_path / "symlink_target")
+        with open(target, "w") as f:
+            f.write("target content")
+        cache_path = _get_cache_path()
+        os.symlink(target, cache_path)
+        assert os.path.islink(cache_path)
+        clear_jwt_cache()
+        # The symlink should be removed
+        assert not os.path.islink(cache_path)
+        # The target file should still exist
+        assert os.path.isfile(target)
+        with open(target, "r") as f:
+            assert f.read() == "target content"
+
+
+class TestCacheIntegration:
+    def test_full_round_trip(self, tmp_jwt_cache):
+        exp = time.time() + 3600
+        jwt = _make_jwt(exp)
+        put_cached_jwt(jwt, "oid", "key", None, None)
+        assert get_cached_jwt("oid", "key", None, None) == jwt
+
+    def test_near_expiry_jwt_not_returned(self, tmp_jwt_cache):
+        exp = time.time() + 300  # 5 minutes, within 10-min buffer
+        put_cached_jwt(_make_jwt(exp), "oid", "key", None, None)
+        assert get_cached_jwt("oid", "key", None, None) is None
+
+    def test_multiple_cache_keys_coexist(self, tmp_jwt_cache):
+        exp = time.time() + 3600
+        jwt1 = _make_jwt(exp)
+        jwt2 = _make_jwt(exp + 1)
+        put_cached_jwt(jwt1, "oid1", "key1", None, None)
+        put_cached_jwt(jwt2, "oid2", "key2", None, None)
+        assert get_cached_jwt("oid1", "key1", None, None) == jwt1
+        assert get_cached_jwt("oid2", "key2", None, None) == jwt2
+
+    def test_rapid_sequential_put_get(self, tmp_jwt_cache):
+        for i in range(20):
+            exp = time.time() + 3600
+            jwt = _make_jwt(exp)
+            put_cached_jwt(jwt, f"oid-{i}", f"key-{i}", None, None)
+            assert get_cached_jwt(f"oid-{i}", f"key-{i}", None, None) == jwt
+
+    def test_concurrent_like_puts_both_retrievable(self, tmp_jwt_cache):
+        exp = time.time() + 3600
+        jwt_a = _make_jwt(exp)
+        jwt_b = _make_jwt(exp + 1)
+        put_cached_jwt(jwt_a, "oidA", "keyA", None, None)
+        put_cached_jwt(jwt_b, "oidB", "keyB", None, None)
+        assert get_cached_jwt("oidA", "keyA", None, None) == jwt_a
+        assert get_cached_jwt("oidB", "keyB", None, None) == jwt_b
+
+    def test_cache_survives_process_boundary(self, tmp_jwt_cache):
+        """Simulate a 'process boundary' - write with one function, read back."""
+        exp = time.time() + 3600
+        jwt = _make_jwt(exp)
+        put_cached_jwt(jwt, "oid", "key", None, None)
+
+        # Read the raw cache file directly to prove it's on disk
+        path = _get_cache_path()
+        with open(path, "r") as f:
+            raw = json.load(f)
+        assert len(raw) == 1
+        entry = list(raw.values())[0]
+        assert entry["jwt"] == jwt
+
+        # Read back via the normal API
+        result = get_cached_jwt("oid", "key", None, None)
+        assert result == jwt
+
+
+class TestOAuthCacheRoundTrip:
+    """Verify caching works correctly for the OAuth authentication path."""
+
+    def test_oauth_put_and_get_round_trip(self, tmp_jwt_cache):
+        """OAuth-path put uses api_key=None, oauth_creds dict."""
+        exp = time.time() + 3600
+        jwt = _make_jwt(exp)
+        oauth_creds = {"id_token": "id-tok", "refresh_token": "ref-tok"}
+        put_cached_jwt(jwt, "oid", None, oauth_creds, None)
+        result = get_cached_jwt("oid", None, oauth_creds, None)
+        assert result == jwt
+
+    def test_oauth_and_api_key_coexist_independently(self, tmp_jwt_cache):
+        """Same OID but different auth methods get separate cache entries."""
+        exp = time.time() + 3600
+        jwt_api = _make_jwt(exp)
+        jwt_oauth = _make_jwt(exp + 1)  # slightly different to distinguish
+        oauth_creds = {"id_token": "id", "refresh_token": "ref"}
+        put_cached_jwt(jwt_api, "oid", "api-key", None, None)
+        put_cached_jwt(jwt_oauth, "oid", None, oauth_creds, None)
+        assert get_cached_jwt("oid", "api-key", None, None) == jwt_api
+        assert get_cached_jwt("oid", None, oauth_creds, None) == jwt_oauth
+
+    def test_oauth_invalidate_does_not_affect_api_key(self, tmp_jwt_cache):
+        exp = time.time() + 3600
+        jwt_api = _make_jwt(exp)
+        jwt_oauth = _make_jwt(exp + 1)
+        oauth_creds = {"id_token": "id", "refresh_token": "ref"}
+        put_cached_jwt(jwt_api, "oid", "api-key", None, None)
+        put_cached_jwt(jwt_oauth, "oid", None, oauth_creds, None)
+        invalidate_cached_jwt("oid", None, oauth_creds, None)
+        assert get_cached_jwt("oid", "api-key", None, None) == jwt_api
+        assert get_cached_jwt("oid", None, oauth_creds, None) is None
+
+    def test_oauth_updated_refresh_token_is_new_cache_key(self, tmp_jwt_cache):
+        """When OAuth token refresh changes the refresh_token, the old
+        cache entry becomes stale and a new one is written."""
+        exp = time.time() + 3600
+        jwt_old = _make_jwt(exp)
+        jwt_new = _make_jwt(exp + 1)
+        old_creds = {"id_token": "id1", "refresh_token": "old-ref"}
+        new_creds = {"id_token": "id2", "refresh_token": "new-ref"}
+        put_cached_jwt(jwt_old, "oid", None, old_creds, None)
+        put_cached_jwt(jwt_new, "oid", None, new_creds, None)
+        # New creds get the new JWT
+        assert get_cached_jwt("oid", None, new_creds, None) == jwt_new
+        # Old creds still see the old JWT (stale but valid until expiry)
+        assert get_cached_jwt("oid", None, old_creds, None) == jwt_old
+
+    def test_oauth_with_uid(self, tmp_jwt_cache):
+        """OAuth path with uid still caches correctly (uid not in OAuth key)."""
+        exp = time.time() + 3600
+        jwt = _make_jwt(exp)
+        oauth_creds = {"id_token": "id", "refresh_token": "ref"}
+        # OAuth path: uid is passed but _compute_cache_key ignores it for OAuth
+        put_cached_jwt(jwt, "oid", None, oauth_creds, "some-uid")
+        result = get_cached_jwt("oid", None, oauth_creds, "some-uid")
+        assert result == jwt
+
+
+class TestCacheEdgeCases:
+    def test_corrupt_cache_file_handled(self, tmp_jwt_cache):
+        path = _get_cache_path()
+        with open(path, "w") as f:
+            f.write('{"partial": ')
+        assert get_cached_jwt("oid", "key", None, None) is None
+        # Next put should overwrite the corrupt file
+        exp = time.time() + 3600
+        jwt = _make_jwt(exp)
+        put_cached_jwt(jwt, "oid", "key", None, None)
+        assert get_cached_jwt("oid", "key", None, None) == jwt
+
+    def test_empty_cache_file(self, tmp_jwt_cache):
+        path = _get_cache_path()
+        with open(path, "w") as f:
+            pass
+        assert get_cached_jwt("oid", "key", None, None) is None
+
+    def test_wrong_type_for_entry(self, tmp_jwt_cache):
+        """Cache entry is a string instead of a dict."""
+        path = _get_cache_path()
+        key = _compute_cache_key("oid", "key", None, None)
+        with open(path, "w") as f:
+            json.dump({key: "not a dict"}, f)
+        assert get_cached_jwt("oid", "key", None, None) is None
+
+    def test_very_long_jwt(self, tmp_jwt_cache):
+        # Create a JWT with a very large payload
+        header = base64.urlsafe_b64encode(json.dumps({"alg": "HS256"}).encode()).rstrip(b"=")
+        payload_data = {"exp": time.time() + 3600, "data": "x" * 100000}
+        payload = base64.urlsafe_b64encode(json.dumps(payload_data).encode()).rstrip(b"=")
+        sig = base64.urlsafe_b64encode(b"sig").rstrip(b"=")
+        jwt = f"{header.decode()}.{payload.decode()}.{sig.decode()}"
+        put_cached_jwt(jwt, "oid", "key", None, None)
+        assert get_cached_jwt("oid", "key", None, None) == jwt
+
+    def test_unicode_in_oid(self, tmp_jwt_cache):
+        exp = time.time() + 3600
+        jwt = _make_jwt(exp)
+        put_cached_jwt(jwt, "oid-\u00e9\u00e8\u00ea", "key", None, None)
+        assert get_cached_jwt("oid-\u00e9\u00e8\u00ea", "key", None, None) == jwt
+
+    def test_cache_key_collision_resistance(self):
+        """Different credential combos should not collide."""
+        keys = set()
+        combos = [
+            ("oid1", "key1", None, None),
+            ("oid1", "key2", None, None),
+            ("oid2", "key1", None, None),
+            ("oid1", "key1", None, "uid1"),
+            ("oid1", "key1", None, "uid2"),
+            ("oid1", None, {"refresh_token": "rt1"}, None),
+            ("oid1", None, {"refresh_token": "rt2"}, None),
+        ]
+        for combo in combos:
+            k = _compute_cache_key(*combo)
+            assert k not in keys, f"Collision for {combo}"
+            keys.add(k)
+
+    def test_cache_file_is_json_array(self, tmp_jwt_cache):
+        """Cache file contains [1,2,3] instead of a dict.
+
+        _load_cache returns {} for non-dict JSON, so get returns None.
+        A subsequent put should overwrite the file with a valid dict.
+        """
+        path = _get_cache_path()
+        with open(path, "w") as f:
+            json.dump([1, 2, 3], f)
+        os.chmod(path, 0o600)
+        assert get_cached_jwt("oid", "key", None, None) is None
+        # Now put should overwrite the invalid file
+        exp = time.time() + 3600
+        jwt = _make_jwt(exp)
+        put_cached_jwt(jwt, "oid", "key", None, None)
+        assert get_cached_jwt("oid", "key", None, None) == jwt
+
+    def test_cache_file_contains_non_utf8_bytes(self, tmp_jwt_cache):
+        """Cache file has raw bytes that are not valid UTF-8.
+
+        get_cached_jwt should return None gracefully without raising.
+        """
+        path = _get_cache_path()
+        with open(path, "wb") as f:
+            f.write(b"\x80\x81")
+        os.chmod(path, 0o600)
+        assert get_cached_jwt("oid", "key", None, None) is None
+
+    def test_api_key_and_oauth_with_same_token_do_not_collide(self):
+        """If an API key UUID happens to match an OAuth refresh_token UUID,
+        they must produce different cache keys (different auth method)."""
+        same_uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        k_api = _compute_cache_key("oid", same_uuid, None, None)
+        k_oauth = _compute_cache_key("oid", None, {"refresh_token": same_uuid}, None)
+        assert k_api != k_oauth
+
+
+class TestIsCacheDisabled:
+    def test_not_disabled_by_default(self, tmp_jwt_cache):
+        assert _is_cache_disabled() is False
+
+    def test_disabled_by_ephemeral_creds(self, tmp_jwt_cache, monkeypatch):
+        monkeypatch.setenv("LC_EPHEMERAL_CREDS", "1")
+        assert _is_cache_disabled() is True
+
+    def test_disabled_by_no_jwt_cache_env(self, tmp_jwt_cache, monkeypatch):
+        monkeypatch.setenv("LC_NO_JWT_CACHE", "1")
+        assert _is_cache_disabled() is True
+
+    def test_disabled_by_config_option(self, tmp_jwt_cache):
+        import yaml
+        config_path = tmp_jwt_cache[: -len("_jwt_cache")]
+        with open(config_path, "w") as f:
+            yaml.safe_dump({"no_jwt_cache": True}, f)
+        assert _is_cache_disabled() is True
+
+    def test_not_disabled_when_config_option_false(self, tmp_jwt_cache):
+        import yaml
+        config_path = tmp_jwt_cache[: -len("_jwt_cache")]
+        with open(config_path, "w") as f:
+            yaml.safe_dump({"no_jwt_cache": False}, f)
+        assert _is_cache_disabled() is False
+
+    def test_not_disabled_when_config_option_absent(self, tmp_jwt_cache):
+        import yaml
+        config_path = tmp_jwt_cache[: -len("_jwt_cache")]
+        with open(config_path, "w") as f:
+            yaml.safe_dump({"oid": "test"}, f)
+        assert _is_cache_disabled() is False
+
+
+class TestSymlinkProtection:
+    @pytest.mark.skipif(os.name == "nt", reason="Unix-only symlink test")
+    def test_put_refuses_symlinked_cache_file(self, tmp_jwt_cache, tmp_path):
+        """Attacker places symlink at cache path - put must not follow it."""
+        target = str(tmp_path / "attacker_target")
+        with open(target, "w") as f:
+            f.write("original")
+        # Create symlink at the expected cache path
+        cache_path = _get_cache_path()
+        os.symlink(target, cache_path)
+        exp = time.time() + 3600
+        # put_cached_jwt should silently fail (best-effort, no raise)
+        put_cached_jwt(_make_jwt(exp), "oid", "key", None, None)
+        # Verify target file was NOT overwritten
+        with open(target, "r") as f:
+            assert f.read() == "original"
+
+    @pytest.mark.skipif(os.name == "nt", reason="Unix-only symlink test")
+    def test_get_refuses_symlinked_cache_file(self, tmp_jwt_cache, tmp_path):
+        """Attacker places symlink to feed controlled JWT data."""
+        # Write a valid-looking cache file as the "attacker"
+        exp = time.time() + 3600
+        jwt = _make_jwt(exp)
+        from limacharlie.jwt_cache import _compute_cache_key
+        key = _compute_cache_key("oid", "key", None, None)
+        fake_cache = json.dumps({key: {"jwt": jwt}})
+        target = str(tmp_path / "attacker_cache")
+        with open(target, "w") as f:
+            f.write(fake_cache)
+        # Place symlink at cache path
+        cache_path = _get_cache_path()
+        os.symlink(target, cache_path)
+        # get should refuse to read through symlink
+        assert get_cached_jwt("oid", "key", None, None) is None
+
+    @pytest.mark.skipif(os.name == "nt", reason="Unix-only symlink test")
+    def test_invalidate_refuses_symlinked_cache_file(self, tmp_jwt_cache, tmp_path):
+        """invalidate should not follow symlinks either."""
+        target = str(tmp_path / "target")
+        with open(target, "w") as f:
+            f.write("{}")
+        cache_path = _get_cache_path()
+        os.symlink(target, cache_path)
+        # Should silently fail, not modify target
+        invalidate_cached_jwt("oid", "key", None, None)
+
+
+class TestCrossplatformPaths:
+    def test_cache_path_from_default(self, monkeypatch, tmp_path):
+        default = str(tmp_path / ".limacharlie")
+        monkeypatch.setattr("limacharlie.jwt_cache.CONFIG_FILE_PATH", default)
+        monkeypatch.delenv("LC_CREDS_FILE", raising=False)
+        assert _get_cache_path() == default + "_jwt_cache"
+
+    def test_cache_path_from_env(self, monkeypatch, tmp_path):
+        custom = str(tmp_path / "custom" / "config")
+        monkeypatch.setenv("LC_CREDS_FILE", custom)
+        assert _get_cache_path() == custom + "_jwt_cache"
+
+    def test_path_with_spaces(self, monkeypatch, tmp_path):
+        spaced = str(tmp_path / "path with spaces" / ".limacharlie")
+        monkeypatch.setenv("LC_CREDS_FILE", spaced)
+        assert _get_cache_path() == spaced + "_jwt_cache"


### PR DESCRIPTION
## Details

Each CLI invocation previously created a new JWT via an HTTP roundtrip to `jwt.limacharlie.io`, even when running many commands within the same hour. This meant N active JWTs and N network requests for N commands. This change caches JWTs to disk so subsequent CLI invocations reuse the same token until it nears expiry, matching the caching the web frontend does via React Query.

**Benefits:**
- **Reduced attack surface**: Instead of N active JWTs for N commands in an hour, there is a single reused JWT. Fewer active tokens means fewer tokens that could be leaked or compromised.
- **Better performance**: Eliminates the JWT HTTP roundtrip on every CLI invocation. For rapid sequential commands (scripts, automation), this removes ~100-200ms latency per command.
- **Lower server load**: Reduces pressure on `jwt.limacharlie.io` from CLI-heavy workflows.
- **Search command optimization**: `search run` and `search saved-run` reuse cached long-lived JWTs (4h default) if the remaining TTL is sufficient, instead of generating a new 4-hour token each time.

## Design

- **Cache file**: `~/.limacharlie_jwt_cache` (sibling to `~/.limacharlie` config file). Respects `LC_CREDS_FILE` for custom paths.
- **Cache key**: SHA-256 of `oid + auth_method_tag + credential_identity` (null-byte separated, with `apikey`/`oauth` method tags to prevent cross-method collisions).
- **Expiry buffer**: 10 minutes. A cached JWT is only reused if it has >10 minutes remaining.
- **Concurrency**: Last-write-wins via atomic writes (`tempfile` + `os.replace`). No file locking. Worst case is a redundant JWT request.
- **401 recovery**: If the server rejects a cached JWT (401), the cache entry is invalidated, a fresh JWT is fetched, cached, and the request is retried.
- **Search token reuse**: `get_jwt(expiry_hours=N)` checks if the currently cached JWT has >= N hours remaining. If so, reuses it. Otherwise fetches a new long-lived token and caches it.

### Security

- **File permissions**: 0o600 on Unix, owner-only on Windows.
- **Symlink protection**: Both read and write paths reject symlinks. On Unix, reads use `O_NOFOLLOW` for atomic kernel-level symlink rejection (no TOCTOU). Writes use `os.replace()` which does not follow symlinks at the destination.
- **Atomic writes**: `tempfile.mkstemp` + `secure_file_permissions` + `os.replace` - readers never see partial content.
- **Cross-platform**: All Unix-only APIs (`os.chown`, `os.getuid`, `O_NOFOLLOW`) are guarded behind `os.name != "nt"` / `hasattr` checks.

### Disable caching

- `LC_NO_JWT_CACHE=1` environment variable
- `LC_EPHEMERAL_CREDS=1` environment variable (existing)
- `no_jwt_cache: true` in `~/.limacharlie` config file

### Debug logging

All cache operations are logged when `--debug` is used:
- Cache file path, hit/miss status, token expiry
- Fresh token fetch, cache write with TTL
- 401 invalidation events
- Search token reuse decisions

## Benchmark results

Microbenchmarks (pytest-benchmark, Linux, Python 3.11):

| Operation | Mean | Context |
|-----------|------|---------|
| `_is_cache_disabled` (memoized) | **36 ns** | Subsequent calls, bool check only |
| `_compute_cache_key` | **500 ns** | SHA-256 hash of credentials |
| `_decode_jwt_exp` | **1.7 us** | Base64 decode + JSON parse of JWT payload |
| `_is_cache_disabled` (cold, no config) | **3.3 us** | First call, env var check only |
| `safe_open_read` (small file) | **8.8 us** | O_NOFOLLOW + read |
| **`get_cached_jwt` (cache hit)** | **14.6 us** | **Full hot path per CLI invocation** |
| `atomic_write` (typical) | **33 us** | tempfile + chmod + os.replace |
| `put_cached_jwt` (new entry) | **60 us** | Read + modify + atomic write |
| `_is_cache_disabled` (cold, YAML parse) | **93 us** | First call with config file |
| **JWT HTTP roundtrip (before)** | **~100-200 ms** | **Network request to jwt.limacharlie.io** |

**Key takeaway**: A cache hit costs ~15us vs ~100-200ms for a JWT HTTP roundtrip. The caching overhead is ~0.01% of the saved time. Even the cold path (_is_cache_disabled with YAML parse at ~93us) is negligible compared to network I/O.

## Blast radius / isolation

- **Affected**: `Client.__init__` (cache lookup), `refresh_jwt` / `_refresh_jwt_oauth` (cache write), `get_jwt` (TTL-aware reuse), `request` / `raw_request` 401 handler (cache invalidation).
- **NOT affected**: All SDK methods, CLI command parsing, config file format, OAuth token refresh flow logic. The cache is purely additive - on any error it falls back to the existing behavior (fetch fresh JWT).
- **config.py**: `save_config()` refactored to use shared `atomic_write` helper. Fixes an existing Windows bug (`os.chown` is Unix-only). Behavior is otherwise identical.

## Performance characteristics

- **Best case**: Eliminates JWT HTTP roundtrip (~100-200ms) on every CLI invocation after the first.
- **Worst case**: One extra file read (~15us) on cache hit, or file read + file write (~75us) on cache miss. Negligible vs network latency.
- **`_is_cache_disabled()`**: Result cached per-process to avoid repeated YAML parsing.

## Notable contracts / APIs

- **New env var**: `LC_NO_JWT_CACHE` - set to disable JWT disk caching.
- **New config option**: `no_jwt_cache: true` - set in `~/.limacharlie` to disable.
- **New cache file**: `~/.limacharlie_jwt_cache` - JSON format, created automatically.
- **`get_jwt()` behavior change**: Now reuses cached JWT when remaining TTL is sufficient for the requested `expiry_hours`, instead of always fetching a new token.
- **New CI step**: "Run Microbenchmarks" in cloudbuild_pr.yaml.
- **New dev dependency**: `pytest-benchmark>=5.0.0`.
- **No wire format changes**. No API contract changes. Cache is local-only.

## Files changed

| File | Change |
|------|--------|
| `limacharlie/file_utils.py` | **NEW** - Cross-platform `secure_file_permissions`, `safe_open_read`, `atomic_write`, `_reject_symlink` |
| `limacharlie/jwt_cache.py` | **NEW** - All cache logic (get/put/invalidate/clear, expiry decode, cache key) |
| `limacharlie/config.py` | Refactored `save_config` to use `atomic_write`; added `ENV_NO_JWT_CACHE` |
| `limacharlie/client.py` | Cache lookup in `__init__`, cache write in `refresh_jwt`/`_refresh_jwt_oauth`, TTL-aware reuse in `get_jwt`, cache invalidation on 401, debug logging |
| `cloudbuild_pr.yaml` | Added "Run Microbenchmarks" CI step |
| `pyproject.toml` | Added `pytest-benchmark>=5.0.0` to dev dependencies |
| `tests/unit/test_file_utils.py` | **NEW** - 23 tests (permissions, atomic write, symlink rejection, O_NOFOLLOW) |
| `tests/unit/test_jwt_cache.py` | **NEW** - 83 tests (cache key, JWT decode, get/put/invalidate/clear, edge cases, symlink protection) |
| `tests/unit/test_client.py` | 12 new tests (cache integration, get_jwt TTL reuse, raw_request 401) |
| `tests/integration/test_jwt_cache_integration.py` | **NEW** - 11 E2E tests with mock HTTP server |
| `tests/microbenchmarks/test_jwt_cache_microbenchmark.py` | **NEW** - 23 microbenchmarks |

## Test plan

- [x] `pytest tests/unit/test_file_utils.py -v` - cross-platform file helpers (23 tests)
- [x] `pytest tests/unit/test_jwt_cache.py -v` - all cache logic (83 tests)
- [x] `pytest tests/unit/test_client.py -v` - client integration (12 new tests)
- [x] `pytest tests/unit/test_config.py -v` - existing config tests still pass
- [x] `pytest tests/unit/ -v` - full unit suite (1267 passed, 2 skipped)
- [x] `pytest tests/integration/test_jwt_cache_integration.py --oid dummy --key dummy -v` - E2E with mock server (11 passed)
- [x] `pytest tests/microbenchmarks/ -v --benchmark-only` - all benchmarks pass (23 tests)
- [ ] Manual: `limacharlie --debug sensors list` twice - second invocation shows "JWT cache: hit"
- [ ] Manual: `limacharlie --debug search run ...` twice - second shows "JWT: reusing current token"
- [ ] Manual: verify `~/.limacharlie_jwt_cache` has 0o600 permissions
- [ ] Manual: `LC_NO_JWT_CACHE=1 limacharlie sensors list` - no cache file created

🤖 Generated with [Claude Code](https://claude.com/claude-code)