### PR TITLE
feat: search poll retry + checkpoint/resume

### DIFF
--- a/limacharlie/client.py
+++ b/limacharlie/client.py
@@ -603,6 +603,8 @@ class Client:
             else:
                 u = urlopen(request, timeout=effective_timeout)
 
+            data = None
+            data_str = ""
             try:
                 data = u.read()
                 data_str = data.decode() if data else ""
@@ -623,7 +625,7 @@ class Client:
                     self._debug(
                         f"Rate limit warning: quota={quota_limit}, period={quota_period}s"
                     )
-                self._debug_response(HTTP_OK, resp_headers, data_str if data else "")
+                self._debug_response(HTTP_OK, resp_headers, data_str)
                 u.close()
 
             return (HTTP_OK, resp)

--- a/limacharlie/commands/search.py
+++ b/limacharlie/commands/search.py
@@ -15,6 +15,8 @@ response unchanged.
 from __future__ import annotations
 
 import json
+import os
+import shlex
 import sys
 from collections.abc import Callable
 from datetime import datetime, timezone
@@ -22,6 +24,12 @@ from typing import Any
 
 import click
 
+from ..search_checkpoint import (
+    CheckpointReader,
+    CheckpointResumer,
+    CheckpointWriter,
+    list_checkpoints,
+)
 from ..cli import pass_context
 from ..client import Client
 from ..config import get_config_value
@@ -72,6 +80,118 @@ def _make_progress_fn(ctx: click.Context) -> Callable[[str], None] | None:
         click.echo(click.style(msg, dim=True), err=True)
         sys.stderr.flush()
     return _progress
+
+
+def _print_checkpoint_cancel(
+    checkpoint_path: str,
+    pages: int,
+    result_count: int,
+    total_events: int,
+    last_token: str | None,
+) -> None:
+    """Print a detailed cancel message when a checkpointed search is interrupted.
+
+    Shows session stats and the exact command to resume.
+    """
+    lines = [
+        "",
+        f"Search canceled. Checkpoint saved: {checkpoint_path}",
+        f"  Pages fetched:  {pages}",
+        f"  Results:        {result_count}",
+        f"  Total events:   {total_events:,}",
+    ]
+    if last_token:
+        lines.append(f"  Resume token:   {last_token}")
+    else:
+        lines.append("  Resume token:   (none - will re-fetch from start)")
+    lines.append("")
+    lines.append(f"  Resume with:    limacharlie search run --resume --checkpoint {checkpoint_path}")
+    click.echo("\n".join(lines), err=True)
+    sys.stderr.flush()
+
+
+def _build_fresh_query_cmd(meta: dict[str, Any], checkpoint_path: str) -> str:
+    """Build a CLI command string to re-run a checkpoint's query from scratch.
+
+    Used when a resume fails because the pagination token has expired
+    (server-side TTL is roughly 8 hours).
+
+    Args:
+        meta: Checkpoint metadata dict.
+        checkpoint_path: Path to the checkpoint data file.
+
+    Returns:
+        A shell command string the user can copy-paste.
+    """
+    parts = ["limacharlie search run"]
+    parts.append(f"--query {shlex.quote(meta.get('query', ''))}")
+    parts.append(f"--start {meta.get('start_time', '')}")
+    parts.append(f"--end {meta.get('end_time', '')}")
+    if meta.get("stream"):
+        parts.append(f"--stream {shlex.quote(str(meta['stream']))}")
+    if meta.get("limit"):
+        parts.append(f"--limit {meta['limit']}")
+    parts.append(f"--checkpoint {shlex.quote(checkpoint_path)}")
+    parts.append("--force")
+    return " \\\n    ".join(parts)
+
+
+# Keywords in SearchError messages that indicate an expired pagination
+# token or query results that have been garbage-collected on the server.
+# These are checked against SearchError only (not auth errors).
+# Deliberately narrow to avoid false positives - "expired" alone would
+# match JWT expiry errors wrapped in SearchError.
+_TOKEN_EXPIRED_KEYWORDS = (
+    "query not found",
+    "results not found",
+    "no longer available",
+    "query does not exist",
+    "invalid token",
+    "unknown query",
+    "token expired",
+    "results expired",
+)
+
+
+def _is_token_expired_error(exc: Exception) -> bool:
+    """Check if an exception indicates the server rejected a pagination token.
+
+    This typically means the token is malformed, corrupt, or the server
+    cannot process it. Used as a safety net during resume to provide a
+    helpful error message with the command to re-run from scratch.
+
+    NOT triggered for auth errors (401/403) - those are credential
+    issues, not token problems.
+
+    Args:
+        exc: The exception from the search execution.
+
+    Returns:
+        True if the error likely indicates expired results/token.
+    """
+    from ..errors import (
+        AuthenticationError,
+        NotFoundError,
+        PermissionDeniedError,
+        RateLimitError,
+        SearchError,
+    )
+
+    # Auth/permission/rate-limit errors are never token expiry.
+    if isinstance(exc, (AuthenticationError, PermissionDeniedError, RateLimitError)):
+        return False
+
+    # 404 on the poll request strongly suggests the query/token expired.
+    if isinstance(exc, NotFoundError):
+        return True
+
+    # Only check SearchError messages (not all exception types) to avoid
+    # false positives from unrelated errors that happen to contain keywords.
+    if isinstance(exc, SearchError):
+        msg = str(exc).lower()
+        return any(kw in msg for kw in _TOKEN_EXPIRED_KEYWORDS)
+
+    return False
 
 
 def _flatten_event_row(row: dict[str, Any]) -> dict[str, Any]:
@@ -247,6 +367,11 @@ def _output_search_results(
 
     For machine-readable formats (json, yaml, csv, jsonl): passes the
     raw API results through unchanged.
+
+    Note: requires the full results list in memory. Table formatting
+    needs all rows upfront to compute column widths. For large result
+    sets, use ``--output jsonl`` which streams via
+    ``CheckpointReader.iter_results()`` in the checkpoint-show path.
 
     Args:
         ctx: Click context with output settings.
@@ -527,6 +652,27 @@ Token expiry defaults to 4 hours to avoid mid-query JWT expiry on
 long-running searches.  Override with --token-expiry or set
 'search_token_expiry_hours' in ~/.limacharlie.
 
+Checkpoint/Resume:
+  Use --checkpoint to incrementally save results to a JSONL file.
+  If the search is interrupted (Ctrl+C, network error), the checkpoint
+  preserves all results fetched so far.  Use --resume --checkpoint
+  to pick up where you left off.
+
+  # Start with checkpointing
+  limacharlie search run \\
+      --query "..." --start X --end Y --checkpoint /tmp/search.jsonl
+
+  # Resume after interruption
+  limacharlie search run --resume --checkpoint /tmp/search.jsonl
+
+  Resume uses the stored pagination token to skip directly to the
+  next un-fetched page on the server.  The server re-runs the query
+  from the cursor position embedded in the token, so resume works
+  even after long delays between sessions.
+
+  The --query, --start, --end, and --stream flags are incompatible
+  with --resume (query parameters are loaded from the checkpoint).
+
 IMPORTANT: Do not write LCQL queries from scratch. Use
 'limacharlie ai generate-query --prompt "<description>"' to generate
 a query from a natural language description, then pass the result to
@@ -536,9 +682,9 @@ register_explain("search.run", _EXPLAIN_RUN)
 
 
 @group.command()
-@click.option("--query", required=True, help="LCQL query string.")
-@click.option("--start", required=True, type=int, help="Start time (unix seconds).")
-@click.option("--end", required=True, type=int, help="End time (unix seconds).")
+@click.option("--query", default=None, help="LCQL query string.")
+@click.option("--start", default=None, type=int, help="Start time (unix seconds).")
+@click.option("--end", default=None, type=int, help="End time (unix seconds).")
 @click.option("--stream", default=None, help="Stream type (event, detect, audit).")
 @click.option("--limit", default=None, type=int, help="Maximum number of results.")
 @click.option(
@@ -548,9 +694,74 @@ register_explain("search.run", _EXPLAIN_RUN)
 )
 @click.option("--raw", is_flag=True, default=False, help="Show raw API result objects without unwrapping.")
 @click.option("--expand", is_flag=True, default=False, help="Show each event as a full pretty-printed JSON block.")
+@click.option("--checkpoint", "checkpoint_path", default=None, type=click.Path(),
+              help="Write results incrementally to JSONL file at this path.")
+@click.option("--resume", is_flag=True, default=False,
+              help="Resume from existing checkpoint (requires --checkpoint).")
+@click.option("--force", is_flag=True, default=False,
+              help="Overwrite existing checkpoint data file (use with --checkpoint).")
 @pass_context
-def run(ctx: click.Context, query: str, start: int, end: int, stream: str | None,
-        limit: int | None, token_expiry: float | None, raw: bool, expand: bool) -> None:
+def run(ctx: click.Context, query: str | None, start: int | None, end: int | None,
+        stream: str | None, limit: int | None, token_expiry: float | None,
+        raw: bool, expand: bool, checkpoint_path: str | None, resume: bool,
+        force: bool) -> None:
+    # --- Validate flag combinations ---
+    if resume:
+        if not checkpoint_path:
+            click.echo("Error: --resume requires --checkpoint.", err=True)
+            ctx.exit(4)
+            return
+        # These flags are incompatible with --resume because overriding
+        # them would produce inconsistent results (data file has results
+        # from original query, new results would come from different query).
+        forbidden = []
+        if query is not None:
+            forbidden.append("--query")
+        if start is not None:
+            forbidden.append("--start")
+        if end is not None:
+            forbidden.append("--end")
+        if stream is not None:
+            forbidden.append("--stream")
+        if forbidden:
+            click.echo(
+                f"Error: {', '.join(forbidden)} cannot be used with --resume. "
+                "Query parameters are loaded from the checkpoint.",
+                err=True,
+            )
+            ctx.exit(4)
+            return
+    else:
+        # Normal mode: query, start, end are required.
+        if not query:
+            click.echo("Error: --query is required (unless using --resume).", err=True)
+            ctx.exit(4)
+            return
+        if start is None:
+            click.echo("Error: --start is required (unless using --resume).", err=True)
+            ctx.exit(4)
+            return
+        if end is None:
+            click.echo("Error: --end is required (unless using --resume).", err=True)
+            ctx.exit(4)
+            return
+
+    if resume:
+        _run_resume(ctx, checkpoint_path, limit, token_expiry, raw, expand)
+    elif checkpoint_path:
+        _run_with_checkpoint(ctx, query, start, end, stream, limit,
+                             token_expiry, raw, expand, checkpoint_path, force)
+    else:
+        _run_normal(ctx, query, start, end, stream, limit,
+                    token_expiry, raw, expand)
+
+
+def _run_normal(
+    ctx: click.Context, query: str, start: int, end: int,
+    stream: str | None, limit: int | None, token_expiry: float | None,
+    raw: bool, expand: bool,
+) -> None:
+    """Execute a search without checkpointing."""
     validate_epoch_seconds(start, "start")
     validate_epoch_seconds(end, "end")
     org = _get_org(ctx)
@@ -572,6 +783,319 @@ def run(ctx: click.Context, query: str, start: int, end: int, stream: str | None
         ctx.exit(130)
         return
     _output_search_results(ctx, results, raw=raw, expand=expand)
+
+
+def _run_with_checkpoint(
+    ctx: click.Context, query: str, start: int, end: int,
+    stream: str | None, limit: int | None, token_expiry: float | None,
+    raw: bool, expand: bool, checkpoint_path: str, force: bool = False,
+) -> None:
+    """Execute a search with checkpoint persistence."""
+    validate_epoch_seconds(start, "start")
+    validate_epoch_seconds(end, "end")
+    org = _get_org(ctx)
+    debug_fn = ctx.obj.debug_fn
+    effective_expiry = _resolve_token_expiry(token_expiry, environment=ctx.obj.environment)
+    if effective_expiry > 24:
+        click.echo(
+            f"Warning: generating a token valid for {effective_expiry} hours. "
+            "Long-lived tokens increase security exposure if leaked.",
+            err=True,
+        )
+    org.client.get_jwt(expiry_hours=effective_expiry)
+    search = Search(org)
+    progress_fn = _make_progress_fn(ctx)
+
+    if debug_fn:
+        debug_fn(f"Checkpoint: creating data file at {checkpoint_path} (force={force})")
+
+    try:
+        writer = CheckpointWriter(
+            data_path=checkpoint_path,
+            query=query,
+            start_time=start,
+            end_time=end,
+            stream=stream,
+            limit=limit,
+            oid=org.oid,
+            force=force,
+        )
+    except FileExistsError:
+        # Give a context-aware message based on checkpoint state.
+        try:
+            existing_meta = CheckpointReader.read_metadata(checkpoint_path)
+            if existing_meta.get("completed"):
+                result_count = existing_meta.get("result_count", 0)
+                total_events = existing_meta.get("total_events", 0)
+                click.echo(
+                    f"Error: Checkpoint already exists and is completed "
+                    f"({result_count} results, {total_events:,} events).\n"
+                    f"Use --force to overwrite with a new search, "
+                    f"or delete the file and retry.\n"
+                    f"\n"
+                    f"  View results:  limacharlie search checkpoint-show --checkpoint {checkpoint_path}\n"
+                    f"  Overwrite:     add --force to your command",
+                    err=True,
+                )
+            else:
+                result_count = existing_meta.get("result_count", 0)
+                total_events = existing_meta.get("total_events", 0)
+                page = existing_meta.get("page", 1)
+                click.echo(
+                    f"Error: Checkpoint already exists and is in-progress "
+                    f"(page {page}, {result_count} results, {total_events:,} events).\n"
+                    f"Use --resume to continue from where it left off, "
+                    f"--force to overwrite, or delete the file and retry.\n"
+                    f"\n"
+                    f"  Resume:    limacharlie search run --resume --checkpoint {checkpoint_path}\n"
+                    f"  Overwrite: add --force to your command",
+                    err=True,
+                )
+        except (FileNotFoundError, Exception):
+            # No metadata or can't read it - fall back to generic message.
+            click.echo(
+                f"Error: Checkpoint data file already exists: {os.path.abspath(checkpoint_path)}.\n"
+                f"Use --force to overwrite, or delete the file and retry.",
+                err=True,
+            )
+        ctx.exit(4)
+        return
+
+    results: list[dict] = []
+    count = 0
+    page = 1
+    total_events = 0
+    last_token: str | None = None
+    last_event_ts: int | None = None
+    try:
+        with writer:
+            for item in search.execute(query, start, end, stream=stream,
+                                       limit=limit, progress_fn=progress_fn):
+                writer.write_result(item)
+                results.append(item)
+                count += 1
+                # Track token, page, events, and timestamps.
+                if item.get("nextToken"):
+                    last_token = item["nextToken"]
+                    page += 1
+                if item.get("type") == "events":
+                    rows = item.get("rows") or []
+                    total_events += len(rows)
+                    for row in rows:
+                        ts = (row.get("mtd") or {}).get("ts")
+                        if ts is not None:
+                            last_event_ts = ts
+                writer.update_progress(page, count, completed=False,
+                                       last_token=last_token,
+                                       total_events=total_events,
+                                       last_event_ts=last_event_ts)
+            writer.update_progress(page, count, completed=True,
+                                   last_token=last_token,
+                                   total_events=total_events,
+                                   last_event_ts=last_event_ts)
+    except KeyboardInterrupt:
+        _print_checkpoint_cancel(checkpoint_path, page, count,
+                                 total_events, last_token)
+        ctx.exit(130)
+        return
+    except Exception:
+        if count > 0 and progress_fn:
+            progress_fn(f"Search failed after {count} results. Checkpoint saved: {checkpoint_path}")
+        raise
+
+    if progress_fn:
+        progress_fn(f"Checkpoint complete: {count} results saved to {checkpoint_path}")
+    _output_search_results(ctx, results, raw=raw, expand=expand)
+
+
+def _run_resume(
+    ctx: click.Context, checkpoint_path: str,
+    limit: int | None, token_expiry: float | None,
+    raw: bool, expand: bool,
+) -> None:
+    """Resume a search from an existing checkpoint.
+
+    Uses the stored pagination token to skip directly to the next
+    un-fetched page on the server side, avoiding re-fetching already-
+    checkpointed data.
+    """
+    debug_fn = ctx.obj.debug_fn
+    if debug_fn:
+        debug_fn(f"Checkpoint: resuming from {checkpoint_path}")
+
+    try:
+        resumer = CheckpointResumer(checkpoint_path)
+    except FileNotFoundError as exc:
+        click.echo(f"Error: {exc}", err=True)
+        ctx.exit(4)
+        return
+
+    meta = resumer.metadata
+    last_token = meta.get("last_token")
+    if debug_fn:
+        debug_fn(f"Checkpoint metadata: query={meta.get('query')!r}, "
+                 f"result_count={meta.get('result_count')}, "
+                 f"page={meta.get('page')}, completed={meta.get('completed')}, "
+                 f"last_token={last_token!r}")
+
+    if meta.get("completed"):
+        click.echo("Checkpoint is already completed. Nothing to resume.", err=True)
+        # Output existing results from the data file.
+        all_results = list(CheckpointReader.iter_results(checkpoint_path))
+        _output_search_results(ctx, all_results, raw=raw, expand=expand)
+        return
+
+    query = meta["query"]
+    start = meta["start_time"]
+    end = meta["end_time"]
+    stream = meta.get("stream")
+    checkpoint_limit = meta.get("limit")
+    existing_count = resumer.existing_count
+
+    # Use the resume limit if provided, otherwise use the original limit.
+    effective_limit = limit if limit is not None else checkpoint_limit
+
+    if debug_fn:
+        debug_fn(f"Checkpoint: {existing_count} existing results, "
+                 f"effective_limit={effective_limit}, "
+                 f"resuming from token={last_token!r}")
+
+    org = _get_org(ctx)
+    effective_expiry = _resolve_token_expiry(token_expiry, environment=ctx.obj.environment)
+    if effective_expiry > 24:
+        click.echo(
+            f"Warning: generating a token valid for {effective_expiry} hours. "
+            "Long-lived tokens increase security exposure if leaked.",
+            err=True,
+        )
+    org.client.get_jwt(expiry_hours=effective_expiry)
+    search = Search(org)
+    progress_fn = _make_progress_fn(ctx)
+
+    resume_page = meta.get("page", 1)
+    if progress_fn:
+        if last_token:
+            progress_fn(
+                f"Resuming from page {resume_page} "
+                f"({existing_count} results already fetched)..."
+            )
+        else:
+            progress_fn(
+                f"Resuming from start ({existing_count} results already "
+                f"fetched, no pagination token - will re-fetch and skip)..."
+            )
+
+    count = existing_count
+    page = resume_page
+    total_events = meta.get("total_events", 0)
+    last_token_new: str | None = last_token
+    last_event_ts: int | None = meta.get("last_event_ts")
+    try:
+        with resumer:
+            # Use start_token to skip directly to the next un-fetched page
+            # on the server side. If no token is available (e.g. interrupted
+            # on page 1 before any results), fall back to re-fetch + skip.
+            gen = search.execute(
+                query, start, end, stream=stream,
+                limit=effective_limit, progress_fn=progress_fn,
+                start_token=last_token,
+                start_page=resume_page,
+            )
+
+            if last_token:
+                # Server-side resume: token jumps us to the right page,
+                # all results from the generator are new.
+                for item in gen:
+                    resumer.write_result(item)
+                    count += 1
+                    if item.get("nextToken"):
+                        last_token_new = item["nextToken"]
+                        page += 1
+                    if item.get("type") == "events":
+                        rows = item.get("rows") or []
+                        total_events += len(rows)
+                        for row in rows:
+                            ts = (row.get("mtd") or {}).get("ts")
+                            if ts is not None:
+                                last_event_ts = ts
+                    resumer.update_progress(page, count, completed=False,
+                                            last_token=last_token_new,
+                                            total_events=total_events,
+                                            last_event_ts=last_event_ts)
+            else:
+                # No token available - re-fetch from start and skip
+                # already-fetched results. This is the slow path that
+                # only happens when the checkpoint has no token (e.g.
+                # interrupted before any page completed).
+                # NOTE: this assumes the server returns results in the
+                # same order for identical queries. Non-deterministic
+                # ordering could cause missed or duplicate results.
+                skipped = 0
+                for item in gen:
+                    if skipped < existing_count:
+                        skipped += 1
+                        if debug_fn:
+                            debug_fn(f"Checkpoint resume: skipping result {skipped}/{existing_count}")
+                        continue
+                    resumer.write_result(item)
+                    count += 1
+                    if item.get("nextToken"):
+                        last_token_new = item["nextToken"]
+                        page += 1
+                    if item.get("type") == "events":
+                        rows = item.get("rows") or []
+                        total_events += len(rows)
+                        for row in rows:
+                            ts = (row.get("mtd") or {}).get("ts")
+                            if ts is not None:
+                                last_event_ts = ts
+                    resumer.update_progress(page, count, completed=False,
+                                            last_token=last_token_new,
+                                            total_events=total_events,
+                                            last_event_ts=last_event_ts)
+
+            resumer.update_progress(page, count, completed=True,
+                                    last_token=last_token_new,
+                                    total_events=total_events,
+                                    last_event_ts=last_event_ts)
+    except KeyboardInterrupt:
+        new_pages = page - resume_page
+        _print_checkpoint_cancel(checkpoint_path, new_pages, count,
+                                 total_events, last_token_new)
+        ctx.exit(130)
+        return
+    except Exception as exc:
+        if _is_token_expired_error(exc):
+            # The server rejected the pagination token. Show a helpful
+            # message with the command to start fresh.
+            fresh_cmd = _build_fresh_query_cmd(meta, checkpoint_path)
+            click.echo(
+                f"\nError: Resume failed - the server rejected the pagination token.\n"
+                f"\n"
+                f"The token from this checkpoint may be invalid or the server\n"
+                f"could not process it.\n"
+                f"\n"
+                f"To re-run the query from scratch (overwrites the checkpoint):\n"
+                f"\n"
+                f"  {fresh_cmd}\n",
+                err=True,
+            )
+            sys.stderr.flush()
+            ctx.exit(1)
+            return
+        if count > existing_count and progress_fn:
+            progress_fn(f"Search failed after {count} results. Checkpoint saved: {checkpoint_path}")
+        raise
+
+    if progress_fn:
+        new_count = count - existing_count
+        progress_fn(f"Resume complete: {new_count} new results ({count} total) saved to {checkpoint_path}")
+
+    # Read all results from the checkpoint file (existing + new) for output.
+    # The data file now contains everything; no need to keep results in memory
+    # during the search loop.
+    all_results = list(CheckpointReader.iter_results(checkpoint_path))
+    _output_search_results(ctx, all_results, raw=raw, expand=expand)
 
 
 # ---------------------------------------------------------------------------
@@ -861,4 +1385,213 @@ def saved_run(ctx: click.Context, name: str, limit: int | None, token_expiry: fl
         sys.stderr.flush()
         ctx.exit(130)
         return
+    _output_search_results(ctx, results, raw=raw, expand=expand)
+
+
+# ---------------------------------------------------------------------------
+# checkpoints
+# ---------------------------------------------------------------------------
+
+_EXPLAIN_CHECKPOINTS = """\
+List all search checkpoints stored locally.  Shows the data file path,
+query, time range, result count, and completion status for each
+checkpoint.  Use this to find interrupted searches that can be resumed
+with 'search run --resume --checkpoint <path>'.
+"""
+register_explain("search.checkpoints", _EXPLAIN_CHECKPOINTS)
+
+
+@group.command("checkpoints")
+@pass_context
+def checkpoints_list(ctx: click.Context) -> None:
+    """List local search checkpoints. Automatically cleans up stale metadata."""
+    cps = list_checkpoints(cleanup=True, debug_fn=ctx.obj.debug_fn)
+    if not cps:
+        if not ctx.obj.quiet:
+            click.echo("No checkpoints found.")
+        return
+
+    fmt = ctx.obj.output_format or detect_output_format()
+    if fmt != "table":
+        click.echo(format_output(cps, fmt))
+        return
+
+    rows: list[dict[str, Any]] = []
+    for cp in cps:
+        start_ts = cp.get("start_time")
+        end_ts = cp.get("end_time")
+        try:
+            start_str = datetime.fromtimestamp(start_ts, tz=timezone.utc).strftime("%Y-%m-%d %H:%M") if start_ts else ""
+        except (OSError, ValueError, OverflowError, TypeError):
+            start_str = str(start_ts)
+        try:
+            end_str = datetime.fromtimestamp(end_ts, tz=timezone.utc).strftime("%Y-%m-%d %H:%M") if end_ts else ""
+        except (OSError, ValueError, OverflowError, TypeError):
+            end_str = str(end_ts)
+
+        query_str = cp.get("query", "")
+        if len(query_str) > 50:
+            query_str = query_str[:47] + "..."
+
+        status = "completed" if cp.get("completed") else "in-progress"
+        if not cp.get("data_file_exists", True):
+            status += " (data missing)"
+
+        page = cp.get("page", 1)
+        total_events = cp.get("total_events", 0)
+
+        # Compute time range progress percentage from last_event_ts.
+        progress_str = ""
+        last_event_ts = cp.get("last_event_ts")
+        if last_event_ts is not None and start_ts and end_ts and end_ts > start_ts:
+            # last_event_ts is in milliseconds, start/end are in seconds.
+            last_sec = last_event_ts / 1000
+            total_range = end_ts - start_ts
+            covered = max(0, min(last_sec - start_ts, total_range))
+            pct = (covered / total_range) * 100
+            progress_str = f"{pct:.0f}%"
+            # Also show the last event timestamp.
+            try:
+                last_ts_str = datetime.fromtimestamp(
+                    last_sec, tz=timezone.utc
+                ).strftime("%Y-%m-%d %H:%M")
+                progress_str = f"{pct:.0f}% ({last_ts_str})"
+            except (OSError, ValueError, OverflowError, TypeError):
+                pass
+
+        # Format created_at for display
+        created = cp.get("created_at", "")
+        if created:
+            try:
+                created = created[:19].replace("T", " ")  # "2026-03-16 10:30:00"
+            except (TypeError, IndexError):
+                pass
+
+        updated = cp.get("updated_at", "")
+        if updated:
+            try:
+                updated = updated[:19].replace("T", " ")
+            except (TypeError, IndexError):
+                pass
+
+        # Truncate token for display (show suffix since prefix is always the same).
+        token_display = ""
+        cp_token = cp.get("last_token")
+        if cp_token:
+            token_display = "..." + cp_token[-12:] if len(cp_token) > 16 else cp_token
+
+        rows.append({
+            "data_file": cp.get("data_file", ""),
+            "query": query_str,
+            "range": f"{start_str} - {end_str}" if start_str and end_str else "",
+            "pages": page,
+            "events": f"{total_events:,}" if total_events else "0",
+            "progress": progress_str,
+            "status": status,
+            "token": token_display,
+            "created": created,
+            "updated": updated,
+        })
+
+    click.echo(format_table(rows))
+
+
+# ---------------------------------------------------------------------------
+# checkpoint-show
+# ---------------------------------------------------------------------------
+
+_EXPLAIN_CHECKPOINT_SHOW = """\
+Display results from a checkpoint data file.  Reads the JSONL data file
+and renders it through the same output pipeline as a live search -
+table unwrapping, --expand, --raw, and all --output formats work.
+
+This is useful for reviewing results from an interrupted or completed
+search without re-running the query.
+
+Examples:
+  # Table output (default)
+  limacharlie search checkpoint-show --checkpoint /tmp/my_search.jsonl
+
+  # Expanded JSON events
+  limacharlie search checkpoint-show --checkpoint /tmp/my_search.jsonl --expand
+
+  # JSON for scripting
+  limacharlie search checkpoint-show --checkpoint /tmp/my_search.jsonl --output json
+
+  # Pipe to jq
+  limacharlie search checkpoint-show --checkpoint /tmp/my_search.jsonl --output jsonl | jq '.rows[].data'
+
+Related: 'search checkpoints' to list all checkpoints,
+'search run --resume' to continue an interrupted search.
+"""
+register_explain("search.checkpoint-show", _EXPLAIN_CHECKPOINT_SHOW)
+
+
+@group.command("checkpoint-show")
+@click.option("--checkpoint", "checkpoint_path", required=True, type=click.Path(exists=True),
+              help="Path to the checkpoint JSONL data file.")
+@click.option("--raw", is_flag=True, default=False, help="Show raw API result objects without unwrapping.")
+@click.option("--expand", is_flag=True, default=False, help="Show each event as a full pretty-printed JSON block.")
+@pass_context
+def checkpoint_show(ctx: click.Context, checkpoint_path: str, raw: bool, expand: bool) -> None:
+    """Display results from a checkpoint data file.
+
+    Streams results lazily for JSONL output (``--output jsonl``) to
+    avoid loading the entire file into memory. For table, expand, JSON,
+    and CSV formats, loads all results into memory because those formats
+    require the full data set (table needs all rows for column widths,
+    JSON needs the complete array, etc.). For large checkpoints, use
+    ``--output jsonl`` and pipe to jq or other streaming tools.
+    """
+    try:
+        meta = CheckpointReader.read_metadata(checkpoint_path)
+    except FileNotFoundError as exc:
+        click.echo(f"Error: {exc}", err=True)
+        ctx.exit(4)
+        return
+
+    # Print checkpoint summary to stderr (like stats from a live search).
+    if not ctx.obj.quiet and sys.stderr.isatty():
+        total_events = meta.get("total_events", 0)
+        pages = meta.get("page", 1)
+        result_count = meta.get("result_count", 0)
+        status = "completed" if meta.get("completed") else "in-progress"
+        query = meta.get("query", "")
+        if len(query) > 80:
+            query = query[:77] + "..."
+        click.echo(click.style(
+            f"Checkpoint: {status}, {pages} pages, "
+            f"{total_events:,} events, {result_count} results",
+            dim=True,
+        ), err=True)
+        click.echo(click.style(f"Query: {query}", dim=True), err=True)
+        sys.stderr.flush()
+
+    if ctx.obj.quiet:
+        return
+
+    fmt = ctx.obj.output_format or detect_output_format()
+
+    # JSONL: stream one result per line without loading all into memory.
+    if fmt == "jsonl":
+        has_results = False
+        for result in CheckpointReader.iter_results(checkpoint_path):
+            has_results = True
+            click.echo(json.dumps(result, default=str))
+        if not has_results:
+            click.echo("Checkpoint is empty (no results).")
+        return
+
+    # All other formats need the full list.
+    try:
+        _, results = CheckpointReader.read(checkpoint_path)
+    except FileNotFoundError as exc:
+        click.echo(f"Error: {exc}", err=True)
+        ctx.exit(4)
+        return
+
+    if not results:
+        click.echo("Checkpoint is empty (no results).")
+        return
+
     _output_search_results(ctx, results, raw=raw, expand=expand)

--- a/limacharlie/file_utils.py
+++ b/limacharlie/file_utils.py
@@ -66,6 +66,57 @@ def secure_file_permissions(path: str) -> None:
         os.chown(path, os.getuid(), os.getgid())
 
 
+def secure_dir_permissions(path: str) -> None:
+    """Restrict directory permissions to owner-only access.
+
+    On Unix: sets mode to 0o700 (rwx------) and chowns to current user/group.
+    On Windows: sets via os.chmod (limited - Windows home dirs are already
+    ACL-restricted by default).
+
+    Args:
+        path: absolute path to the directory to secure.
+    """
+    os.chmod(path, stat.S_IRWXU)
+    if os.name != "nt":
+        os.chown(path, os.getuid(), os.getgid())
+
+
+def secure_makedirs(path: str) -> None:
+    """Create directories with owner-only permissions, creating parents as needed.
+
+    Each directory in the path that does not yet exist is created with 0o700
+    permissions (owner rwx only). Existing directories also have their
+    permissions tightened to 0o700 to ensure security even if they were
+    created by another process with permissive permissions.
+
+    Cross-platform: on Unix, uses 0o700 mode; on Windows, relies on the
+    user's home directory ACLs (os.chmod has limited effect on directories).
+
+    Args:
+        path: absolute path to the leaf directory to create.
+    """
+    # Walk from root to leaf, creating each missing component with
+    # secure permissions. os.makedirs(mode=) applies mode only to the
+    # leaf on some platforms, so we create each level explicitly.
+    path = os.path.abspath(path)
+    components: list[str] = []
+    current = path
+    while not os.path.isdir(current):
+        components.append(current)
+        parent = os.path.dirname(current)
+        if parent == current:
+            break
+        current = parent
+    # Create from shallowest to deepest.
+    for d in reversed(components):
+        os.mkdir(d)
+        secure_dir_permissions(d)
+    # Ensure the leaf directory (and its immediate parent if we created it)
+    # has correct permissions even if it already existed.
+    if os.path.isdir(path):
+        secure_dir_permissions(path)
+
+
 def safe_open_read(path: str) -> bytes:
     """Read a file's contents, rejecting symlinks atomically.
 

--- a/limacharlie/sdk/search.py
+++ b/limacharlie/sdk/search.py
@@ -8,11 +8,21 @@ from __future__ import annotations
 
 import json
 import re
+import ssl
 import time
 from collections.abc import Callable, Generator
 from typing import Any, TYPE_CHECKING
 
-from ..errors import LimaCharlieError, SearchError
+from ..errors import (
+    ApiError,
+    AuthenticationError,
+    LimaCharlieError,
+    NotFoundError,
+    PermissionDeniedError,
+    RateLimitError,
+    SearchError,
+    ValidationError,
+)
 
 if TYPE_CHECKING:
     from .organization import Organization
@@ -27,6 +37,53 @@ def _exc_message(exc: Exception) -> str:
     if isinstance(exc, LimaCharlieError):
         return exc.raw_message
     return str(exc)
+
+
+# Transient HTTP status codes that are safe to retry on poll requests.
+# These indicate server-side or infrastructure issues, not client errors.
+_TRANSIENT_STATUS_CODES = frozenset({500, 502, 503, 504})
+
+# Maximum backoff delay in seconds for poll retries.
+_MAX_BACKOFF_SECONDS = 30
+
+
+def _is_transient_poll_error(exc: Exception) -> bool:
+    """Classify whether a poll exception is transient and safe to retry.
+
+    Retryable: ApiError with 5xx status, ConnectionError, TimeoutError,
+    OSError (network errors), ssl.SSLError.
+
+    NOT retryable: AuthenticationError (401), RateLimitError (429),
+    NotFoundError (404), ValidationError (422), PermissionDeniedError (403),
+    or any other non-transient error.
+
+    Args:
+        exc: The exception raised during a poll request.
+
+    Returns:
+        True if the error is transient and the poll should be retried.
+    """
+    # Non-retryable LimaCharlie error types - these are permanent failures.
+    if isinstance(exc, (AuthenticationError, RateLimitError, NotFoundError,
+                        ValidationError, PermissionDeniedError)):
+        return False
+
+    # ApiError with a transient HTTP status code.
+    if isinstance(exc, ApiError):
+        return exc.status_code in _TRANSIENT_STATUS_CODES
+
+    # Network-level errors are transient.
+    if isinstance(exc, (ConnectionError, TimeoutError, ssl.SSLError)):
+        return True
+
+    # OSError covers low-level socket errors (ECONNRESET, EPIPE, etc.)
+    # but we exclude subclasses that are not network-related.
+    if isinstance(exc, OSError) and not isinstance(exc, (FileNotFoundError,
+                                                          PermissionError,
+                                                          IsADirectoryError)):
+        return True
+
+    return False
 
 
 # Pattern to extract region identifier from search URL.
@@ -112,6 +169,62 @@ class Search:
         # Estimate uses the validate endpoint with additional parameters
         return self.validate(query, start_time, end_time, stream)
 
+    def _poll_with_retry(
+        self,
+        query_id: str,
+        search_url: str,
+        query_params: dict[str, str] | None,
+        max_retries: int = 3,
+        progress_fn: Callable[[str], None] | None = None,
+    ) -> dict[str, Any]:
+        """Execute a single poll GET request with retry on transient errors.
+
+        Uses exponential backoff (2^attempt seconds, capped at 30s) between
+        retries. Only retries on transient errors as classified by
+        ``_is_transient_poll_error`` - permanent errors (auth, validation,
+        rate limit) are raised immediately.
+
+        Poll responses containing an ``"error"`` key in the body are NOT
+        retried - these are search-engine errors (e.g. "context canceled"),
+        not transport errors.
+
+        Args:
+            query_id: Active search query ID.
+            search_url: Base search API URL.
+            query_params: Query parameters for the GET request (e.g. pagination token).
+            max_retries: Maximum number of retry attempts (default 3).
+            progress_fn: Optional callback for retry status messages.
+
+        Returns:
+            The poll response dict.
+
+        Raises:
+            The original exception if all retries are exhausted or the
+            error is not transient.
+        """
+        last_exc: Exception | None = None
+        for attempt in range(max_retries + 1):
+            try:
+                return self._org.client.request(
+                    "GET", f"search/{query_id}",
+                    query_params=query_params,
+                    alt_root=search_url,
+                )
+            except Exception as exc:
+                if attempt >= max_retries or not _is_transient_poll_error(exc):
+                    raise
+                last_exc = exc
+                backoff = min(2 ** attempt, _MAX_BACKOFF_SECONDS)
+                if progress_fn:
+                    progress_fn(
+                        f"Retrying poll (attempt {attempt + 2}/{max_retries + 1}, "
+                        f"waiting {backoff}s)..."
+                    )
+                time.sleep(backoff)
+
+        # Should not reach here, but satisfy type checker.
+        raise last_exc  # type: ignore[misc]
+
     def execute(
         self,
         query: str,
@@ -120,6 +233,9 @@ class Search:
         stream: str | None = None,
         limit: int | None = None,
         progress_fn: Callable[[str], None] | None = None,
+        poll_max_retries: int = 3,
+        start_token: str | None = None,
+        start_page: int = 1,
     ) -> Generator[dict[str, Any], None, None]:
         """Execute an LCQL query and return results.
 
@@ -133,6 +249,17 @@ class Search:
                 "Running search...", "Fetching page 2...").  Called with
                 a human-readable status string.  Intended for CLI progress
                 output to stderr in interactive mode.
+            poll_max_retries: Maximum number of retries for each individual
+                poll request on transient errors (default 3). Set to 0 to
+                disable retries.
+            start_token: Resume pagination from this token. When provided,
+                the first poll request immediately uses this token to skip
+                ahead to the page following the one that produced it.
+                Used by checkpoint/resume to avoid re-fetching already-
+                fetched pages.
+            start_page: Starting page number for progress display (default 1).
+                Used with start_token to show accurate page numbers when
+                resuming mid-search.
 
         Yields:
             dict: Result records.
@@ -195,21 +322,26 @@ class Search:
             progress_fn(f"Running search... query_id: {query_id}")
 
         count = 0
-        page = 1
+        page = start_page
         total_events = 0
         start_ts = time.monotonic()
-        token: str | None = None
+        token: str | None = start_token
         _interrupted = False
+
+        if start_token and progress_fn:
+            tok_display = "..." + start_token[-12:] if len(start_token) > 16 else start_token
+            progress_fn(f"Resuming from page {page} (token={tok_display})")
         try:
             while True:
                 qp: dict[str, str] = {}
                 if token:
                     qp["token"] = token
 
-                poll = self._org.client.request(
-                    "GET", f"search/{query_id}",
+                poll = self._poll_with_retry(
+                    query_id, search_url,
                     query_params=qp or None,
-                    alt_root=search_url,
+                    max_retries=poll_max_retries,
+                    progress_fn=progress_fn,
                 )
 
                 # Check for error in poll response
@@ -243,9 +375,13 @@ class Search:
                         page += 1
                         if progress_fn:
                             elapsed = time.monotonic() - start_ts
+                            # Show last 12 chars of token (the prefix is
+                            # always the same, the suffix varies).
+                            tok_display = "..." + next_token[-12:] if len(next_token) > 16 else next_token
                             progress_fn(
                                 f"Fetching page {page}... "
-                                f"({total_events:,} events, {elapsed:.0f}s elapsed)"
+                                f"({total_events:,} events, {elapsed:.0f}s elapsed, "
+                                f"token={tok_display})"
                             )
                     else:
                         break

--- a/limacharlie/search_checkpoint.py
+++ b/limacharlie/search_checkpoint.py
@@ -1,0 +1,593 @@
+"""Checkpoint/resume support for long-running search queries.
+
+Provides incremental persistence of search results so that interrupted
+searches can be resumed without losing already-fetched data.
+
+Architecture:
+- Data file (user-specified path): Append-only JSONL, one SearchResult
+  dict per line. This is the user's data - lives wherever they want.
+- Metadata file (~/.limacharlie/checkpoints/<id>.meta.json): Query
+  parameters, progress state (page, result count, completed). Stored
+  in the standard LimaCharlie config area.
+
+The metadata file is rewritten atomically (tempfile + rename) each time
+a page completes. The data file is append-only and flushed after each
+write. On resume, the query is re-run and already-fetched results are
+skipped.
+
+Resume mechanism: the pagination token contains a cursor encoding the
+position in the result set. On resume, a fresh search is initiated and
+the server re-runs the query starting from the cursor position. This
+means resume works even after long delays between sessions - there is
+no server-side TTL that limits when a checkpoint can be resumed.
+
+Concurrency model: single-writer. No file locking. If two processes
+write to the same checkpoint simultaneously, results will be corrupted.
+This is acceptable since search queries are interactive CLI operations.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import stat
+import time
+from collections.abc import Generator
+from datetime import datetime, timezone
+from typing import Any
+
+from .config import ENV_CREDS_FILE, CONFIG_FILE_PATH
+from .file_utils import (
+    _reject_symlink,
+    atomic_write,
+    secure_file_permissions,
+    secure_makedirs,
+)
+
+
+def get_data_dir() -> str:
+    """Return the directory for checkpoint metadata files.
+
+    Path resolution:
+    - Default: ~/.limacharlie/search_checkpoints/
+      Uses a directory named after the config file with a .d suffix
+      to avoid conflicting with the flat config file. For the default
+      ~/.limacharlie config, this gives ~/.limacharlie.d/search_checkpoints/.
+      When the config eventually migrates to a directory layout
+      (~/.limacharlie/ as a dir), this naturally becomes
+      ~/.limacharlie/search_checkpoints/.
+    - Respects LC_CREDS_FILE: if config is at /foo/bar, checkpoints go
+      to /foo/bar.d/search_checkpoints/.
+
+    Returns:
+        Absolute path to the checkpoints directory.
+    """
+    config_path = os.environ.get(ENV_CREDS_FILE, CONFIG_FILE_PATH)
+    config_dir = os.path.dirname(config_path)
+    config_base = os.path.basename(config_path)
+
+    # If the config path is already a directory (future layout or custom),
+    # use <config_path>/search_checkpoints/ directly.
+    if os.path.isdir(config_path):
+        return os.path.join(config_path, "search_checkpoints")
+
+    # Config path is a flat file (current layout) or doesn't exist yet.
+    # Use <config_path>.d/search_checkpoints/ to avoid conflict with the
+    # flat file. For ~/.limacharlie -> ~/.limacharlie.d/search_checkpoints/.
+    return os.path.join(config_dir, config_base + ".d", "search_checkpoints")
+
+
+def _checkpoint_id(data_path: str) -> str:
+    """Compute a checkpoint ID from the absolute path of the data file.
+
+    Uses SHA-256 hash of the absolute path so metadata and data are
+    always paired regardless of the data file location.
+
+    Args:
+        data_path: Absolute path to the JSONL data file.
+
+    Returns:
+        Hex-encoded SHA-256 hash string.
+    """
+    return hashlib.sha256(os.path.abspath(data_path).encode()).hexdigest()
+
+
+def _meta_path(data_path: str) -> str:
+    """Return the metadata file path for a given data file.
+
+    Args:
+        data_path: Absolute path to the JSONL data file.
+
+    Returns:
+        Absolute path to the metadata JSON file.
+    """
+    return os.path.join(get_data_dir(), _checkpoint_id(data_path) + ".meta.json")
+
+
+class CheckpointWriter:
+    """Incrementally writes search results to a JSONL data file
+    and maintains a metadata file for resume support.
+
+    Data file: append-only JSONL at user-specified path.
+    Metadata file: atomic JSON in the checkpoints directory.
+
+    Usage:
+        writer = CheckpointWriter(data_path, query, start_time, end_time,
+                                  stream, limit, oid)
+        for result in search.execute(...):
+            writer.write_result(result)
+            writer.update_progress(page, result_count, completed=False)
+        writer.update_progress(page, result_count, completed=True)
+        writer.close()
+    """
+
+    def __init__(
+        self,
+        data_path: str,
+        query: str,
+        start_time: int,
+        end_time: int,
+        stream: str | None,
+        limit: int | None,
+        oid: str,
+        force: bool = False,
+    ) -> None:
+        """Initialize checkpoint writer.
+
+        Creates the data file and metadata file. Raises if the data file
+        already exists unless force=True (which overwrites it).
+
+        Args:
+            data_path: Path to the JSONL data file.
+            query: LCQL query string.
+            start_time: Start time (unix seconds).
+            end_time: End time (unix seconds).
+            stream: Stream type or None.
+            limit: Result limit or None.
+            oid: Organization ID.
+            force: If True, overwrite existing data file and metadata.
+
+        Raises:
+            FileExistsError: If data_path already exists and force is False.
+        """
+        self._data_path = os.path.abspath(data_path)
+        self._meta_path = _meta_path(self._data_path)
+
+        # Reject symlinks at the data file path to prevent symlink attacks.
+        _reject_symlink(self._data_path)
+
+        if os.path.exists(self._data_path) and not force:
+            raise FileExistsError(
+                f"Checkpoint data file already exists: {self._data_path}. "
+                "Use --resume to continue, --force to overwrite, "
+                "or delete the file and retry."
+            )
+
+        # If force, remove existing data and metadata files.
+        if force and os.path.exists(self._data_path):
+            os.unlink(self._data_path)
+            if os.path.exists(self._meta_path):
+                os.unlink(self._meta_path)
+
+        # Ensure parent directories exist.
+        # The data file dir uses regular makedirs (user controls the path).
+        data_dir = os.path.dirname(self._data_path)
+        if data_dir:
+            os.makedirs(data_dir, exist_ok=True)
+
+        # The metadata dir is in ~/.limacharlie.d/ and must be owner-only.
+        meta_dir = os.path.dirname(self._meta_path)
+        if meta_dir:
+            secure_makedirs(meta_dir)
+
+        now = datetime.now(timezone.utc).isoformat()
+        self._metadata: dict[str, Any] = {
+            "version": 1,
+            "data_file": self._data_path,
+            "query": query,
+            "start_time": start_time,
+            "end_time": end_time,
+            "stream": stream,
+            "limit": limit,
+            "oid": oid,
+            "created_at": now,
+            "updated_at": now,
+            "result_count": 0,
+            "total_events": 0,
+            "page": 1,
+            "last_token": None,
+            "completed": False,
+        }
+
+        # Create the data file with secure permissions. Use O_CREAT|O_EXCL
+        # when not forcing to atomically prevent TOCTOU races (another process
+        # creating the file between our exists-check and open). On Unix,
+        # O_NOFOLLOW also rejects symlinks at open time.
+        # Search results may contain sensitive telemetry, so restrict
+        # access to owner-only (0o600).
+        open_flags = os.O_WRONLY | os.O_CREAT | os.O_APPEND
+        if not force:
+            open_flags |= os.O_EXCL
+        if os.name != "nt" and hasattr(os, "O_NOFOLLOW"):
+            open_flags |= os.O_NOFOLLOW
+        try:
+            fd = os.open(self._data_path, open_flags, stat.S_IRUSR | stat.S_IWUSR)
+        except FileExistsError:
+            raise FileExistsError(
+                f"Checkpoint data file already exists: {self._data_path}. "
+                "Use --resume to continue, --force to overwrite, "
+                "or delete the file and retry."
+            )
+        self._file = os.fdopen(fd, "a", encoding="utf-8")
+        secure_file_permissions(self._data_path)
+
+        # Write initial metadata (atomic_write handles its own permissions).
+        self._write_metadata()
+
+    def write_result(self, result: dict[str, Any]) -> None:
+        """Append a single search result to the data file.
+
+        Each result is written as a single JSON line, flushed immediately.
+
+        Args:
+            result: A SearchResult dict from the API.
+        """
+        self._file.write(json.dumps(result, default=str) + "\n")
+        self._file.flush()
+
+    def update_progress(self, page: int, result_count: int, completed: bool,
+                        last_token: str | None = None,
+                        total_events: int | None = None,
+                        last_event_ts: int | None = None) -> None:
+        """Update checkpoint metadata with current progress.
+
+        Rewrites the metadata file atomically.
+
+        Args:
+            page: Current page number.
+            result_count: Total results (SearchResult wrappers) written so far.
+            completed: Whether the search has completed.
+            last_token: The most recent nextToken from results, used for
+                server-side resume.
+            total_events: Cumulative count of individual event rows across
+                all results fetched so far.
+            last_event_ts: Timestamp (milliseconds epoch) of the most recent
+                event in the last fetched page, used to show progress through
+                the time range.
+        """
+        self._metadata["page"] = page
+        self._metadata["result_count"] = result_count
+        self._metadata["completed"] = completed
+        if last_token is not None:
+            self._metadata["last_token"] = last_token
+        if total_events is not None:
+            self._metadata["total_events"] = total_events
+        if last_event_ts is not None:
+            self._metadata["last_event_ts"] = last_event_ts
+        self._metadata["updated_at"] = datetime.now(timezone.utc).isoformat()
+        self._write_metadata()
+
+    def close(self) -> None:
+        """Close the data file handle."""
+        if self._file and not self._file.closed:
+            self._file.close()
+
+    def _write_metadata(self) -> None:
+        """Atomically write metadata to disk."""
+        content = json.dumps(self._metadata, indent=2).encode("utf-8")
+        atomic_write(self._meta_path, content)
+
+    def __enter__(self) -> "CheckpointWriter":
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        self.close()
+
+
+class CheckpointReader:
+    """Reads checkpoint metadata and data for resume.
+
+    Provides both eager (``read``) and lazy (``iter_results``) access
+    to checkpoint data. Use ``iter_results`` for large checkpoints to
+    avoid loading all results into memory at once.
+
+    Handles corrupt last line in data file gracefully - if the last
+    line is not valid JSON (e.g. from a crash mid-write), it is
+    silently dropped.
+    """
+
+    @staticmethod
+    def iter_results(data_path: str) -> Generator[dict[str, Any], None, None]:
+        """Lazily iterate over results in the checkpoint data file.
+
+        Streams one JSONL line at a time without buffering the entire
+        file in memory. Suitable for large checkpoints.
+
+        Only the very last line is allowed to be corrupt (crash mid-write).
+        Corrupt lines in the middle raise ValueError.
+
+        Args:
+            data_path: Absolute path to the JSONL data file.
+
+        Yields:
+            Parsed result dicts, one per JSONL line.
+
+        Raises:
+            FileNotFoundError: If data file does not exist.
+            ValueError: If a non-last line is corrupt.
+        """
+        abs_path = os.path.abspath(data_path)
+        if not os.path.exists(abs_path):
+            raise FileNotFoundError(
+                f"Checkpoint data file not found: {abs_path}"
+            )
+
+        # We need to know whether a corrupt line is the last one.
+        # Use a one-line lookahead: parse the previous line only after
+        # confirming the current line exists (meaning previous wasn't last).
+        pending: tuple[int, str] | None = None  # (line_number, raw_line)
+        line_num = 0
+        with open(abs_path, "r", encoding="utf-8") as f:
+            for raw_line in f:
+                stripped = raw_line.strip()
+                if not stripped:
+                    continue
+                line_num += 1
+
+                if pending is not None:
+                    # Previous line is NOT the last - must be valid.
+                    prev_num, prev_line = pending
+                    try:
+                        yield json.loads(prev_line)
+                    except json.JSONDecodeError:
+                        raise ValueError(
+                            f"Corrupt line {prev_num} in checkpoint data file "
+                            f"{abs_path} (only the last line may be corrupt)"
+                        )
+
+                pending = (line_num, stripped)
+
+        # Process the final line - tolerate corruption.
+        if pending is not None:
+            _, last_line = pending
+            try:
+                yield json.loads(last_line)
+            except json.JSONDecodeError:
+                # Last line corrupt (crash mid-write) - skip silently.
+                pass
+
+    @staticmethod
+    def read(data_path: str) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+        """Read checkpoint metadata and data file contents.
+
+        Loads all results into memory. For large checkpoints, prefer
+        ``iter_results`` combined with ``read_metadata``.
+
+        Args:
+            data_path: Absolute path to the JSONL data file.
+
+        Returns:
+            Tuple of (metadata dict, list of result dicts from data file).
+
+        Raises:
+            FileNotFoundError: If data file or metadata file is missing.
+        """
+        metadata = CheckpointReader.read_metadata(data_path)
+
+        abs_path = os.path.abspath(data_path)
+        results = list(CheckpointReader.iter_results(abs_path))
+        return metadata, results
+
+    @staticmethod
+    def read_metadata(data_path: str) -> dict[str, Any]:
+        """Read only the checkpoint metadata (not the data file).
+
+        Uses safe_open_read to reject symlinks at the metadata path.
+
+        Args:
+            data_path: Absolute path to the JSONL data file.
+
+        Returns:
+            Metadata dict.
+
+        Raises:
+            FileNotFoundError: If metadata file is missing.
+        """
+        from .file_utils import safe_open_read as _safe_read
+        abs_path = os.path.abspath(data_path)
+        meta_file = _meta_path(abs_path)
+        if not os.path.exists(meta_file):
+            raise FileNotFoundError(
+                f"Checkpoint metadata not found for: {abs_path}"
+            )
+        return json.loads(_safe_read(meta_file))
+
+    @staticmethod
+    def count_results(data_path: str) -> int:
+        """Count results in the data file without loading them into memory.
+
+        Counts non-empty lines. Used by CheckpointResumer to determine
+        the skip count without loading all results.
+
+        Args:
+            data_path: Absolute path to the JSONL data file.
+
+        Returns:
+            Number of result lines in the data file.
+        """
+        count = 0
+        with open(data_path, "r", encoding="utf-8") as f:
+            for line in f:
+                if line.strip():
+                    count += 1
+        return count
+
+
+class CheckpointResumer:
+    """Resumes a search from a checkpoint.
+
+    Re-opens the data file for appending and updates the existing
+    metadata file as new results arrive.
+    """
+
+    def __init__(self, data_path: str) -> None:
+        """Initialize from an existing checkpoint.
+
+        Args:
+            data_path: Path to the existing JSONL data file.
+
+        Raises:
+            FileNotFoundError: If data file or metadata is missing.
+        """
+        self._data_path = os.path.abspath(data_path)
+        self._meta_path = _meta_path(self._data_path)
+
+        # Read metadata only; count results without loading all data
+        # into memory (checkpoints can be very large).
+        self._metadata = CheckpointReader.read_metadata(self._data_path)
+        if not os.path.exists(self._data_path):
+            raise FileNotFoundError(
+                f"Checkpoint data file not found: {self._data_path}"
+            )
+        self._existing_count = CheckpointReader.count_results(self._data_path)
+        self._file: Any = None
+
+    @property
+    def metadata(self) -> dict[str, Any]:
+        """The checkpoint metadata dict."""
+        return self._metadata
+
+    @property
+    def existing_count(self) -> int:
+        """Number of results already in the data file."""
+        return self._existing_count
+
+    def open(self) -> None:
+        """Open the data file for appending. Rejects symlinks."""
+        _reject_symlink(self._data_path)
+        self._file = open(self._data_path, "a", encoding="utf-8")
+
+    def write_result(self, result: dict[str, Any]) -> None:
+        """Append a single search result to the data file.
+
+        Args:
+            result: A SearchResult dict from the API.
+        """
+        self._file.write(json.dumps(result, default=str) + "\n")
+        self._file.flush()
+
+    def update_progress(self, page: int, result_count: int, completed: bool,
+                        last_token: str | None = None,
+                        total_events: int | None = None,
+                        last_event_ts: int | None = None) -> None:
+        """Update checkpoint metadata with current progress.
+
+        Args:
+            page: Current page number.
+            result_count: Total results written so far.
+            completed: Whether the search has completed.
+            last_token: The most recent nextToken for server-side resume.
+            total_events: Cumulative count of individual event rows.
+            last_event_ts: Timestamp (ms epoch) of most recent event.
+        """
+        self._metadata["page"] = page
+        self._metadata["result_count"] = result_count
+        self._metadata["completed"] = completed
+        if last_token is not None:
+            self._metadata["last_token"] = last_token
+        if total_events is not None:
+            self._metadata["total_events"] = total_events
+        if last_event_ts is not None:
+            self._metadata["last_event_ts"] = last_event_ts
+        self._metadata["updated_at"] = datetime.now(timezone.utc).isoformat()
+        content = json.dumps(self._metadata, indent=2).encode("utf-8")
+        atomic_write(self._meta_path, content)
+
+    def close(self) -> None:
+        """Close the data file handle."""
+        if self._file and not self._file.closed:
+            self._file.close()
+
+    def __enter__(self) -> "CheckpointResumer":
+        self.open()
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        self.close()
+
+
+def list_checkpoints(
+    cleanup: bool = True,
+    debug_fn: Any = None,
+) -> list[dict[str, Any]]:
+    """List all checkpoint metadata files.
+
+    Scans the checkpoints directory and reads each .meta.json file.
+    When cleanup=True (default), automatically deletes stale metadata
+    files whose data files no longer exist on disk.
+
+    Args:
+        cleanup: If True, delete metadata for checkpoints whose data
+            file has been removed. Default True.
+        debug_fn: Optional callback for debug messages.
+
+    Returns:
+        List of metadata dicts for live checkpoints. Corrupt and stale
+        metadata files are cleaned up silently.
+    """
+    data_dir = get_data_dir()
+    if debug_fn:
+        debug_fn(f"Checkpoint metadata dir: {data_dir}")
+    if not os.path.isdir(data_dir):
+        if debug_fn:
+            debug_fn("Checkpoint metadata dir does not exist")
+        return []
+
+    checkpoints: list[dict[str, Any]] = []
+    for name in sorted(os.listdir(data_dir)):
+        if not name.endswith(".meta.json"):
+            continue
+        path = os.path.join(data_dir, name)
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                meta = json.load(f)
+        except (json.JSONDecodeError, OSError, KeyError):
+            # Corrupt metadata - clean up.
+            if cleanup:
+                if debug_fn:
+                    debug_fn(f"Removing corrupt checkpoint metadata: {path}")
+                try:
+                    os.unlink(path)
+                except OSError:
+                    pass
+            continue
+
+        data_file = meta.get("data_file", "")
+        # Validate data_file is an absolute path to prevent path traversal
+        # from malicious or corrupt metadata files.
+        if not data_file or not os.path.isabs(data_file):
+            if cleanup:
+                if debug_fn:
+                    debug_fn(f"Removing metadata with invalid data_file path: {data_file!r}")
+                try:
+                    os.unlink(path)
+                except OSError:
+                    pass
+            continue
+        data_exists = os.path.exists(data_file)
+
+        if not data_exists and cleanup:
+            # Data file has been deleted - clean up stale metadata.
+            if debug_fn:
+                debug_fn(f"Cleaning up stale checkpoint metadata (data file missing): {data_file}")
+            try:
+                os.unlink(path)
+            except OSError:
+                pass
+            continue
+
+        meta["data_file_exists"] = data_exists
+        checkpoints.append(meta)
+
+    return checkpoints

--- a/tests/unit/test_file_utils.py
+++ b/tests/unit/test_file_utils.py
@@ -9,7 +9,9 @@ from limacharlie.file_utils import (
     _reject_symlink,
     atomic_write,
     safe_open_read,
+    secure_dir_permissions,
     secure_file_permissions,
+    secure_makedirs,
 )
 
 
@@ -45,6 +47,68 @@ class TestSecureFilePermissions:
         path = str(tmp_path / "nonexistent")
         with pytest.raises(OSError):
             secure_file_permissions(path)
+
+
+class TestSecureDirPermissions:
+    """Tests for secure_dir_permissions."""
+
+    @pytest.mark.skipif(os.name == "nt", reason="Unix permission model")
+    def test_sets_owner_only_permissions(self, tmp_path):
+        d = str(tmp_path / "secure_dir")
+        os.mkdir(d)
+        os.chmod(d, 0o755)  # Start permissive
+        secure_dir_permissions(d)
+        mode = os.stat(d).st_mode & 0o777
+        assert mode == 0o700
+
+    @pytest.mark.skipif(os.name == "nt", reason="Unix-only ownership check")
+    def test_sets_ownership_to_current_user(self, tmp_path):
+        d = str(tmp_path / "owned_dir")
+        os.mkdir(d)
+        secure_dir_permissions(d)
+        st = os.stat(d)
+        assert st.st_uid == os.getuid()
+        assert st.st_gid == os.getgid()
+
+    def test_nonexistent_dir_raises(self, tmp_path):
+        with pytest.raises(OSError):
+            secure_dir_permissions(str(tmp_path / "nonexistent"))
+
+
+class TestSecureMakedirs:
+    """Tests for secure_makedirs."""
+
+    @pytest.mark.skipif(os.name == "nt", reason="Unix permission model")
+    def test_creates_single_dir_with_secure_perms(self, tmp_path):
+        d = str(tmp_path / "new_dir")
+        secure_makedirs(d)
+        assert os.path.isdir(d)
+        mode = os.stat(d).st_mode & 0o777
+        assert mode == 0o700
+
+    @pytest.mark.skipif(os.name == "nt", reason="Unix permission model")
+    def test_creates_nested_dirs_all_secure(self, tmp_path):
+        d = str(tmp_path / "a" / "b" / "c")
+        secure_makedirs(d)
+        assert os.path.isdir(d)
+        # Check each created level
+        for level in ["a", os.path.join("a", "b"), os.path.join("a", "b", "c")]:
+            path = str(tmp_path / level)
+            mode = os.stat(path).st_mode & 0o777
+            assert mode == 0o700, f"{path} has {oct(mode)}, expected 0o700"
+
+    def test_existing_dir_is_noop(self, tmp_path):
+        """If directory already exists, secure_makedirs does not fail."""
+        d = str(tmp_path / "existing")
+        os.mkdir(d)
+        # Should not raise
+        secure_makedirs(d)
+
+    def test_works_on_all_platforms(self, tmp_path):
+        """secure_makedirs succeeds on all platforms without crashing."""
+        d = str(tmp_path / "crossplat" / "nested")
+        secure_makedirs(d)
+        assert os.path.isdir(d)
 
 
 class TestAtomicWrite:

--- a/tests/unit/test_sdk_search.py
+++ b/tests/unit/test_sdk_search.py
@@ -1,17 +1,27 @@
 """Tests for limacharlie.sdk.search module.
 
-Tests cover LCQL query execution, validation, and error handling.
+Tests cover LCQL query execution, validation, error handling, and
+poll retry logic for transient errors.
 All search errors should include query_id, region, oid, and query
 for troubleshooting when available.
 """
 
 import json
+import ssl
 import time
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, patch, call
 import pytest
 
-from limacharlie.sdk.search import Search
-from limacharlie.errors import SearchError
+from limacharlie.sdk.search import Search, _is_transient_poll_error
+from limacharlie.errors import (
+    ApiError,
+    AuthenticationError,
+    NotFoundError,
+    PermissionDeniedError,
+    RateLimitError,
+    SearchError,
+    ValidationError,
+)
 
 
 @pytest.fixture
@@ -344,3 +354,454 @@ class TestSearchExecuteErrors:
         # Message should have truncated version
         msg = str(err).split("\n")[0]
         assert "..." in msg
+
+
+class TestIsTransientPollError:
+    """Tests for _is_transient_poll_error classification."""
+
+    def test_api_error_500_is_transient(self):
+        assert _is_transient_poll_error(ApiError("fail", status_code=500)) is True
+
+    def test_api_error_502_is_transient(self):
+        assert _is_transient_poll_error(ApiError("fail", status_code=502)) is True
+
+    def test_api_error_503_is_transient(self):
+        assert _is_transient_poll_error(ApiError("fail", status_code=503)) is True
+
+    def test_api_error_504_is_transient(self):
+        assert _is_transient_poll_error(ApiError("fail", status_code=504)) is True
+
+    def test_api_error_400_not_transient(self):
+        assert _is_transient_poll_error(ApiError("fail", status_code=400)) is False
+
+    def test_connection_error_is_transient(self):
+        assert _is_transient_poll_error(ConnectionError("reset")) is True
+
+    def test_timeout_error_is_transient(self):
+        assert _is_transient_poll_error(TimeoutError("timed out")) is True
+
+    def test_ssl_error_is_transient(self):
+        assert _is_transient_poll_error(ssl.SSLError("handshake")) is True
+
+    def test_os_error_is_transient(self):
+        """Generic OSError (e.g. ECONNRESET) is transient."""
+        assert _is_transient_poll_error(OSError("connection reset")) is True
+
+    def test_auth_error_not_transient(self):
+        assert _is_transient_poll_error(AuthenticationError("401")) is False
+
+    def test_rate_limit_error_not_transient(self):
+        assert _is_transient_poll_error(RateLimitError("429")) is False
+
+    def test_not_found_error_not_transient(self):
+        assert _is_transient_poll_error(NotFoundError("404")) is False
+
+    def test_validation_error_not_transient(self):
+        assert _is_transient_poll_error(ValidationError("bad input")) is False
+
+    def test_permission_denied_not_transient(self):
+        assert _is_transient_poll_error(PermissionDeniedError("403")) is False
+
+    def test_file_not_found_not_transient(self):
+        """FileNotFoundError is an OSError subclass but not transient."""
+        assert _is_transient_poll_error(FileNotFoundError("no such file")) is False
+
+    def test_permission_error_not_transient(self):
+        """PermissionError (OS) is an OSError subclass but not transient."""
+        assert _is_transient_poll_error(PermissionError("denied")) is False
+
+    def test_generic_exception_not_transient(self):
+        assert _is_transient_poll_error(RuntimeError("unknown")) is False
+
+    def test_value_error_not_transient(self):
+        assert _is_transient_poll_error(ValueError("bad value")) is False
+
+
+class TestSearchPollRetry:
+    """Tests for poll retry logic in Search.execute()."""
+
+    @patch("limacharlie.sdk.search.time.sleep")
+    def test_transient_5xx_retried_and_succeeds(self, mock_sleep, search, mock_org):
+        """Transient 5xx error is retried and succeeds on next attempt."""
+        mock_org.client.request.side_effect = [
+            {"queryId": "q-retry"},
+            # First poll: transient 502
+            ApiError("bad gateway", status_code=502),
+            # Retry succeeds
+            {"results": [{"type": "events", "rows": [{"a": 1}]}], "completed": True},
+            {},  # DELETE cleanup
+        ]
+        results = list(search.execute("event", 1000, 2000))
+        assert len(results) == 1
+        # Should have slept once for backoff (2^0 = 1 second)
+        mock_sleep.assert_called_once_with(1)
+
+    @patch("limacharlie.sdk.search.time.sleep")
+    def test_connection_error_retried(self, mock_sleep, search, mock_org):
+        """ConnectionError is retried."""
+        mock_org.client.request.side_effect = [
+            {"queryId": "q-conn"},
+            ConnectionError("reset"),
+            {"results": [{"a": 1}], "completed": True},
+            {},  # DELETE
+        ]
+        results = list(search.execute("event", 1000, 2000))
+        assert len(results) == 1
+
+    @patch("limacharlie.sdk.search.time.sleep")
+    def test_timeout_error_retried(self, mock_sleep, search, mock_org):
+        """TimeoutError is retried."""
+        mock_org.client.request.side_effect = [
+            {"queryId": "q-timeout"},
+            TimeoutError("timed out"),
+            {"results": [{"x": 1}], "completed": True},
+            {},  # DELETE
+        ]
+        results = list(search.execute("event", 1000, 2000))
+        assert len(results) == 1
+
+    @patch("limacharlie.sdk.search.time.sleep")
+    def test_fatal_error_not_retried(self, mock_sleep, search, mock_org):
+        """AuthenticationError (401) is NOT retried - raised immediately."""
+        mock_org.client.request.side_effect = [
+            {"queryId": "q-auth"},
+            AuthenticationError("token expired"),
+        ]
+        with pytest.raises(SearchError) as exc_info:
+            list(search.execute("event", 1000, 2000))
+        assert "token expired" in str(exc_info.value)
+        # No sleep calls - no retry
+        mock_sleep.assert_not_called()
+
+    @patch("limacharlie.sdk.search.time.sleep")
+    def test_not_found_not_retried(self, mock_sleep, search, mock_org):
+        """NotFoundError (404) is NOT retried."""
+        mock_org.client.request.side_effect = [
+            {"queryId": "q-404"},
+            NotFoundError("query not found"),
+        ]
+        with pytest.raises(SearchError):
+            list(search.execute("event", 1000, 2000))
+        mock_sleep.assert_not_called()
+
+    @patch("limacharlie.sdk.search.time.sleep")
+    def test_validation_error_not_retried(self, mock_sleep, search, mock_org):
+        """ValidationError (422) is NOT retried."""
+        mock_org.client.request.side_effect = [
+            {"queryId": "q-422"},
+            ValidationError("bad query"),
+        ]
+        with pytest.raises(SearchError):
+            list(search.execute("event", 1000, 2000))
+        mock_sleep.assert_not_called()
+
+    @patch("limacharlie.sdk.search.time.sleep")
+    def test_poll_body_error_not_retried(self, mock_sleep, search, mock_org):
+        """Poll response with 'error' key is NOT retried (search-engine error)."""
+        mock_org.client.request.side_effect = [
+            {"queryId": "q-body-err"},
+            {"error": "context canceled"},
+            {},  # DELETE
+        ]
+        with pytest.raises(SearchError, match="context canceled"):
+            list(search.execute("event", 1000, 2000))
+        # No retries for body errors
+        mock_sleep.assert_not_called()
+
+    @patch("limacharlie.sdk.search.time.sleep")
+    def test_retries_exhausted_raises(self, mock_sleep, search, mock_org):
+        """When all retries are exhausted, the original error is raised."""
+        mock_org.client.request.side_effect = [
+            {"queryId": "q-exhaust"},
+            ApiError("502", status_code=502),
+            ApiError("502", status_code=502),
+            ApiError("502", status_code=502),
+            ApiError("502", status_code=502),  # 4th attempt (3 retries + 1 initial)
+        ]
+        with pytest.raises(SearchError, match="502"):
+            list(search.execute("event", 1000, 2000))
+        # Should have slept 3 times (exponential: 1, 2, 4)
+        assert mock_sleep.call_count == 3
+
+    @patch("limacharlie.sdk.search.time.sleep")
+    def test_exponential_backoff_timing(self, mock_sleep, search, mock_org):
+        """Verifies exponential backoff delays: 1s, 2s, 4s."""
+        mock_org.client.request.side_effect = [
+            {"queryId": "q-backoff"},
+            ApiError("503", status_code=503),
+            ApiError("503", status_code=503),
+            ApiError("503", status_code=503),
+            {"results": [{"a": 1}], "completed": True},
+            {},  # DELETE
+        ]
+        results = list(search.execute("event", 1000, 2000))
+        assert len(results) == 1
+        assert mock_sleep.call_args_list == [call(1), call(2), call(4)]
+
+    @patch("limacharlie.sdk.search.time.sleep")
+    def test_poll_max_retries_parameter(self, mock_sleep, search, mock_org):
+        """poll_max_retries=1 limits to one retry attempt."""
+        mock_org.client.request.side_effect = [
+            {"queryId": "q-max1"},
+            ApiError("503", status_code=503),
+            ApiError("503", status_code=503),  # Second failure -> exhausted
+        ]
+        with pytest.raises(SearchError):
+            list(search.execute("event", 1000, 2000, poll_max_retries=1))
+        # Only 1 sleep (1 retry)
+        assert mock_sleep.call_count == 1
+
+    @patch("limacharlie.sdk.search.time.sleep")
+    def test_poll_max_retries_zero_disables_retry(self, mock_sleep, search, mock_org):
+        """poll_max_retries=0 disables retries entirely."""
+        mock_org.client.request.side_effect = [
+            {"queryId": "q-no-retry"},
+            ApiError("503", status_code=503),
+        ]
+        with pytest.raises(SearchError):
+            list(search.execute("event", 1000, 2000, poll_max_retries=0))
+        mock_sleep.assert_not_called()
+
+    @patch("limacharlie.sdk.search.time.sleep")
+    def test_retry_reports_progress(self, mock_sleep, search, mock_org):
+        """Progress function receives retry status messages."""
+        progress_msgs = []
+        mock_org.client.request.side_effect = [
+            {"queryId": "q-prog"},
+            ApiError("502", status_code=502),
+            {"results": [{"a": 1}], "completed": True},
+            {},  # DELETE
+        ]
+        results = list(search.execute("event", 1000, 2000,
+                                      progress_fn=progress_msgs.append))
+        assert any("Retrying poll" in msg for msg in progress_msgs)
+        assert any("attempt 2/4" in msg for msg in progress_msgs)
+
+    @patch("limacharlie.sdk.search.time.sleep")
+    def test_backoff_capped_at_30_seconds(self, mock_sleep, search, mock_org):
+        """Backoff delay is capped at 30 seconds even with many retries."""
+        # Use max_retries=6 to get 2^5=32 which should be capped to 30.
+        mock_org.client.request.side_effect = [
+            {"queryId": "q-cap"},
+            *[ApiError("503", status_code=503) for _ in range(6)],
+            {"results": [{"a": 1}], "completed": True},
+            {},  # DELETE
+        ]
+        results = list(search.execute("event", 1000, 2000, poll_max_retries=6))
+        assert len(results) == 1
+        # Backoff sequence: 1, 2, 4, 8, 16, 30 (capped)
+        assert mock_sleep.call_args_list == [
+            call(1), call(2), call(4), call(8), call(16), call(30),
+        ]
+
+    @patch("limacharlie.sdk.search.time.sleep")
+    def test_retry_on_second_page_poll(self, mock_sleep, search, mock_org):
+        """Transient error on a later page poll is retried correctly."""
+        mock_org.client.request.side_effect = [
+            {"queryId": "q-page2"},
+            # Page 1: success with nextToken
+            {"results": [{"type": "events", "rows": [{"a": 1}], "nextToken": "tok1"}], "completed": True},
+            # Page 2: transient failure then success
+            ApiError("502", status_code=502),
+            {"results": [{"type": "events", "rows": [{"b": 2}]}], "completed": True},
+            {},  # DELETE
+        ]
+        results = list(search.execute("event", 1000, 2000))
+        assert len(results) == 2
+        assert results[0]["rows"] == [{"a": 1}]
+        assert results[1]["rows"] == [{"b": 2}]
+
+    @patch("limacharlie.sdk.search.time.sleep")
+    def test_multiple_transient_errors_across_different_polls(self, mock_sleep, search, mock_org):
+        """Retry counter resets between poll calls - each poll gets fresh retries."""
+        mock_org.client.request.side_effect = [
+            {"queryId": "q-multi"},
+            # Poll 1: 2 transient failures then success
+            ApiError("503", status_code=503),
+            ApiError("503", status_code=503),
+            {"results": [{"type": "events", "rows": [{"a": 1}], "nextToken": "tok1"}], "completed": True},
+            # Poll 2: 1 transient failure then success
+            ApiError("502", status_code=502),
+            {"results": [{"type": "events", "rows": [{"b": 2}]}], "completed": True},
+            {},  # DELETE
+        ]
+        results = list(search.execute("event", 1000, 2000))
+        assert len(results) == 2
+        # 2 sleeps for poll 1 (1s, 2s) + 1 sleep for poll 2 (1s)
+        assert mock_sleep.call_count == 3
+
+
+class TestSearchCancellation:
+    """Tests for KeyboardInterrupt handling during search execution.
+
+    Verifies that Ctrl+C always:
+    1. Cancels the server-side query (DELETE request)
+    2. Re-raises KeyboardInterrupt to the caller
+    3. Does not interfere with retry logic
+    """
+
+    def test_keyboard_interrupt_during_poll_cancels_query(self, search, mock_org):
+        """KeyboardInterrupt during poll triggers server-side cancel."""
+        mock_org.client.request.side_effect = [
+            {"queryId": "q-cancel"},
+            KeyboardInterrupt(),
+            {},  # DELETE response
+        ]
+        with pytest.raises(KeyboardInterrupt):
+            list(search.execute("event", 1000, 2000))
+
+        # Verify DELETE was called to cancel the query on server.
+        delete_calls = [c for c in mock_org.client.request.call_args_list
+                        if c[0][0] == "DELETE"]
+        assert len(delete_calls) == 1
+        assert "search/q-cancel" in delete_calls[0][0][1]
+
+    def test_keyboard_interrupt_not_retried(self, search, mock_org):
+        """KeyboardInterrupt is never retried - it's not a transient error."""
+        call_count = 0
+
+        def side_effect(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return {"queryId": "q-no-retry-ki"}
+            elif call_count == 2:
+                raise KeyboardInterrupt()
+            else:
+                return {}  # DELETE
+
+        mock_org.client.request.side_effect = side_effect
+        with pytest.raises(KeyboardInterrupt):
+            list(search.execute("event", 1000, 2000))
+
+        # Only 3 calls: POST (initiate), GET (interrupted), DELETE (cancel).
+        # No retry attempts.
+        assert call_count <= 3
+
+    @patch("limacharlie.sdk.search.time.sleep")
+    def test_keyboard_interrupt_during_retry_backoff(self, mock_sleep, search, mock_org):
+        """KeyboardInterrupt during retry sleep propagates without catching.
+
+        If sleep raises KeyboardInterrupt (user hits Ctrl+C while waiting
+        for retry backoff), the interrupt propagates and the query is canceled.
+        """
+        mock_sleep.side_effect = KeyboardInterrupt()
+        mock_org.client.request.side_effect = [
+            {"queryId": "q-sleep-ki"},
+            ApiError("503", status_code=503),  # Triggers retry + sleep
+            {},  # DELETE
+        ]
+        with pytest.raises(KeyboardInterrupt):
+            list(search.execute("event", 1000, 2000))
+
+        # DELETE should still be called via the finally block.
+        delete_calls = [c for c in mock_org.client.request.call_args_list
+                        if c[0][0] == "DELETE"]
+        assert len(delete_calls) == 1
+
+    def test_keyboard_interrupt_after_partial_results(self, search, mock_org):
+        """KeyboardInterrupt after yielding some results still cancels query."""
+        call_count = 0
+
+        def side_effect(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return {"queryId": "q-partial-ki"}
+            elif call_count == 2:
+                # Page 1: some results
+                return {
+                    "results": [{"type": "events", "rows": [{"a": 1}], "nextToken": "tok1"}],
+                    "completed": True,
+                }
+            elif call_count == 3:
+                # Page 2 poll: user cancels
+                raise KeyboardInterrupt()
+            else:
+                return {}  # DELETE
+
+        mock_org.client.request.side_effect = side_effect
+
+        results = []
+        with pytest.raises(KeyboardInterrupt):
+            for item in search.execute("event", 1000, 2000):
+                results.append(item)
+
+        # Should have gotten page 1 results before interrupt.
+        assert len(results) == 1
+        assert results[0]["rows"] == [{"a": 1}]
+
+        # Server query should still be canceled.
+        delete_calls = [c for c in mock_org.client.request.call_args_list
+                        if c[0][0] == "DELETE"]
+        assert len(delete_calls) == 1
+
+    def test_keyboard_interrupt_cancel_message_with_progress_fn(self, search, mock_org):
+        """Progress function receives cancel message on KeyboardInterrupt."""
+        messages = []
+        mock_org.client.request.side_effect = [
+            {"queryId": "q-cancel-msg"},
+            KeyboardInterrupt(),
+            {},  # DELETE
+        ]
+        with pytest.raises(KeyboardInterrupt):
+            list(search.execute("event", 1000, 2000, progress_fn=messages.append))
+
+        # Should have "Running search..." and "Canceling search query..." messages.
+        assert any("Canceling" in m for m in messages)
+
+    def test_keyboard_interrupt_no_cancel_message_without_progress_fn(self, search, mock_org):
+        """No cancel message when progress_fn is None."""
+        mock_org.client.request.side_effect = [
+            {"queryId": "q-no-msg"},
+            KeyboardInterrupt(),
+            {},  # DELETE
+        ]
+        with pytest.raises(KeyboardInterrupt):
+            list(search.execute("event", 1000, 2000, progress_fn=None))
+
+        # DELETE still called - just no message.
+        delete_calls = [c for c in mock_org.client.request.call_args_list
+                        if c[0][0] == "DELETE"]
+        assert len(delete_calls) == 1
+
+    def test_cancel_delete_failure_does_not_mask_interrupt(self, search, mock_org):
+        """If DELETE fails during cancel, KeyboardInterrupt still propagates."""
+        mock_org.client.request.side_effect = [
+            {"queryId": "q-del-fail"},
+            KeyboardInterrupt(),
+            Exception("DELETE network error"),  # DELETE also fails
+        ]
+        with pytest.raises(KeyboardInterrupt):
+            list(search.execute("event", 1000, 2000))
+
+    @patch("limacharlie.sdk.search.time.sleep")
+    def test_keyboard_interrupt_during_wait_poll(self, mock_sleep, search, mock_org):
+        """KeyboardInterrupt during wait-for-results sleep propagates correctly.
+
+        When completed=False and we sleep for nextPollInMs, a Ctrl+C during
+        that sleep should cancel the query.
+        """
+        call_count = 0
+
+        def request_side_effect(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return {"queryId": "q-wait-ki"}
+            elif call_count == 2:
+                # Not completed yet - will trigger sleep
+                return {"results": [], "completed": False, "nextPollInMs": 1000}
+            else:
+                return {}  # DELETE
+
+        mock_org.client.request.side_effect = request_side_effect
+        # sleep() raises KeyboardInterrupt (user presses Ctrl+C while waiting)
+        mock_sleep.side_effect = KeyboardInterrupt()
+
+        with pytest.raises(KeyboardInterrupt):
+            list(search.execute("event", 1000, 2000))
+
+        delete_calls = [c for c in mock_org.client.request.call_args_list
+                        if c[0][0] == "DELETE"]
+        assert len(delete_calls) == 1

--- a/tests/unit/test_search_checkpoint.py
+++ b/tests/unit/test_search_checkpoint.py
@@ -1,0 +1,632 @@
+"""Tests for limacharlie.search_checkpoint module.
+
+Tests cover CheckpointWriter, CheckpointReader, CheckpointResumer,
+path derivation, and the list_checkpoints function.
+"""
+
+import json
+import os
+import tempfile
+from unittest.mock import patch
+
+import pytest
+
+from limacharlie.search_checkpoint import (
+    CheckpointReader,
+    CheckpointResumer,
+    CheckpointWriter,
+    get_data_dir,
+    list_checkpoints,
+    _checkpoint_id,
+    _meta_path,
+)
+
+
+@pytest.fixture
+def tmp_dir(tmp_path):
+    """Provide a temporary directory for test data files."""
+    return tmp_path
+
+
+@pytest.fixture
+def checkpoints_dir(tmp_path):
+    """Provide a temporary checkpoints metadata directory."""
+    cp_dir = tmp_path / "checkpoints_meta"
+    cp_dir.mkdir()
+    return cp_dir
+
+
+@pytest.fixture(autouse=True)
+def patch_data_dir(checkpoints_dir):
+    """Patch get_data_dir to use the test-local checkpoints directory."""
+    with patch("limacharlie.search_checkpoint.get_data_dir", return_value=str(checkpoints_dir)):
+        yield
+
+
+class TestGetDataDir:
+    """Tests for checkpoint metadata directory path derivation.
+
+    These tests use a dedicated _real_get_data_dir reference captured
+    before the autouse patch to test the actual logic.
+    """
+
+    # Capture the real function before autouse patches it.
+    _real_fn = staticmethod(get_data_dir)
+
+    @pytest.fixture(autouse=True)
+    def _undo_autouse(self, patch_data_dir):
+        """The class-level autouse still runs; we just ignore its effect
+        by calling _real_fn directly."""
+
+    def test_default_config_path(self):
+        """Default: ~/.limacharlie -> ~/.limacharlie.d/search_checkpoints."""
+        import limacharlie.search_checkpoint as cp_module
+        saved = cp_module.get_data_dir
+        cp_module.get_data_dir = self._real_fn
+        try:
+            with patch.object(cp_module, "CONFIG_FILE_PATH", "/home/user/.limacharlie"):
+                env = {k: v for k, v in os.environ.items() if k != "LC_CREDS_FILE"}
+                with patch.dict(os.environ, env, clear=True):
+                    with patch.object(cp_module.os.path, "isdir", return_value=False):
+                        result = cp_module.get_data_dir()
+                        assert result == "/home/user/.limacharlie.d/search_checkpoints"
+        finally:
+            cp_module.get_data_dir = saved
+
+    def test_respects_lc_creds_file(self):
+        """Respects LC_CREDS_FILE: /foo/bar -> /foo/bar.d/search_checkpoints."""
+        import limacharlie.search_checkpoint as cp_module
+        saved = cp_module.get_data_dir
+        cp_module.get_data_dir = self._real_fn
+        try:
+            with patch.dict(os.environ, {"LC_CREDS_FILE": "/foo/bar"}, clear=False):
+                with patch.object(cp_module.os.path, "isdir", return_value=False):
+                    result = cp_module.get_data_dir()
+                    assert result == "/foo/bar.d/search_checkpoints"
+        finally:
+            cp_module.get_data_dir = saved
+
+    def test_directory_config_uses_subdirectory(self, tmp_path):
+        """If config path is a directory, use <dir>/search_checkpoints/."""
+        config_dir = tmp_path / "config_as_dir"
+        config_dir.mkdir()
+
+        import limacharlie.search_checkpoint as cp_module
+        saved = cp_module.get_data_dir
+        cp_module.get_data_dir = self._real_fn
+        try:
+            env = {k: v for k, v in os.environ.items() if k != "LC_CREDS_FILE"}
+            with patch.dict(os.environ, env, clear=True):
+                with patch.object(cp_module, "CONFIG_FILE_PATH", str(config_dir)):
+                    result = cp_module.get_data_dir()
+                    assert result == os.path.join(str(config_dir), "search_checkpoints")
+        finally:
+            cp_module.get_data_dir = saved
+
+
+class TestCheckpointId:
+    """Tests for _checkpoint_id helper."""
+
+    def test_deterministic(self, tmp_dir):
+        """Same path always produces the same ID."""
+        path = str(tmp_dir / "data.jsonl")
+        assert _checkpoint_id(path) == _checkpoint_id(path)
+
+    def test_different_paths_different_ids(self, tmp_dir):
+        """Different paths produce different IDs."""
+        id1 = _checkpoint_id(str(tmp_dir / "a.jsonl"))
+        id2 = _checkpoint_id(str(tmp_dir / "b.jsonl"))
+        assert id1 != id2
+
+    def test_relative_vs_absolute(self, tmp_dir, monkeypatch):
+        """Relative path is resolved to absolute before hashing."""
+        monkeypatch.chdir(tmp_dir)
+        abs_id = _checkpoint_id(str(tmp_dir / "data.jsonl"))
+        rel_id = _checkpoint_id("data.jsonl")
+        assert abs_id == rel_id
+
+
+class TestCheckpointWriter:
+    """Tests for CheckpointWriter."""
+
+    def test_creates_data_and_meta_files(self, tmp_dir):
+        """Writer creates both data file and metadata file."""
+        data_path = str(tmp_dir / "results.jsonl")
+        with CheckpointWriter(data_path, "test query", 1000, 2000,
+                              "event", None, "test-oid") as w:
+            pass
+
+        assert os.path.exists(data_path)
+        meta_file = _meta_path(data_path)
+        assert os.path.exists(meta_file)
+
+    def test_refuses_existing_data_file(self, tmp_dir):
+        """Raises FileExistsError if data file already exists."""
+        data_path = str(tmp_dir / "existing.jsonl")
+        with open(data_path, "w") as f:
+            f.write("existing data\n")
+
+        with pytest.raises(FileExistsError, match="already exists"):
+            CheckpointWriter(data_path, "query", 1000, 2000, None, None, "oid")
+
+    def test_refuses_existing_data_file_error_message(self, tmp_dir):
+        """Error message mentions --resume, --force, and delete as options."""
+        data_path = str(tmp_dir / "existing2.jsonl")
+        with open(data_path, "w") as f:
+            f.write("existing data\n")
+
+        with pytest.raises(FileExistsError, match="--resume") as exc_info:
+            CheckpointWriter(data_path, "query", 1000, 2000, None, None, "oid")
+        msg = str(exc_info.value)
+        assert "--force" in msg
+        assert "delete" in msg
+
+    def test_force_overwrites_existing_data_file(self, tmp_dir):
+        """force=True overwrites existing data and metadata files."""
+        data_path = str(tmp_dir / "overwrite.jsonl")
+        # Create initial checkpoint
+        with CheckpointWriter(data_path, "old query", 1000, 2000,
+                              None, None, "oid") as w:
+            w.write_result({"old": True})
+            w.update_progress(1, 1, completed=True)
+
+        # Force overwrite
+        with CheckpointWriter(data_path, "new query", 3000, 4000,
+                              "event", None, "oid", force=True) as w:
+            w.write_result({"new": True})
+            w.update_progress(1, 1, completed=True)
+
+        meta, results = CheckpointReader.read(data_path)
+        assert len(results) == 1
+        assert results[0]["new"] is True
+        assert meta["query"] == "new query"
+        assert meta["start_time"] == 3000
+
+    def test_force_works_when_no_existing_file(self, tmp_dir):
+        """force=True works fine even when no file exists."""
+        data_path = str(tmp_dir / "new_force.jsonl")
+        with CheckpointWriter(data_path, "query", 1000, 2000,
+                              None, None, "oid", force=True) as w:
+            w.write_result({"a": 1})
+        assert os.path.exists(data_path)
+
+    def test_write_result_appends_jsonl(self, tmp_dir):
+        """write_result appends JSON lines to data file."""
+        data_path = str(tmp_dir / "results.jsonl")
+        with CheckpointWriter(data_path, "query", 1000, 2000,
+                              None, None, "oid") as w:
+            w.write_result({"type": "events", "rows": [{"a": 1}]})
+            w.write_result({"type": "events", "rows": [{"b": 2}]})
+
+        with open(data_path) as f:
+            lines = [line.strip() for line in f if line.strip()]
+        assert len(lines) == 2
+        assert json.loads(lines[0])["rows"] == [{"a": 1}]
+        assert json.loads(lines[1])["rows"] == [{"b": 2}]
+
+    def test_update_progress_updates_metadata(self, tmp_dir):
+        """update_progress rewrites metadata atomically."""
+        data_path = str(tmp_dir / "results.jsonl")
+        with CheckpointWriter(data_path, "query", 1000, 2000,
+                              "event", 50, "test-oid") as w:
+            w.update_progress(page=2, result_count=10, completed=False)
+
+            meta_file = _meta_path(data_path)
+            with open(meta_file) as f:
+                meta = json.load(f)
+            assert meta["page"] == 2
+            assert meta["result_count"] == 10
+            assert meta["completed"] is False
+
+            w.update_progress(page=3, result_count=20, completed=True)
+            with open(meta_file) as f:
+                meta = json.load(f)
+            assert meta["page"] == 3
+            assert meta["result_count"] == 20
+            assert meta["completed"] is True
+
+    def test_metadata_contains_all_fields(self, tmp_dir):
+        """Metadata file has all required fields."""
+        data_path = str(tmp_dir / "results.jsonl")
+        with CheckpointWriter(data_path, "my query", 1000, 2000,
+                              "detect", 100, "org-123") as w:
+            pass
+
+        meta_file = _meta_path(data_path)
+        with open(meta_file) as f:
+            meta = json.load(f)
+
+        assert meta["version"] == 1
+        assert meta["data_file"] == os.path.abspath(data_path)
+        assert meta["query"] == "my query"
+        assert meta["start_time"] == 1000
+        assert meta["end_time"] == 2000
+        assert meta["stream"] == "detect"
+        assert meta["limit"] == 100
+        assert meta["oid"] == "org-123"
+        assert "created_at" in meta
+        assert "updated_at" in meta
+        assert meta["result_count"] == 0
+        assert meta["page"] == 1
+        assert meta["completed"] is False
+
+    def test_creates_parent_directories(self, tmp_dir):
+        """Writer creates parent directories for data file if needed."""
+        data_path = str(tmp_dir / "subdir" / "deep" / "results.jsonl")
+        with CheckpointWriter(data_path, "query", 1000, 2000,
+                              None, None, "oid") as w:
+            w.write_result({"test": True})
+        assert os.path.exists(data_path)
+
+    def test_flush_after_write(self, tmp_dir):
+        """Data is flushed to disk after each write_result call."""
+        data_path = str(tmp_dir / "results.jsonl")
+        writer = CheckpointWriter(data_path, "query", 1000, 2000,
+                                  None, None, "oid")
+        writer.write_result({"a": 1})
+
+        # Read before close - data should be flushed.
+        with open(data_path) as f:
+            content = f.read()
+        assert '"a": 1' in content
+        writer.close()
+
+
+class TestCheckpointReader:
+    """Tests for CheckpointReader."""
+
+    def _create_checkpoint(self, tmp_dir, results, completed=False):
+        """Helper to create a checkpoint with given results."""
+        data_path = str(tmp_dir / "data.jsonl")
+        with CheckpointWriter(data_path, "test query", 1000, 2000,
+                              "event", None, "test-oid") as w:
+            for r in results:
+                w.write_result(r)
+            w.update_progress(1, len(results), completed)
+        return data_path
+
+    def test_read_valid_checkpoint(self, tmp_dir):
+        """Reads back metadata and results correctly."""
+        results = [{"type": "events", "rows": [{"a": i}]} for i in range(3)]
+        data_path = self._create_checkpoint(tmp_dir, results)
+
+        meta, data = CheckpointReader.read(data_path)
+        assert meta["query"] == "test query"
+        assert meta["result_count"] == 3
+        assert len(data) == 3
+        assert data[0]["rows"] == [{"a": 0}]
+
+    def test_read_empty_data_file(self, tmp_dir):
+        """Empty data file returns empty results list."""
+        data_path = self._create_checkpoint(tmp_dir, [])
+
+        meta, data = CheckpointReader.read(data_path)
+        assert len(data) == 0
+        assert meta["result_count"] == 0
+
+    def test_read_corrupted_last_line(self, tmp_dir):
+        """Corrupt last line is gracefully skipped."""
+        data_path = self._create_checkpoint(
+            tmp_dir, [{"type": "events", "rows": [{"a": 1}]}]
+        )
+        # Append corrupt data
+        with open(data_path, "a") as f:
+            f.write('{"incomplete json\n')
+
+        meta, data = CheckpointReader.read(data_path)
+        # Should get the valid line, corrupt line is skipped
+        assert len(data) == 1
+
+    def test_read_corrupted_middle_line_raises(self, tmp_dir):
+        """Corrupt line in the middle of the file raises ValueError."""
+        data_path = self._create_checkpoint(
+            tmp_dir, [{"type": "events", "rows": [{"a": 1}]}]
+        )
+        # Insert corrupt line followed by a valid line
+        with open(data_path, "a") as f:
+            f.write('corrupt middle line\n')
+            f.write('{"type": "events", "rows": [{"b": 2}]}\n')
+
+        with pytest.raises(ValueError, match="Corrupt line"):
+            CheckpointReader.read(data_path)
+
+    def test_count_results(self, tmp_dir):
+        """count_results returns the line count without loading data."""
+        results = [{"type": "events", "rows": [{"a": i}]} for i in range(5)]
+        data_path = self._create_checkpoint(tmp_dir, results)
+        assert CheckpointReader.count_results(data_path) == 5
+
+    def test_count_results_empty_file(self, tmp_dir):
+        """count_results returns 0 for an empty checkpoint."""
+        data_path = self._create_checkpoint(tmp_dir, [])
+        assert CheckpointReader.count_results(data_path) == 0
+
+    def test_read_missing_data_file(self, tmp_dir):
+        """Raises FileNotFoundError for missing data file."""
+        with pytest.raises(FileNotFoundError):
+            CheckpointReader.read(str(tmp_dir / "nonexistent.jsonl"))
+
+    def test_iter_results_missing_data_file(self, tmp_dir):
+        """iter_results raises FileNotFoundError for missing data file."""
+        with pytest.raises(FileNotFoundError, match="data file not found"):
+            list(CheckpointReader.iter_results(str(tmp_dir / "nonexistent.jsonl")))
+
+    def test_read_missing_metadata(self, tmp_dir):
+        """Raises FileNotFoundError for missing metadata."""
+        data_path = str(tmp_dir / "orphan.jsonl")
+        with open(data_path, "w") as f:
+            f.write('{"a": 1}\n')
+
+        with pytest.raises(FileNotFoundError, match="metadata not found"):
+            CheckpointReader.read(data_path)
+
+    def test_read_metadata_only(self, tmp_dir):
+        """read_metadata returns just the metadata dict."""
+        data_path = self._create_checkpoint(tmp_dir, [{"x": 1}])
+        meta = CheckpointReader.read_metadata(data_path)
+        assert meta["query"] == "test query"
+        assert meta["start_time"] == 1000
+
+
+class TestCheckpointResumer:
+    """Tests for CheckpointResumer."""
+
+    def _create_checkpoint(self, tmp_dir, results, completed=False):
+        """Helper to create a checkpoint."""
+        data_path = str(tmp_dir / "data.jsonl")
+        with CheckpointWriter(data_path, "test query", 1000, 2000,
+                              "event", None, "test-oid") as w:
+            for r in results:
+                w.write_result(r)
+            w.update_progress(1, len(results), completed)
+        return data_path
+
+    def test_loads_existing_checkpoint(self, tmp_dir):
+        """Resumer loads metadata and counts existing results."""
+        results = [{"type": "events", "rows": [{"a": i}]} for i in range(5)]
+        data_path = self._create_checkpoint(tmp_dir, results)
+
+        resumer = CheckpointResumer(data_path)
+        assert resumer.existing_count == 5
+        assert resumer.metadata["query"] == "test query"
+
+    def test_appends_new_results(self, tmp_dir):
+        """Resumer appends new results to existing data file."""
+        results = [{"type": "events", "rows": [{"a": 1}]}]
+        data_path = self._create_checkpoint(tmp_dir, results)
+
+        with CheckpointResumer(data_path) as resumer:
+            resumer.write_result({"type": "events", "rows": [{"b": 2}]})
+            resumer.update_progress(2, 2, completed=True)
+
+        meta, data = CheckpointReader.read(data_path)
+        assert len(data) == 2
+        assert meta["result_count"] == 2
+        assert meta["completed"] is True
+
+    def test_missing_data_file_raises(self, tmp_dir):
+        """Raises FileNotFoundError for missing data file."""
+        with pytest.raises(FileNotFoundError):
+            CheckpointResumer(str(tmp_dir / "missing.jsonl"))
+
+    def test_missing_metadata_raises(self, tmp_dir):
+        """Raises FileNotFoundError for orphan data file."""
+        data_path = str(tmp_dir / "orphan.jsonl")
+        with open(data_path, "w") as f:
+            f.write('{"a": 1}\n')
+
+        with pytest.raises(FileNotFoundError, match="metadata not found"):
+            CheckpointResumer(data_path)
+
+
+class TestListCheckpoints:
+    """Tests for list_checkpoints function."""
+
+    def test_empty_directory(self, checkpoints_dir):
+        """Returns empty list when no checkpoints exist."""
+        assert list_checkpoints() == []
+
+    def test_lists_checkpoints(self, tmp_dir, checkpoints_dir):
+        """Returns metadata for all checkpoints."""
+        # Create two checkpoints
+        path1 = str(tmp_dir / "search1.jsonl")
+        with CheckpointWriter(path1, "query 1", 1000, 2000,
+                              "event", None, "oid-1") as w:
+            w.write_result({"a": 1})
+            w.update_progress(1, 1, completed=True)
+
+        path2 = str(tmp_dir / "search2.jsonl")
+        with CheckpointWriter(path2, "query 2", 3000, 4000,
+                              "detect", 50, "oid-2") as w:
+            w.write_result({"b": 2})
+            w.write_result({"c": 3})
+            w.update_progress(1, 2, completed=False)
+
+        cps = list_checkpoints()
+        assert len(cps) == 2
+
+        # Check that data_file_exists is set
+        for cp in cps:
+            assert "data_file_exists" in cp
+
+    def test_cleanup_removes_stale_metadata(self, tmp_dir, checkpoints_dir):
+        """Stale metadata (missing data file) is deleted on list with cleanup=True."""
+        path = str(tmp_dir / "temp.jsonl")
+        with CheckpointWriter(path, "query", 1000, 2000,
+                              None, None, "oid") as w:
+            pass
+
+        meta_file = _meta_path(path)
+        assert os.path.exists(meta_file)
+
+        # Delete the data file but leave metadata
+        os.unlink(path)
+
+        # Default cleanup=True should remove stale metadata
+        cps = list_checkpoints()
+        assert len(cps) == 0
+        assert not os.path.exists(meta_file)
+
+    def test_cleanup_false_preserves_stale_metadata(self, tmp_dir, checkpoints_dir):
+        """With cleanup=False, stale metadata is preserved and reported."""
+        path = str(tmp_dir / "temp2.jsonl")
+        with CheckpointWriter(path, "query", 1000, 2000,
+                              None, None, "oid") as w:
+            pass
+
+        meta_file = _meta_path(path)
+        os.unlink(path)
+
+        cps = list_checkpoints(cleanup=False)
+        assert len(cps) == 1
+        assert cps[0]["data_file_exists"] is False
+        assert os.path.exists(meta_file)
+
+    def test_cleanup_removes_corrupt_metadata(self, checkpoints_dir):
+        """Corrupt metadata files are deleted on list with cleanup=True."""
+        corrupt_path = os.path.join(str(checkpoints_dir), "corrupt.meta.json")
+        with open(corrupt_path, "w") as f:
+            f.write("not valid json{{{")
+
+        cps = list_checkpoints(cleanup=True)
+        assert len(cps) == 0
+        assert not os.path.exists(corrupt_path)
+
+    def test_cleanup_preserves_live_checkpoints(self, tmp_dir, checkpoints_dir):
+        """Cleanup only removes stale/corrupt entries, not live ones."""
+        # Create a live checkpoint
+        live_path = str(tmp_dir / "live.jsonl")
+        with CheckpointWriter(live_path, "query", 1000, 2000,
+                              None, None, "oid") as w:
+            w.write_result({"a": 1})
+
+        # Create a stale checkpoint
+        stale_path = str(tmp_dir / "stale.jsonl")
+        with CheckpointWriter(stale_path, "query2", 3000, 4000,
+                              None, None, "oid") as w:
+            pass
+        os.unlink(stale_path)
+
+        cps = list_checkpoints(cleanup=True)
+        assert len(cps) == 1
+        assert cps[0]["data_file"] == os.path.abspath(live_path)
+
+    def test_nonexistent_directory(self, tmp_path):
+        """Returns empty list when checkpoints directory does not exist."""
+        with patch("limacharlie.search_checkpoint.get_data_dir",
+                   return_value=str(tmp_path / "does_not_exist")):
+            assert list_checkpoints() == []
+
+
+class TestCheckpointPermissions:
+    """Tests for secure file and directory permissions.
+
+    Verifies that checkpoint directories and files are created with
+    owner-only permissions to protect sensitive search telemetry.
+    On Windows, permissions are best-effort (relies on home dir ACLs).
+    """
+
+    @pytest.mark.skipif(os.name == "nt", reason="Unix permission model")
+    def test_metadata_dir_is_owner_only(self, tmp_dir, checkpoints_dir):
+        """Metadata directory has 0o700 permissions (owner rwx only)."""
+        # The autouse patch uses a pre-created dir, but we need to test
+        # the real secure_makedirs path. Create a fresh checkpoint that
+        # triggers directory creation.
+        import limacharlie.search_checkpoint as cp_module
+        fresh_dir = str(tmp_dir / "fresh_meta")
+        with patch("limacharlie.search_checkpoint.get_data_dir", return_value=fresh_dir):
+            data_path = str(tmp_dir / "perms_test.jsonl")
+            with CheckpointWriter(data_path, "query", 1000, 2000,
+                                  None, None, "oid") as w:
+                pass
+
+        assert os.path.isdir(fresh_dir)
+        mode = os.stat(fresh_dir).st_mode & 0o777
+        assert mode == 0o700, f"Expected 0o700, got {oct(mode)}"
+
+    @pytest.mark.skipif(os.name == "nt", reason="Unix permission model")
+    def test_metadata_file_is_owner_only(self, tmp_dir):
+        """Metadata .meta.json file has 0o600 permissions."""
+        data_path = str(tmp_dir / "meta_perms.jsonl")
+        with CheckpointWriter(data_path, "query", 1000, 2000,
+                              None, None, "oid") as w:
+            pass
+
+        meta_file = _meta_path(data_path)
+        mode = os.stat(meta_file).st_mode & 0o777
+        assert mode == 0o600, f"Expected 0o600, got {oct(mode)}"
+
+    @pytest.mark.skipif(os.name == "nt", reason="Unix permission model")
+    def test_data_file_is_owner_only(self, tmp_dir):
+        """Data JSONL file has 0o600 permissions (contains sensitive telemetry)."""
+        data_path = str(tmp_dir / "data_perms.jsonl")
+        with CheckpointWriter(data_path, "query", 1000, 2000,
+                              None, None, "oid") as w:
+            w.write_result({"sensitive": "data"})
+
+        mode = os.stat(data_path).st_mode & 0o777
+        assert mode == 0o600, f"Expected 0o600, got {oct(mode)}"
+
+    @pytest.mark.skipif(os.name == "nt", reason="Unix permission model")
+    def test_nested_metadata_dirs_are_all_secure(self, tmp_dir):
+        """All directories in the metadata path have 0o700 permissions.
+
+        The path ~/.limacharlie.d/search_checkpoints/ has two levels of
+        directories that both need to be secured.
+        """
+        import limacharlie.search_checkpoint as cp_module
+        # Create a deep fresh path to test multi-level creation.
+        base = str(tmp_dir / "deep_meta" / "level1" / "level2")
+        with patch("limacharlie.search_checkpoint.get_data_dir", return_value=base):
+            data_path = str(tmp_dir / "deep_perms.jsonl")
+            with CheckpointWriter(data_path, "query", 1000, 2000,
+                                  None, None, "oid") as w:
+                pass
+
+        # Check each created directory.
+        current = base
+        while current != str(tmp_dir / "deep_meta"):
+            if os.path.isdir(current):
+                mode = os.stat(current).st_mode & 0o777
+                assert mode == 0o700, f"Dir {current} has {oct(mode)}, expected 0o700"
+            parent = os.path.dirname(current)
+            if parent == current:
+                break
+            current = parent
+
+    @pytest.mark.skipif(os.name == "nt", reason="Unix permission model")
+    def test_force_overwrite_preserves_secure_permissions(self, tmp_dir):
+        """Force-overwriting a checkpoint preserves secure file permissions."""
+        data_path = str(tmp_dir / "force_perms.jsonl")
+        with CheckpointWriter(data_path, "query", 1000, 2000,
+                              None, None, "oid") as w:
+            w.write_result({"old": True})
+
+        with CheckpointWriter(data_path, "query2", 3000, 4000,
+                              None, None, "oid", force=True) as w:
+            w.write_result({"new": True})
+
+        data_mode = os.stat(data_path).st_mode & 0o777
+        assert data_mode == 0o600, f"Data file: expected 0o600, got {oct(data_mode)}"
+
+        meta_file = _meta_path(data_path)
+        meta_mode = os.stat(meta_file).st_mode & 0o777
+        assert meta_mode == 0o600, f"Meta file: expected 0o600, got {oct(meta_mode)}"
+
+    def test_works_on_all_platforms(self, tmp_dir):
+        """Checkpoint creation succeeds on all platforms regardless of permission model.
+
+        This test runs on all platforms (including Windows) to verify that
+        the secure permission calls don't crash, even if they have limited
+        effect on non-Unix systems.
+        """
+        data_path = str(tmp_dir / "crossplat.jsonl")
+        with CheckpointWriter(data_path, "query", 1000, 2000,
+                              None, None, "oid") as w:
+            w.write_result({"a": 1})
+            w.update_progress(1, 1, completed=True)
+
+        assert os.path.exists(data_path)
+        meta, results = CheckpointReader.read(data_path)
+        assert len(results) == 1
+        assert meta["completed"] is True

--- a/tests/unit/test_search_checkpoint_cli.py
+++ b/tests/unit/test_search_checkpoint_cli.py
@@ -1,0 +1,1112 @@
+"""CLI-level integration tests for search checkpoint/resume.
+
+Tests invoke actual CLI commands via Click's CliRunner with mocked API
+responses. This tests the full flow from CLI args through flag validation,
+checkpoint creation, search execution, output formatting, and error handling
+- with minimal mocking (only the HTTP layer is mocked).
+
+Compared to the unit tests in test_checkpoint.py and
+test_search_checkpoint_integration.py which test individual components,
+these tests exercise the entire command pipeline as a user would.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from unittest.mock import MagicMock, patch, PropertyMock
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from limacharlie.search_checkpoint import CheckpointReader, _meta_path, get_data_dir
+from limacharlie.cli import cli
+
+
+@pytest.fixture
+def checkpoints_dir(tmp_path):
+    """Temporary checkpoints metadata directory."""
+    cp_dir = tmp_path / "checkpoints_meta"
+    cp_dir.mkdir()
+    return cp_dir
+
+
+@pytest.fixture(autouse=True)
+def patch_checkpoint_dir(checkpoints_dir):
+    """Patch get_data_dir for all tests."""
+    with patch("limacharlie.search_checkpoint.get_data_dir", return_value=str(checkpoints_dir)):
+        yield
+
+
+@pytest.fixture
+def mock_client():
+    """Mock Client that returns a mock org with search capabilities."""
+    client = MagicMock()
+    client.oid = "test-oid"
+    client.get_jwt.return_value = "fake-jwt"
+    return client
+
+
+@pytest.fixture
+def mock_org(mock_client):
+    """Mock Organization with search URL."""
+    org = MagicMock()
+    org.oid = "test-oid"
+    org.client = mock_client
+    org.get_urls.return_value = {"search": "abc123.replay-search.limacharlie.io"}
+    return org
+
+
+def _patch_search_command(mock_org, search_side_effects):
+    """Create patches for the search command module.
+
+    Returns a dict of patch context managers to be used as:
+        with _patch_search_command(...) as patches:
+            result = runner.invoke(...)
+
+    Args:
+        mock_org: Mock Organization instance.
+        search_side_effects: List of side_effect values for client.request
+            (POST initiate, GET poll(s), DELETE cleanup).
+    """
+    mock_org.client.request.side_effect = search_side_effects
+    return {
+        "client": patch("limacharlie.commands.search.Client", return_value=mock_org.client),
+        "org": patch("limacharlie.commands.search.Organization", return_value=mock_org),
+    }
+
+
+def _make_search_responses(pages, events_per_page=2):
+    """Build mock API responses for a multi-page search.
+
+    Each page has one events-type result with the specified number of event
+    rows. Pages are linked by nextToken except the last.
+    """
+    responses = [{"queryId": "q-test"}]
+    for i in range(pages):
+        is_last = i == pages - 1
+        result = {
+            "type": "events",
+            "rows": [
+                {"mtd": {"ts": (1700000000 + i * 1000 + j) * 1000, "stream": "event"},
+                 "data": {"routing": {"event_type": "NEW_PROCESS"}, "event": {"idx": i * events_per_page + j}}}
+                for j in range(events_per_page)
+            ],
+        }
+        if not is_last:
+            result["nextToken"] = f"tok-{i + 1}"
+        responses.append({"results": [result], "completed": True})
+    responses.append({})  # DELETE cleanup
+    return responses
+
+
+class TestSearchRunCheckpointCli:
+    """Test 'search run --checkpoint' via CliRunner."""
+
+    def test_checkpoint_creates_files_and_outputs_results(self, tmp_path, mock_org):
+        """Full search with --checkpoint creates data file, metadata, and outputs results."""
+        data_path = str(tmp_path / "test.jsonl")
+        responses = _make_search_responses(2)
+        mock_org.client.request.side_effect = responses
+
+        runner = CliRunner()
+        with patch("limacharlie.commands.search.Client", return_value=mock_org.client), \
+             patch("limacharlie.commands.search.Organization", return_value=mock_org):
+            result = runner.invoke(cli, [
+                "--oid", "test-oid", "--output", "json",
+                "search", "run",
+                "--query", "* | NEW_PROCESS | *",
+                "--start", "1700000000", "--end", "1700086400",
+                "--checkpoint", data_path,
+            ])
+
+        assert result.exit_code == 0, f"CLI failed: {result.output}"
+
+        # Data file exists with results
+        assert os.path.exists(data_path)
+        meta, results = CheckpointReader.read(data_path)
+        assert len(results) == 2
+        assert meta["completed"] is True
+        assert meta["query"] == "* | NEW_PROCESS | *"
+        assert meta["start_time"] == 1700000000
+        assert meta["end_time"] == 1700086400
+        assert meta["total_events"] == 4  # 2 pages x 2 events
+        assert meta["last_token"] == "tok-1"
+
+    def test_checkpoint_existing_file_without_metadata_errors(self, tmp_path, mock_org):
+        """Existing file with no checkpoint metadata shows generic error."""
+        data_path = str(tmp_path / "existing.jsonl")
+        with open(data_path, "w") as f:
+            f.write("existing\n")
+
+        runner = CliRunner()
+        with patch("limacharlie.commands.search.Client", return_value=mock_org.client), \
+             patch("limacharlie.commands.search.Organization", return_value=mock_org):
+            result = runner.invoke(cli, [
+                "--oid", "test-oid",
+                "search", "run",
+                "--query", "* | * | *", "--start", "1000", "--end", "2000",
+                "--checkpoint", data_path,
+            ])
+
+        assert result.exit_code != 0
+        assert "--force" in result.output
+
+    def test_checkpoint_completed_existing_shows_no_resume(self, tmp_path, mock_org):
+        """Completed checkpoint shows 'completed' message without --resume suggestion."""
+        data_path = str(tmp_path / "completed_exists.jsonl")
+        mock_org.client.request.side_effect = _make_search_responses(1)
+
+        runner = CliRunner()
+        with patch("limacharlie.commands.search.Client", return_value=mock_org.client), \
+             patch("limacharlie.commands.search.Organization", return_value=mock_org):
+            # Create completed checkpoint
+            runner.invoke(cli, [
+                "--oid", "test-oid", "--output", "json",
+                "search", "run",
+                "--query", "test", "--start", "1000", "--end", "2000",
+                "--checkpoint", data_path,
+            ])
+
+        # Try to create again without --force
+        with patch("limacharlie.commands.search.Client", return_value=mock_org.client), \
+             patch("limacharlie.commands.search.Organization", return_value=mock_org):
+            result = runner.invoke(cli, [
+                "--oid", "test-oid",
+                "search", "run",
+                "--query", "test", "--start", "1000", "--end", "2000",
+                "--checkpoint", data_path,
+            ])
+
+        assert result.exit_code != 0
+        assert "completed" in result.output
+        assert "--force" in result.output
+        assert "checkpoint-show" in result.output
+        # Should NOT suggest --resume for a completed checkpoint
+        assert "--resume" not in result.output
+
+    def test_checkpoint_in_progress_existing_shows_resume(self, tmp_path, mock_org):
+        """In-progress checkpoint shows --resume suggestion with resume command."""
+        data_path = str(tmp_path / "inprogress_exists.jsonl")
+        call_count = 0
+
+        def side_effect(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return {"queryId": "q1"}
+            elif call_count == 2:
+                return {
+                    "results": [{"type": "events",
+                                 "rows": [{"mtd": {"ts": 1000000}, "data": {}}],
+                                 "nextToken": "tok1"}],
+                    "completed": True,
+                }
+            elif call_count == 3:
+                raise KeyboardInterrupt()
+            else:
+                return {}
+
+        mock_org.client.request.side_effect = side_effect
+
+        runner = CliRunner(mix_stderr=False)
+        with patch("limacharlie.commands.search.Client", return_value=mock_org.client), \
+             patch("limacharlie.commands.search.Organization", return_value=mock_org):
+            runner.invoke(cli, [
+                "--oid", "test-oid",
+                "search", "run",
+                "--query", "test query", "--start", "1000", "--end", "2000",
+                "--checkpoint", data_path,
+            ])
+
+        # Try to create again without --force or --resume.
+        # Use a default runner (mix_stderr=True) so error output is in result.output.
+        runner2 = CliRunner()
+        with patch("limacharlie.commands.search.Client", return_value=mock_org.client), \
+             patch("limacharlie.commands.search.Organization", return_value=mock_org):
+            result = runner2.invoke(cli, [
+                "--oid", "test-oid",
+                "search", "run",
+                "--query", "test", "--start", "1000", "--end", "2000",
+                "--checkpoint", data_path,
+            ])
+
+        assert result.exit_code != 0
+        assert "in-progress" in result.output
+        assert "--resume" in result.output
+        assert "--force" in result.output
+        assert data_path in result.output
+
+    def test_checkpoint_force_overwrites(self, tmp_path, mock_org):
+        """--checkpoint --force overwrites existing file."""
+        data_path = str(tmp_path / "overwrite.jsonl")
+        with open(data_path, "w") as f:
+            f.write("old data\n")
+
+        responses = _make_search_responses(1)
+        mock_org.client.request.side_effect = responses
+
+        runner = CliRunner()
+        with patch("limacharlie.commands.search.Client", return_value=mock_org.client), \
+             patch("limacharlie.commands.search.Organization", return_value=mock_org):
+            result = runner.invoke(cli, [
+                "--oid", "test-oid", "--output", "json",
+                "search", "run",
+                "--query", "* | * | *", "--start", "1000", "--end", "2000",
+                "--checkpoint", data_path, "--force",
+            ])
+
+        assert result.exit_code == 0, f"CLI failed: {result.output}"
+        meta, results = CheckpointReader.read(data_path)
+        assert len(results) == 1
+        assert meta["completed"] is True
+
+    def test_checkpoint_tracks_events_and_timestamps(self, tmp_path, mock_org):
+        """Checkpoint metadata includes total_events, last_event_ts, last_token."""
+        data_path = str(tmp_path / "meta_test.jsonl")
+        responses = _make_search_responses(3, events_per_page=5)
+        mock_org.client.request.side_effect = responses
+
+        runner = CliRunner()
+        with patch("limacharlie.commands.search.Client", return_value=mock_org.client), \
+             patch("limacharlie.commands.search.Organization", return_value=mock_org):
+            result = runner.invoke(cli, [
+                "--oid", "test-oid", "--output", "json",
+                "search", "run",
+                "--query", "test", "--start", "1700000000", "--end", "1700086400",
+                "--checkpoint", data_path,
+            ])
+
+        assert result.exit_code == 0, f"CLI failed: {result.output}"
+        meta = CheckpointReader.read_metadata(data_path)
+        assert meta["total_events"] == 15  # 3 pages x 5 events
+        assert meta["page"] == 3
+        assert meta["last_token"] == "tok-2"
+        assert meta["last_event_ts"] is not None
+
+
+class TestSearchRunResumeCli:
+    """Test 'search run --resume --checkpoint' via CliRunner."""
+
+    def _create_checkpoint(self, tmp_path, mock_org, pages=2, events_per_page=2):
+        """Helper: run a search with checkpoint, return data_path."""
+        data_path = str(tmp_path / "resume_test.jsonl")
+        responses = _make_search_responses(pages, events_per_page)
+        mock_org.client.request.side_effect = responses
+
+        runner = CliRunner()
+        with patch("limacharlie.commands.search.Client", return_value=mock_org.client), \
+             patch("limacharlie.commands.search.Organization", return_value=mock_org):
+            result = runner.invoke(cli, [
+                "--oid", "test-oid", "--output", "json",
+                "search", "run",
+                "--query", "* | * | *", "--start", "1700000000", "--end", "1700086400",
+                "--stream", "event",
+                "--checkpoint", data_path, "--limit", str(pages - 1),
+            ])
+        assert result.exit_code == 0, f"Setup failed: {result.output}"
+        return data_path
+
+    def test_resume_uses_stored_token(self, tmp_path, mock_org):
+        """Resume passes stored token to server, skipping already-fetched pages."""
+        data_path = str(tmp_path / "resume_tok.jsonl")
+        # Initial run: page 1 returns, then KeyboardInterrupt on page 2 poll
+        call_count = 0
+
+        def first_run_side_effect(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return {"queryId": "q-init"}
+            elif call_count == 2:
+                return {
+                    "results": [{"type": "events",
+                                 "rows": [{"mtd": {"ts": 1700000000000}, "data": {}}],
+                                 "nextToken": "tok-1"}],
+                    "completed": True,
+                }
+            elif call_count == 3:
+                # Page 2 poll: interrupt
+                raise KeyboardInterrupt()
+            else:
+                return {}  # DELETE
+
+        mock_org.client.request.side_effect = first_run_side_effect
+
+        runner = CliRunner(mix_stderr=False)
+        with patch("limacharlie.commands.search.Client", return_value=mock_org.client), \
+             patch("limacharlie.commands.search.Organization", return_value=mock_org):
+            result = runner.invoke(cli, [
+                "--oid", "test-oid", "--output", "json",
+                "search", "run",
+                "--query", "test query", "--start", "1700000000", "--end", "1700086400",
+                "--checkpoint", data_path,
+            ])
+        # KeyboardInterrupt -> exit 130
+        assert result.exit_code == 130 or "Checkpoint saved" in (result.stderr or result.output)
+
+        meta = CheckpointReader.read_metadata(data_path)
+        assert meta["last_token"] == "tok-1"
+        assert meta["completed"] is False
+
+        # Resume: server gets tok-1 and returns page 2 directly.
+        calls_before = call_count
+        mock_org.client.request.side_effect = [
+            {"queryId": "q-resume"},
+            {"results": [{"type": "events", "rows": [{"mtd": {"ts": 1700001000000}, "data": {}}]}],
+             "completed": True},
+            {},  # DELETE
+        ]
+
+        with patch("limacharlie.commands.search.Client", return_value=mock_org.client), \
+             patch("limacharlie.commands.search.Organization", return_value=mock_org):
+            result = runner.invoke(cli, [
+                "--oid", "test-oid", "--output", "json",
+                "search", "run",
+                "--resume", "--checkpoint", data_path,
+            ])
+        assert result.exit_code == 0, f"Resume failed: {result.output}"
+
+        # Verify the GET used tok-1 (server-side skip).
+        # After the first run consumed calls_before, the resume should
+        # have POST + GET(tok-1) + DELETE.
+        resume_calls = mock_org.client.request.call_args_list[calls_before:]
+        get_calls = [c for c in resume_calls if c[0][0] == "GET"]
+        assert len(get_calls) == 1
+        assert get_calls[0][1]["query_params"] == {"token": "tok-1"}
+
+        # Data file now has 2 results (1 from initial + 1 from resume)
+        _, results = CheckpointReader.read(data_path)
+        assert len(results) == 2
+
+    def test_resume_completed_checkpoint_exits_cleanly(self, tmp_path, mock_org):
+        """Resuming a completed checkpoint outputs existing results."""
+        data_path = str(tmp_path / "completed.jsonl")
+        mock_org.client.request.side_effect = _make_search_responses(1)
+
+        runner = CliRunner()
+        with patch("limacharlie.commands.search.Client", return_value=mock_org.client), \
+             patch("limacharlie.commands.search.Organization", return_value=mock_org):
+            result = runner.invoke(cli, [
+                "--oid", "test-oid", "--output", "json",
+                "search", "run",
+                "--query", "test", "--start", "1000", "--end", "2000",
+                "--checkpoint", data_path,
+            ])
+        assert result.exit_code == 0
+
+        meta = CheckpointReader.read_metadata(data_path)
+        assert meta["completed"] is True
+
+        # Resume should say already completed and output results
+        with patch("limacharlie.commands.search.Client", return_value=mock_org.client), \
+             patch("limacharlie.commands.search.Organization", return_value=mock_org):
+            result = runner.invoke(cli, [
+                "--oid", "test-oid", "--output", "json",
+                "search", "run",
+                "--resume", "--checkpoint", data_path,
+            ])
+        assert result.exit_code == 0
+        # "already completed" goes to stderr; use mix_stderr=False to capture it
+        # or just check it's in the combined output (default mix_stderr=True)
+        all_output = result.output
+        assert "already completed" in all_output
+
+
+class TestSearchRunResumeValidationCli:
+    """Test --resume flag validation rules via CliRunner."""
+
+    def test_resume_without_checkpoint_errors(self):
+        """--resume without --checkpoint produces an error."""
+        runner = CliRunner()
+        result = runner.invoke(cli, [
+            "--oid", "test-oid",
+            "search", "run", "--resume",
+        ])
+        assert result.exit_code != 0
+        assert "--checkpoint" in result.output
+
+    def test_resume_with_query_flag_errors(self, tmp_path, mock_org):
+        """--resume with --query is forbidden."""
+        # Create a checkpoint first
+        data_path = str(tmp_path / "val.jsonl")
+        mock_org.client.request.side_effect = _make_search_responses(1)
+
+        runner = CliRunner()
+        with patch("limacharlie.commands.search.Client", return_value=mock_org.client), \
+             patch("limacharlie.commands.search.Organization", return_value=mock_org):
+            runner.invoke(cli, [
+                "--oid", "test-oid", "search", "run",
+                "--query", "q", "--start", "1000", "--end", "2000",
+                "--checkpoint", data_path,
+            ])
+
+        # Now try resume with --query
+        with patch("limacharlie.commands.search.Client", return_value=mock_org.client), \
+             patch("limacharlie.commands.search.Organization", return_value=mock_org):
+            result = runner.invoke(cli, [
+                "--oid", "test-oid", "search", "run",
+                "--resume", "--checkpoint", data_path,
+                "--query", "different query",
+            ])
+        assert result.exit_code != 0
+        assert "cannot be used with --resume" in result.output
+
+    def test_resume_with_start_end_flags_errors(self, tmp_path, mock_org):
+        """--resume with --start or --end is forbidden."""
+        data_path = str(tmp_path / "val2.jsonl")
+        mock_org.client.request.side_effect = _make_search_responses(1)
+
+        runner = CliRunner()
+        with patch("limacharlie.commands.search.Client", return_value=mock_org.client), \
+             patch("limacharlie.commands.search.Organization", return_value=mock_org):
+            runner.invoke(cli, [
+                "--oid", "test-oid", "search", "run",
+                "--query", "q", "--start", "1000", "--end", "2000",
+                "--checkpoint", data_path,
+            ])
+
+        with patch("limacharlie.commands.search.Client", return_value=mock_org.client), \
+             patch("limacharlie.commands.search.Organization", return_value=mock_org):
+            result = runner.invoke(cli, [
+                "--oid", "test-oid", "search", "run",
+                "--resume", "--checkpoint", data_path,
+                "--start", "5000",
+            ])
+        assert result.exit_code != 0
+        assert "--start" in result.output
+
+    def test_resume_with_limit_is_allowed(self, tmp_path, mock_org):
+        """--resume with --limit is allowed (caps additional results)."""
+        data_path = str(tmp_path / "val3.jsonl")
+        # Create incomplete checkpoint via interrupt
+        call_count = 0
+
+        def side_effect(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return {"queryId": "q1"}
+            elif call_count == 2:
+                return {"results": [{"type": "events",
+                                     "rows": [{"mtd": {"ts": 1000000}, "data": {}}],
+                                     "nextToken": "tok1"}], "completed": True}
+            elif call_count == 3:
+                raise KeyboardInterrupt()
+            else:
+                return {}
+
+        mock_org.client.request.side_effect = side_effect
+
+        runner = CliRunner(mix_stderr=False)
+        with patch("limacharlie.commands.search.Client", return_value=mock_org.client), \
+             patch("limacharlie.commands.search.Organization", return_value=mock_org):
+            runner.invoke(cli, [
+                "--oid", "test-oid", "search", "run",
+                "--query", "q", "--start", "1000", "--end", "2000",
+                "--checkpoint", data_path,
+            ])
+
+        # Resume with --limit should work
+        mock_org.client.request.side_effect = [
+            {"queryId": "q2"},
+            {"results": [{"type": "events", "rows": [{"mtd": {"ts": 2000000}, "data": {}}]}],
+             "completed": True},
+            {},  # DELETE
+        ]
+
+        with patch("limacharlie.commands.search.Client", return_value=mock_org.client), \
+             patch("limacharlie.commands.search.Organization", return_value=mock_org):
+            result = runner.invoke(cli, [
+                "--oid", "test-oid", "--output", "json",
+                "search", "run",
+                "--resume", "--checkpoint", data_path, "--limit", "5",
+            ])
+        assert result.exit_code == 0, f"Resume with --limit failed: {result.output}"
+
+    def test_resume_nonexistent_checkpoint_errors(self, tmp_path):
+        """--resume with non-existent checkpoint file errors."""
+        runner = CliRunner()
+        result = runner.invoke(cli, [
+            "--oid", "test-oid",
+            "search", "run",
+            "--resume", "--checkpoint", str(tmp_path / "nope.jsonl"),
+        ])
+        assert result.exit_code != 0
+        assert "not found" in result.output.lower()
+
+
+class TestSearchCheckpointsCli:
+    """Test 'search checkpoints' via CliRunner."""
+
+    def test_no_checkpoints_message(self):
+        """Empty checkpoints dir shows 'No checkpoints found.'"""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["search", "checkpoints"])
+        assert result.exit_code == 0
+        assert "No checkpoints found" in result.output
+
+    def test_lists_checkpoints_as_table(self, tmp_path, mock_org):
+        """Lists checkpoints with pages, events, status in table format."""
+        data_path = str(tmp_path / "listed.jsonl")
+        mock_org.client.request.side_effect = _make_search_responses(3, events_per_page=10)
+
+        runner = CliRunner()
+        with patch("limacharlie.commands.search.Client", return_value=mock_org.client), \
+             patch("limacharlie.commands.search.Organization", return_value=mock_org):
+            runner.invoke(cli, [
+                "--oid", "test-oid",
+                "search", "run",
+                "--query", "* | NEW_PROCESS | *",
+                "--start", "1700000000", "--end", "1700086400",
+                "--checkpoint", data_path,
+            ])
+
+        result = runner.invoke(cli, ["search", "checkpoints"])
+        assert result.exit_code == 0
+        assert "listed.jsonl" in result.output
+        assert "completed" in result.output
+
+    def test_lists_checkpoints_as_json(self, tmp_path, mock_org):
+        """Lists checkpoints in JSON format with all metadata fields."""
+        data_path = str(tmp_path / "json_listed.jsonl")
+        mock_org.client.request.side_effect = _make_search_responses(2, events_per_page=3)
+
+        runner = CliRunner()
+        with patch("limacharlie.commands.search.Client", return_value=mock_org.client), \
+             patch("limacharlie.commands.search.Organization", return_value=mock_org):
+            runner.invoke(cli, [
+                "--oid", "test-oid",
+                "search", "run",
+                "--query", "test query",
+                "--start", "1700000000", "--end", "1700086400",
+                "--checkpoint", data_path,
+            ])
+
+        result = runner.invoke(cli, ["--output", "json", "search", "checkpoints"])
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert len(parsed) == 1
+        cp = parsed[0]
+        assert cp["query"] == "test query"
+        assert cp["total_events"] == 6  # 2 pages x 3 events
+        assert cp["completed"] is True
+        assert cp["last_token"] == "tok-1"
+        assert "data_file_exists" in cp
+
+    def test_stale_metadata_cleaned_up(self, tmp_path, mock_org, checkpoints_dir):
+        """Stale metadata files are removed when listing checkpoints."""
+        data_path = str(tmp_path / "stale.jsonl")
+        mock_org.client.request.side_effect = _make_search_responses(1)
+
+        runner = CliRunner()
+        with patch("limacharlie.commands.search.Client", return_value=mock_org.client), \
+             patch("limacharlie.commands.search.Organization", return_value=mock_org):
+            runner.invoke(cli, [
+                "--oid", "test-oid",
+                "search", "run",
+                "--query", "q", "--start", "1000", "--end", "2000",
+                "--checkpoint", data_path,
+            ])
+
+        meta_file = _meta_path(data_path)
+        assert os.path.exists(meta_file)
+
+        # Delete the data file
+        os.unlink(data_path)
+
+        # Listing should clean up the stale metadata
+        result = runner.invoke(cli, ["search", "checkpoints"])
+        assert result.exit_code == 0
+        assert "No checkpoints found" in result.output
+        assert not os.path.exists(meta_file)
+
+
+class TestSearchRunWithoutCheckpointCli:
+    """Verify non-checkpoint search still works through CLI."""
+
+    def test_normal_search_without_checkpoint(self, mock_org):
+        """Regular search run without --checkpoint works as before."""
+        mock_org.client.request.side_effect = _make_search_responses(1)
+
+        runner = CliRunner()
+        with patch("limacharlie.commands.search.Client", return_value=mock_org.client), \
+             patch("limacharlie.commands.search.Organization", return_value=mock_org):
+            result = runner.invoke(cli, [
+                "--oid", "test-oid", "--output", "json",
+                "search", "run",
+                "--query", "* | * | *",
+                "--start", "1700000000", "--end", "1700086400",
+            ])
+
+        assert result.exit_code == 0, f"CLI failed: {result.output}"
+        # Should have JSON output
+        parsed = json.loads(result.output)
+        assert isinstance(parsed, list)
+        assert len(parsed) == 1
+
+    def test_missing_query_errors(self):
+        """--query is required without --resume."""
+        runner = CliRunner()
+        result = runner.invoke(cli, [
+            "--oid", "test-oid",
+            "search", "run",
+            "--start", "1000", "--end", "2000",
+        ])
+        assert result.exit_code != 0
+        assert "--query" in result.output
+
+    def test_missing_start_end_errors(self):
+        """--start and --end are required without --resume."""
+        runner = CliRunner()
+        result = runner.invoke(cli, [
+            "--oid", "test-oid",
+            "search", "run",
+            "--query", "test",
+        ])
+        assert result.exit_code != 0
+        assert "--start" in result.output
+
+
+class TestCheckpointCancelMessageCli:
+    """Test the Ctrl+C cancel message content via CliRunner.
+
+    CliRunner can simulate KeyboardInterrupt mid-search by having the
+    mock raise it at the right point.
+    """
+
+    def test_cancel_message_includes_resume_command(self, tmp_path, mock_org):
+        """Ctrl+C message includes the exact resume command."""
+        data_path = str(tmp_path / "cancel.jsonl")
+        call_count = 0
+
+        def side_effect(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return {"queryId": "q-cancel"}
+            elif call_count == 2:
+                return {
+                    "results": [{"type": "events",
+                                 "rows": [{"mtd": {"ts": 1700000000000}, "data": {}}],
+                                 "nextToken": "tok1"}],
+                    "completed": True,
+                }
+            elif call_count == 3:
+                raise KeyboardInterrupt()
+            else:
+                return {}  # DELETE
+
+        mock_org.client.request.side_effect = side_effect
+
+        runner = CliRunner(mix_stderr=False)
+        with patch("limacharlie.commands.search.Client", return_value=mock_org.client), \
+             patch("limacharlie.commands.search.Organization", return_value=mock_org):
+            result = runner.invoke(cli, [
+                "--oid", "test-oid",
+                "search", "run",
+                "--query", "test", "--start", "1700000000", "--end", "1700086400",
+                "--checkpoint", data_path,
+            ])
+
+        # The cancel output goes to stderr
+        stderr = result.stderr if hasattr(result, 'stderr') else result.output
+        assert "Checkpoint saved" in stderr
+        assert "Resume with:" in stderr
+        assert f"--checkpoint {data_path}" in stderr
+        assert "Resume token:" in stderr
+
+
+class TestRejectedTokenResumeCli:
+    """Test that rejected pagination tokens produce helpful error messages.
+
+    If the server rejects a pagination token during resume (e.g. malformed,
+    corrupt, or server-side issue), the CLI should detect this and show
+    the command to re-run the query from scratch with --force.
+    """
+
+    def _create_incomplete_checkpoint(self, tmp_path, mock_org):
+        """Helper: create an incomplete checkpoint with a token."""
+        data_path = str(tmp_path / "expired.jsonl")
+        call_count = 0
+
+        def side_effect(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return {"queryId": "q-exp"}
+            elif call_count == 2:
+                return {
+                    "results": [{"type": "events",
+                                 "rows": [{"mtd": {"ts": 1700000000000}, "data": {}}],
+                                 "nextToken": "tok-expired"}],
+                    "completed": True,
+                }
+            elif call_count == 3:
+                raise KeyboardInterrupt()
+            else:
+                return {}
+
+        mock_org.client.request.side_effect = side_effect
+
+        runner = CliRunner(mix_stderr=False)
+        with patch("limacharlie.commands.search.Client", return_value=mock_org.client), \
+             patch("limacharlie.commands.search.Organization", return_value=mock_org):
+            runner.invoke(cli, [
+                "--oid", "test-oid",
+                "search", "run",
+                "--query", "* | NEW_PROCESS | event/FILE_PATH contains '/bin/bash'",
+                "--start", "1700000000", "--end", "1700086400",
+                "--stream", "event",
+                "--checkpoint", data_path,
+            ])
+        return data_path
+
+    def test_404_on_resume_shows_rejected_token_message(self, tmp_path, mock_org):
+        """404 during resume shows rejected token error with fresh query command."""
+        from limacharlie.errors import NotFoundError
+
+        data_path = self._create_incomplete_checkpoint(tmp_path, mock_org)
+
+        # Resume: server returns 404 (token expired)
+        mock_org.client.request.side_effect = [
+            {"queryId": "q-exp-resume"},
+            NotFoundError("query not found"),
+        ]
+
+        runner = CliRunner(mix_stderr=False)
+        with patch("limacharlie.commands.search.Client", return_value=mock_org.client), \
+             patch("limacharlie.commands.search.Organization", return_value=mock_org):
+            result = runner.invoke(cli, [
+                "--oid", "test-oid",
+                "search", "run",
+                "--resume", "--checkpoint", data_path,
+            ])
+
+        assert result.exit_code != 0
+        stderr = result.stderr
+        assert "rejected" in stderr.lower() or "failed" in stderr.lower()
+        # Should contain the fresh query command with original params
+        assert "--query" in stderr
+        assert "NEW_PROCESS" in stderr
+        assert "--start 1700000000" in stderr
+        assert "--end 1700086400" in stderr
+        assert "--stream event" in stderr
+        assert "--force" in stderr
+        assert data_path in stderr
+
+    def test_error_message_on_resume_shows_rejected_token_message(self, tmp_path, mock_org):
+        """Search error with 'not found' keyword shows rejected token message."""
+        from limacharlie.errors import SearchError
+
+        data_path = self._create_incomplete_checkpoint(tmp_path, mock_org)
+
+        # Resume: server returns error with expiry-related message
+        mock_org.client.request.side_effect = [
+            {"queryId": "q-exp2"},
+            {"error": "query not found or results expired"},
+            {},  # DELETE
+        ]
+
+        runner = CliRunner(mix_stderr=False)
+        with patch("limacharlie.commands.search.Client", return_value=mock_org.client), \
+             patch("limacharlie.commands.search.Organization", return_value=mock_org):
+            result = runner.invoke(cli, [
+                "--oid", "test-oid",
+                "search", "run",
+                "--resume", "--checkpoint", data_path,
+            ])
+
+        assert result.exit_code != 0
+        stderr = result.stderr
+        assert "rejected" in stderr.lower() or "failed" in stderr.lower()
+        assert "--force" in stderr
+
+    def test_non_token_error_on_resume_propagates_normally(self, tmp_path, mock_org):
+        """Non-token errors during resume are NOT caught by the rejected token handler."""
+        from limacharlie.errors import AuthenticationError
+
+        data_path = self._create_incomplete_checkpoint(tmp_path, mock_org)
+
+        # Resume: auth error (not an expiry error)
+        mock_org.client.request.side_effect = [
+            {"queryId": "q-auth"},
+            AuthenticationError("JWT expired"),
+        ]
+
+        runner = CliRunner(mix_stderr=False)
+        with patch("limacharlie.commands.search.Client", return_value=mock_org.client), \
+             patch("limacharlie.commands.search.Organization", return_value=mock_org):
+            result = runner.invoke(cli, [
+                "--oid", "test-oid",
+                "search", "run",
+                "--resume", "--checkpoint", data_path,
+            ])
+
+        assert result.exit_code != 0
+        # Should NOT show the "rejected token" message with --force
+        # (auth errors are different from token rejection)
+        all_output = result.output + result.stderr
+        assert "re-run the query from scratch" not in all_output
+
+
+class TestCheckpointShowCli:
+    """Test 'search checkpoint-show' via CliRunner.
+
+    Verifies that checkpoint data files can be displayed through the
+    same output pipeline as live searches (table, JSON, expand, raw).
+    """
+
+    def _create_completed_checkpoint(self, tmp_path, mock_org, pages=2, events_per_page=3):
+        """Helper: create a completed checkpoint, return data_path."""
+        data_path = str(tmp_path / "show_test.jsonl")
+        mock_org.client.request.side_effect = _make_search_responses(pages, events_per_page)
+
+        runner = CliRunner()
+        with patch("limacharlie.commands.search.Client", return_value=mock_org.client), \
+             patch("limacharlie.commands.search.Organization", return_value=mock_org):
+            result = runner.invoke(cli, [
+                "--oid", "test-oid", "--output", "json",
+                "search", "run",
+                "--query", "* | NEW_PROCESS | event/COMMAND_LINE contains 'curl'",
+                "--start", "1700000000", "--end", "1700086400",
+                "--stream", "event",
+                "--checkpoint", data_path,
+            ])
+        assert result.exit_code == 0, f"Setup failed: {result.output}"
+        return data_path
+
+    def test_show_json_output(self, tmp_path, mock_org):
+        """checkpoint-show --output json outputs the raw result list."""
+        data_path = self._create_completed_checkpoint(tmp_path, mock_org)
+
+        runner = CliRunner()
+        result = runner.invoke(cli, [
+            "--output", "json",
+            "search", "checkpoint-show",
+            "--checkpoint", data_path,
+        ])
+        assert result.exit_code == 0, f"Failed: {result.output}"
+        parsed = json.loads(result.output)
+        assert isinstance(parsed, list)
+        assert len(parsed) == 2  # 2 pages
+        assert parsed[0]["type"] == "events"
+
+    def test_show_table_output(self, tmp_path, mock_org):
+        """checkpoint-show with table output renders events."""
+        data_path = self._create_completed_checkpoint(tmp_path, mock_org)
+
+        runner = CliRunner()
+        result = runner.invoke(cli, [
+            "--output", "table",
+            "search", "checkpoint-show",
+            "--checkpoint", data_path,
+        ])
+        assert result.exit_code == 0, f"Failed: {result.output}"
+        # Table output should contain event data
+        assert "NEW_PROCESS" in result.output or "event" in result.output.lower()
+
+    def test_show_raw_output(self, tmp_path, mock_org):
+        """checkpoint-show --raw outputs raw SearchResult objects."""
+        data_path = self._create_completed_checkpoint(tmp_path, mock_org)
+
+        runner = CliRunner()
+        result = runner.invoke(cli, [
+            "--output", "json",
+            "search", "checkpoint-show",
+            "--checkpoint", data_path, "--raw",
+        ])
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert isinstance(parsed, list)
+        # Raw mode passes through SearchResult wrappers
+        assert all("type" in r for r in parsed)
+
+    def test_show_expand_output(self, tmp_path, mock_org):
+        """checkpoint-show --expand with table format renders event JSON blocks."""
+        data_path = self._create_completed_checkpoint(tmp_path, mock_org)
+
+        runner = CliRunner()
+        result = runner.invoke(cli, [
+            "--output", "table",
+            "search", "checkpoint-show",
+            "--checkpoint", data_path, "--expand",
+        ])
+        assert result.exit_code == 0
+        # Expand mode shows "---" dividers between events
+        assert "---" in result.output
+
+    def test_show_empty_checkpoint(self, tmp_path, mock_org):
+        """checkpoint-show on empty checkpoint shows appropriate message."""
+        data_path = str(tmp_path / "empty.jsonl")
+        # Create checkpoint with no results
+        mock_org.client.request.side_effect = [
+            {"queryId": "q-empty"},
+            {"results": [], "completed": True},
+            {},  # DELETE
+        ]
+
+        runner = CliRunner()
+        with patch("limacharlie.commands.search.Client", return_value=mock_org.client), \
+             patch("limacharlie.commands.search.Organization", return_value=mock_org):
+            runner.invoke(cli, [
+                "--oid", "test-oid",
+                "search", "run",
+                "--query", "q", "--start", "1000", "--end", "2000",
+                "--checkpoint", data_path,
+            ])
+
+        result = runner.invoke(cli, [
+            "search", "checkpoint-show",
+            "--checkpoint", data_path,
+        ])
+        assert result.exit_code == 0
+        assert "empty" in result.output.lower()
+
+    def test_show_nonexistent_file_errors(self, tmp_path):
+        """checkpoint-show on nonexistent file shows error."""
+        runner = CliRunner()
+        result = runner.invoke(cli, [
+            "search", "checkpoint-show",
+            "--checkpoint", str(tmp_path / "nope.jsonl"),
+        ])
+        assert result.exit_code != 0
+
+    def test_show_quiet_suppresses_output(self, tmp_path, mock_org):
+        """checkpoint-show --quiet suppresses all output."""
+        data_path = self._create_completed_checkpoint(tmp_path, mock_org)
+
+        runner = CliRunner()
+        result = runner.invoke(cli, [
+            "--quiet",
+            "search", "checkpoint-show",
+            "--checkpoint", data_path,
+        ])
+        assert result.exit_code == 0
+        assert result.output.strip() == ""
+
+    def test_show_prints_summary_to_stderr(self, tmp_path, mock_org):
+        """checkpoint-show prints checkpoint summary to stderr."""
+        data_path = self._create_completed_checkpoint(tmp_path, mock_org)
+
+        runner = CliRunner(mix_stderr=False)
+        result = runner.invoke(cli, [
+            "--output", "json",
+            "search", "checkpoint-show",
+            "--checkpoint", data_path,
+        ])
+        assert result.exit_code == 0
+        # Summary goes to stderr (may not appear in test since
+        # CliRunner's stderr may not be a tty)
+        # Just verify we got JSON output on stdout
+        parsed = json.loads(result.output)
+        assert len(parsed) == 2
+
+    def test_show_jsonl_output(self, tmp_path, mock_org):
+        """checkpoint-show --output jsonl outputs one result per line."""
+        data_path = self._create_completed_checkpoint(tmp_path, mock_org)
+
+        runner = CliRunner()
+        result = runner.invoke(cli, [
+            "--output", "jsonl",
+            "search", "checkpoint-show",
+            "--checkpoint", data_path,
+        ])
+        assert result.exit_code == 0
+        lines = [l for l in result.output.strip().split("\n") if l.strip()]
+        assert len(lines) == 2
+        for line in lines:
+            parsed = json.loads(line)
+            assert "type" in parsed
+
+
+class TestIsTokenExpiredError:
+    """Direct unit tests for _is_token_expired_error classifier."""
+
+    def test_not_found_error_detected(self):
+        from limacharlie.errors import NotFoundError
+        from limacharlie.commands.search import _is_token_expired_error
+        assert _is_token_expired_error(NotFoundError("query not found")) is True
+
+    def test_search_error_with_query_not_found(self):
+        from limacharlie.errors import SearchError
+        from limacharlie.commands.search import _is_token_expired_error
+        assert _is_token_expired_error(SearchError("Search failed: query not found")) is True
+
+    def test_search_error_with_invalid_token(self):
+        from limacharlie.errors import SearchError
+        from limacharlie.commands.search import _is_token_expired_error
+        assert _is_token_expired_error(SearchError("invalid token")) is True
+
+    def test_search_error_with_results_expired(self):
+        from limacharlie.errors import SearchError
+        from limacharlie.commands.search import _is_token_expired_error
+        assert _is_token_expired_error(SearchError("results expired")) is True
+
+    def test_search_error_with_unknown_query(self):
+        from limacharlie.errors import SearchError
+        from limacharlie.commands.search import _is_token_expired_error
+        assert _is_token_expired_error(SearchError("unknown query xyz")) is True
+
+    def test_auth_error_not_detected(self):
+        from limacharlie.errors import AuthenticationError
+        from limacharlie.commands.search import _is_token_expired_error
+        assert _is_token_expired_error(AuthenticationError("JWT expired")) is False
+
+    def test_permission_denied_not_detected(self):
+        from limacharlie.errors import PermissionDeniedError
+        from limacharlie.commands.search import _is_token_expired_error
+        assert _is_token_expired_error(PermissionDeniedError("forbidden")) is False
+
+    def test_rate_limit_not_detected(self):
+        from limacharlie.errors import RateLimitError
+        from limacharlie.commands.search import _is_token_expired_error
+        assert _is_token_expired_error(RateLimitError("429")) is False
+
+    def test_generic_search_error_not_detected(self):
+        from limacharlie.errors import SearchError
+        from limacharlie.commands.search import _is_token_expired_error
+        assert _is_token_expired_error(SearchError("connection reset")) is False
+
+    def test_generic_exception_not_detected(self):
+        from limacharlie.commands.search import _is_token_expired_error
+        assert _is_token_expired_error(RuntimeError("something")) is False
+
+
+class TestBuildFreshQueryCmd:
+    """Direct unit tests for _build_fresh_query_cmd."""
+
+    def test_basic_query(self):
+        from limacharlie.commands.search import _build_fresh_query_cmd
+        meta = {"query": "* | * | *", "start_time": 1000, "end_time": 2000}
+        cmd = _build_fresh_query_cmd(meta, "/tmp/test.jsonl")
+        assert "--query" in cmd
+        assert "--start 1000" in cmd
+        assert "--end 2000" in cmd
+        assert "--force" in cmd
+        assert "/tmp/test.jsonl" in cmd
+
+    def test_with_stream_and_limit(self):
+        from limacharlie.commands.search import _build_fresh_query_cmd
+        meta = {"query": "q", "start_time": 1, "end_time": 2,
+                "stream": "event", "limit": 100}
+        cmd = _build_fresh_query_cmd(meta, "/tmp/t.jsonl")
+        assert "--stream" in cmd
+        assert "event" in cmd
+        assert "--limit 100" in cmd
+
+    def test_shell_escapes_query_with_quotes(self):
+        from limacharlie.commands.search import _build_fresh_query_cmd
+        meta = {"query": "event/FILE_PATH contains \"C:\\Windows\"",
+                "start_time": 1, "end_time": 2}
+        cmd = _build_fresh_query_cmd(meta, "/tmp/t.jsonl")
+        # shlex.quote wraps in single quotes for safety
+        assert "'" in cmd or "\\" in cmd
+
+    def test_shell_escapes_path_with_spaces(self):
+        from limacharlie.commands.search import _build_fresh_query_cmd
+        meta = {"query": "q", "start_time": 1, "end_time": 2}
+        cmd = _build_fresh_query_cmd(meta, "/tmp/my search results.jsonl")
+        # Path with spaces should be quoted
+        assert "'" in cmd or '"' in cmd

--- a/tests/unit/test_search_checkpoint_integration.py
+++ b/tests/unit/test_search_checkpoint_integration.py
@@ -1,0 +1,938 @@
+"""Integration tests for search checkpoint/resume flow.
+
+Tests the end-to-end interaction between CheckpointWriter,
+CheckpointResumer, and the search execute generator, using
+mocked SDK responses to simulate real search behavior without
+requiring API credentials.
+
+Covers: normal checkpoint, interruption (KeyboardInterrupt), resume
+after interrupt, error recovery, retry + checkpoint interaction, and
+server-side query cancellation behavior.
+"""
+
+import json
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from limacharlie.search_checkpoint import (
+    CheckpointReader,
+    CheckpointResumer,
+    CheckpointWriter,
+    get_data_dir,
+    list_checkpoints,
+    _meta_path,
+)
+from limacharlie.errors import ApiError, SearchError
+from limacharlie.sdk.search import Search
+
+
+@pytest.fixture
+def checkpoints_dir(tmp_path):
+    """Temporary checkpoints metadata directory."""
+    cp_dir = tmp_path / "checkpoints_meta"
+    cp_dir.mkdir()
+    return cp_dir
+
+
+@pytest.fixture(autouse=True)
+def patch_data_dir(checkpoints_dir):
+    """Patch get_data_dir for all tests."""
+    with patch("limacharlie.search_checkpoint.get_data_dir", return_value=str(checkpoints_dir)):
+        yield
+
+
+@pytest.fixture
+def mock_org():
+    """Mock Organization with search URL."""
+    org = MagicMock()
+    org.oid = "test-oid"
+    org.client = MagicMock()
+    org.get_urls.return_value = {"search": "abc123.replay-search.limacharlie.io"}
+    return org
+
+
+def _make_search_responses(num_pages, results_per_page):
+    """Build mock API responses for a multi-page search.
+
+    Returns a list of side_effect values for mock_org.client.request.
+    """
+    responses = [{"queryId": "q-test"}]
+    for page in range(num_pages):
+        is_last = page == num_pages - 1
+        result = {
+            "type": "events",
+            "rows": [{"data": {"idx": page * results_per_page + i}}
+                     for i in range(results_per_page)],
+        }
+        if not is_last:
+            result["nextToken"] = f"tok-{page + 1}"
+        poll_resp = {
+            "results": [result],
+            "completed": True,
+        }
+        responses.append(poll_resp)
+    responses.append({})  # DELETE cleanup
+    return responses
+
+
+class TestCheckpointEndToEnd:
+    """End-to-end checkpoint creation and verification."""
+
+    def test_checkpoint_captures_all_results(self, tmp_path, mock_org):
+        """Full search with checkpoint saves all results to JSONL."""
+        mock_org.client.request.side_effect = _make_search_responses(3, 2)
+        search = Search(mock_org)
+        data_path = str(tmp_path / "search.jsonl")
+
+        with CheckpointWriter(data_path, "test query", 1000, 2000,
+                              "event", None, "test-oid") as writer:
+            count = 0
+            for item in search.execute("test query", 1000, 2000, stream="event"):
+                writer.write_result(item)
+                count += 1
+                writer.update_progress(1, count, completed=False)
+            writer.update_progress(1, count, completed=True)
+
+        # Verify data file
+        meta, results = CheckpointReader.read(data_path)
+        assert len(results) == 3  # 3 pages, 1 result wrapper each
+        assert meta["completed"] is True
+        assert meta["result_count"] == 3
+
+    def test_checkpoint_survives_interruption(self, tmp_path, mock_org):
+        """Checkpoint preserves results even when search is interrupted."""
+        # Search that returns 3 pages, but we stop after 2
+        responses = _make_search_responses(3, 2)
+        mock_org.client.request.side_effect = responses
+        search = Search(mock_org)
+        data_path = str(tmp_path / "interrupted.jsonl")
+
+        with CheckpointWriter(data_path, "test query", 1000, 2000,
+                              "event", None, "test-oid") as writer:
+            count = 0
+            for item in search.execute("test query", 1000, 2000,
+                                       stream="event", limit=2):
+                writer.write_result(item)
+                count += 1
+                writer.update_progress(1, count, completed=False)
+
+        # Data file should have 2 results
+        meta, results = CheckpointReader.read(data_path)
+        assert len(results) == 2
+        assert meta["completed"] is False
+
+
+class TestResumeEndToEnd:
+    """End-to-end resume from checkpoint.
+
+    Tests the token-based server-side resume path. When a checkpoint has
+    a last_token, resume passes it to execute(start_token=...) so the
+    server skips directly to the next page. No re-fetching of previous pages.
+    """
+
+    def test_resume_with_token_skips_to_correct_page(self, tmp_path, mock_org):
+        """Resume uses stored token to skip directly to the right page."""
+        # Initial run: 2 pages, interrupted after page 2 (has nextToken)
+        mock_org.client.request.side_effect = [
+            {"queryId": "q-init"},
+            {"results": [{"type": "events", "rows": [{"a": 1}], "nextToken": "tok1"}], "completed": True},
+            {"results": [{"type": "events", "rows": [{"b": 2}], "nextToken": "tok2"}], "completed": True},
+            {},  # DELETE (limit=2)
+        ]
+        search = Search(mock_org)
+        data_path = str(tmp_path / "token_resume.jsonl")
+
+        last_token = None
+        page = 1
+        with CheckpointWriter(data_path, "test query", 1000, 2000,
+                              "event", None, "test-oid") as writer:
+            count = 0
+            for item in search.execute("test query", 1000, 2000,
+                                       stream="event", limit=2):
+                writer.write_result(item)
+                count += 1
+                if item.get("nextToken"):
+                    last_token = item["nextToken"]
+                    page += 1
+                writer.update_progress(page, count, completed=False,
+                                       last_token=last_token)
+
+        # Verify checkpoint has token
+        meta = CheckpointReader.read_metadata(data_path)
+        assert meta["last_token"] == "tok2"
+        assert meta["page"] == 3  # was on page 3 when interrupted
+
+        # Resume: server gets new queryId but we pass tok2 to skip ahead
+        mock_org.client.request.reset_mock()
+        mock_org.client.request.side_effect = [
+            {"queryId": "q-resume"},
+            # Server returns page 3 directly (because we passed tok2)
+            {"results": [{"type": "events", "rows": [{"c": 3}]}], "completed": True},
+            {},  # DELETE
+        ]
+        search2 = Search(mock_org)
+        resumer = CheckpointResumer(data_path)
+        resume_token = resumer.metadata.get("last_token")
+        resume_page = resumer.metadata.get("page", 1)
+
+        with resumer:
+            for item in search2.execute("test query", 1000, 2000, stream="event",
+                                        start_token=resume_token,
+                                        start_page=resume_page):
+                resumer.write_result(item)
+
+        # Verify: the first GET used the saved token
+        get_calls = [c for c in mock_org.client.request.call_args_list
+                     if c[0][0] == "GET"]
+        assert len(get_calls) == 1
+        assert get_calls[0][1]["query_params"] == {"token": "tok2"}
+
+        # Data file has 3 results total (2 original + 1 new)
+        _, results = CheckpointReader.read(data_path)
+        assert len(results) == 3
+
+    def test_resume_without_token_falls_back_to_skip(self, tmp_path, mock_org):
+        """Resume without a stored token re-fetches and skips."""
+        # Initial run: interrupted on page 1 before any nextToken
+        mock_org.client.request.side_effect = [
+            {"queryId": "q-no-tok"},
+            {"results": [{"type": "events", "rows": [{"a": 1}]}], "completed": True},
+            {},  # DELETE (limit=1)
+        ]
+        search = Search(mock_org)
+        data_path = str(tmp_path / "no_token.jsonl")
+
+        with CheckpointWriter(data_path, "query", 1000, 2000,
+                              None, None, "test-oid") as writer:
+            for item in search.execute("query", 1000, 2000, limit=1):
+                writer.write_result(item)
+            writer.update_progress(1, 1, completed=False)
+            # No last_token stored
+
+        meta = CheckpointReader.read_metadata(data_path)
+        assert meta.get("last_token") is None
+
+        # Resume: no token, so re-fetches from start
+        mock_org.client.request.side_effect = _make_search_responses(2, 1)
+        search2 = Search(mock_org)
+        resumer = CheckpointResumer(data_path)
+
+        skipped = 0
+        with resumer:
+            for item in search2.execute("query", 1000, 2000):
+                if skipped < resumer.existing_count:
+                    skipped += 1
+                    continue
+                resumer.write_result(item)
+
+        _, results = CheckpointReader.read(data_path)
+        assert len(results) == 2  # 1 original + 1 new
+
+    def test_resume_completed_checkpoint_is_noop(self, tmp_path, mock_org):
+        """Resuming an already-completed checkpoint returns existing results."""
+        responses = _make_search_responses(2, 1)
+        mock_org.client.request.side_effect = responses
+        search = Search(mock_org)
+        data_path = str(tmp_path / "completed.jsonl")
+
+        with CheckpointWriter(data_path, "query", 1000, 2000,
+                              None, None, "test-oid") as writer:
+            count = 0
+            for item in search.execute("query", 1000, 2000):
+                writer.write_result(item)
+                count += 1
+            writer.update_progress(1, count, completed=True)
+
+        meta = CheckpointReader.read_metadata(data_path)
+        assert meta["completed"] is True
+
+        resumer = CheckpointResumer(data_path)
+        assert resumer.metadata["completed"] is True
+
+
+class TestResumeCorrectness:
+    """Tests verifying that resume re-runs the query correctly.
+
+    Validates that:
+    - Resume uses the same query parameters from the checkpoint metadata
+    - The search API is called with proper POST body (same query, start, end, stream)
+    - Pagination tokens are followed correctly on the re-run
+    - The skip count matches exactly the number of results in the data file
+    - Results written to the data file after resume are only the new ones
+    """
+
+    def test_resume_uses_correct_query_parameters(self, tmp_path, mock_org):
+        """Resume re-executes with the exact same query params from metadata."""
+        # Initial run
+        mock_org.client.request.side_effect = [
+            {"queryId": "q-init"},
+            {"results": [{"type": "events", "rows": [{"a": 1}]}], "completed": True},
+            {},  # DELETE
+        ]
+        search = Search(mock_org)
+        data_path = str(tmp_path / "params_test.jsonl")
+
+        with CheckpointWriter(data_path, "plat == linux | DNS_REQUEST | *",
+                              5000, 9000, "event", 100, "org-abc") as writer:
+            for item in search.execute("plat == linux | DNS_REQUEST | *",
+                                       5000, 9000, stream="event", limit=1):
+                writer.write_result(item)
+            # Intentionally NOT marking completed
+
+        # Resume - verify the query parameters
+        mock_org.client.request.reset_mock()
+        mock_org.client.request.side_effect = [
+            {"queryId": "q-resume"},
+            {"results": [{"type": "events", "rows": [{"a": 1}]}], "completed": True},
+            {"results": [{"type": "events", "rows": [{"b": 2}]}], "completed": True},
+            {},  # DELETE
+        ]
+        search2 = Search(mock_org)
+        resumer = CheckpointResumer(data_path)
+
+        # Verify metadata loaded correctly
+        assert resumer.metadata["query"] == "plat == linux | DNS_REQUEST | *"
+        assert resumer.metadata["start_time"] == 5000
+        assert resumer.metadata["end_time"] == 9000
+        assert resumer.metadata["stream"] == "event"
+        assert resumer.metadata["oid"] == "org-abc"
+
+        skipped = 0
+        with resumer:
+            for item in search2.execute("plat == linux | DNS_REQUEST | *",
+                                        5000, 9000, stream="event"):
+                if skipped < resumer.existing_count:
+                    skipped += 1
+                    continue
+                resumer.write_result(item)
+
+        # Verify the POST body sent to initiate search
+        import json
+        post_calls = [c for c in mock_org.client.request.call_args_list
+                      if c[0][0] == "POST"]
+        assert len(post_calls) == 1
+        body = json.loads(post_calls[0][1]["raw_body"])
+        assert body["query"] == "plat == linux | DNS_REQUEST | *"
+        assert body["startTime"] == "5000"
+        assert body["endTime"] == "9000"
+        assert body["stream"] == "event"
+
+    def test_resume_with_token_starts_from_saved_position(self, tmp_path, mock_org):
+        """Resume with stored token skips to the correct page via start_token."""
+        # Initial run: 1 page fetched with nextToken
+        mock_org.client.request.side_effect = [
+            {"queryId": "q-tok-init"},
+            {"results": [{"type": "events", "rows": [{"p": 1}], "nextToken": "tok1"}],
+             "completed": True},
+            {},  # DELETE (limit=1)
+        ]
+        search = Search(mock_org)
+        data_path = str(tmp_path / "token_test.jsonl")
+
+        last_token = None
+        page = 1
+        with CheckpointWriter(data_path, "query", 1000, 2000,
+                              None, None, "test-oid") as writer:
+            for item in search.execute("query", 1000, 2000, limit=1):
+                writer.write_result(item)
+                if item.get("nextToken"):
+                    last_token = item["nextToken"]
+                    page += 1
+            writer.update_progress(page, 1, completed=False, last_token=last_token)
+
+        meta = CheckpointReader.read_metadata(data_path)
+        assert meta["last_token"] == "tok1"
+
+        # Resume: pass tok1 as start_token, server returns pages 2 and 3
+        mock_org.client.request.reset_mock()
+        mock_org.client.request.side_effect = [
+            {"queryId": "q-tok-resume"},
+            # First GET uses tok1 -> returns page 2
+            {"results": [{"type": "events", "rows": [{"p": 2}], "nextToken": "tok2"}],
+             "completed": True},
+            # Second GET uses tok2 -> returns page 3
+            {"results": [{"type": "events", "rows": [{"p": 3}]}],
+             "completed": True},
+            {},  # DELETE
+        ]
+        search2 = Search(mock_org)
+
+        resumer = CheckpointResumer(data_path)
+        resume_token = resumer.metadata.get("last_token")
+        resume_page = resumer.metadata.get("page", 1)
+
+        with resumer:
+            for item in search2.execute("query", 1000, 2000,
+                                        start_token=resume_token,
+                                        start_page=resume_page):
+                resumer.write_result(item)
+
+        # Verify: first GET used tok1 (skipped page 1 entirely)
+        get_calls = [c for c in mock_org.client.request.call_args_list
+                     if c[0][0] == "GET"]
+        assert len(get_calls) == 2
+        # First GET: uses saved token tok1
+        assert get_calls[0][1]["query_params"] == {"token": "tok1"}
+        # Second GET: uses tok2 from page 2
+        assert get_calls[1][1]["query_params"] == {"token": "tok2"}
+
+        # Data file: 3 total (1 original + 2 new from resume)
+        _, results = CheckpointReader.read(data_path)
+        assert len(results) == 3
+
+    def test_resume_skip_count_matches_data_file_lines(self, tmp_path, mock_org):
+        """Skip count is determined by actual data file lines, not metadata.
+
+        If metadata says result_count=5 but data file has 3 lines (crash
+        between metadata update and data write), we trust the data file.
+        """
+        # Create checkpoint with 3 results
+        data_path = str(tmp_path / "count_test.jsonl")
+        with CheckpointWriter(data_path, "query", 1000, 2000,
+                              None, None, "test-oid") as writer:
+            writer.write_result({"r": 1})
+            writer.write_result({"r": 2})
+            writer.write_result({"r": 3})
+            # Metadata says 5 but file only has 3 (simulating inconsistency)
+            writer.update_progress(2, 5, completed=False)
+
+        resumer = CheckpointResumer(data_path)
+        # existing_count should be 3 (from data file), not 5 (from metadata)
+        assert resumer.existing_count == 3
+
+    def test_resume_only_appends_new_results_to_file(self, tmp_path, mock_org):
+        """Resume writes only new results to the data file, not duplicates."""
+        # Create checkpoint with 2 results
+        mock_org.client.request.side_effect = _make_search_responses(3, 1)
+        search = Search(mock_org)
+        data_path = str(tmp_path / "append_test.jsonl")
+
+        with CheckpointWriter(data_path, "query", 1000, 2000,
+                              None, None, "test-oid") as writer:
+            count = 0
+            for item in search.execute("query", 1000, 2000, limit=2):
+                writer.write_result(item)
+                count += 1
+            writer.update_progress(1, count, completed=False)
+
+        _, before = CheckpointReader.read(data_path)
+        assert len(before) == 2
+
+        # Resume
+        mock_org.client.request.side_effect = _make_search_responses(3, 1)
+        search2 = Search(mock_org)
+        resumer = CheckpointResumer(data_path)
+        skip_count = resumer.existing_count
+
+        skipped = 0
+        count = skip_count
+        with resumer:
+            for item in search2.execute("query", 1000, 2000):
+                if skipped < skip_count:
+                    skipped += 1
+                    continue
+                resumer.write_result(item)
+                count += 1
+            resumer.update_progress(1, count, completed=True)
+
+        # File should have exactly 3 lines (2 original + 1 new)
+        with open(data_path) as f:
+            lines = [l for l in f if l.strip()]
+        assert len(lines) == 3
+
+        # And all 3 should be valid JSON
+        import json
+        for line in lines:
+            json.loads(line)
+
+
+
+    """End-to-end listing of checkpoints."""
+
+    def test_list_shows_checkpoints_after_run(self, tmp_path, mock_org):
+        """list_checkpoints returns metadata for created checkpoints."""
+        responses = _make_search_responses(1, 1)
+        mock_org.client.request.side_effect = responses
+        search = Search(mock_org)
+        data_path = str(tmp_path / "listed.jsonl")
+
+        with CheckpointWriter(data_path, "list test query", 5000, 6000,
+                              "detect", 10, "test-oid") as writer:
+            for item in search.execute("list test query", 5000, 6000, stream="detect"):
+                writer.write_result(item)
+            writer.update_progress(1, 1, completed=True)
+
+        cps = list_checkpoints()
+        assert len(cps) == 1
+        cp = cps[0]
+        assert cp["query"] == "list test query"
+        assert cp["start_time"] == 5000
+        assert cp["end_time"] == 6000
+        assert cp["completed"] is True
+        assert cp["data_file_exists"] is True
+
+
+class TestCheckpointCancellation:
+    """Tests for KeyboardInterrupt handling with checkpoint enabled.
+
+    Verifies that Ctrl+C:
+    1. Preserves all results written to the checkpoint data file
+    2. Updates metadata to reflect partial progress (completed=False)
+    3. Allows successful resume after interruption
+    4. Server-side query is canceled (via Search.execute() finally block)
+    """
+
+    def test_keyboard_interrupt_preserves_checkpoint_data(self, tmp_path, mock_org):
+        """KeyboardInterrupt during checkpointed search preserves all
+        results written before the interrupt."""
+        call_count = 0
+
+        def side_effect(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return {"queryId": "q-ki-cp"}
+            elif call_count == 2:
+                return {
+                    "results": [{"type": "events", "rows": [{"a": 1}], "nextToken": "tok1"}],
+                    "completed": True,
+                }
+            elif call_count == 3:
+                # Page 2 poll: user hits Ctrl+C
+                raise KeyboardInterrupt()
+            else:
+                return {}  # DELETE
+
+        mock_org.client.request.side_effect = side_effect
+        search = Search(mock_org)
+        data_path = str(tmp_path / "ki_checkpoint.jsonl")
+
+        writer = CheckpointWriter(data_path, "test query", 1000, 2000,
+                                  "event", None, "test-oid")
+        count = 0
+        with pytest.raises(KeyboardInterrupt):
+            with writer:
+                for item in search.execute("test query", 1000, 2000, stream="event"):
+                    writer.write_result(item)
+                    count += 1
+                    writer.update_progress(1, count, completed=False)
+
+        # Page 1 result should be preserved in data file.
+        meta, results = CheckpointReader.read(data_path)
+        assert len(results) == 1
+        assert results[0]["rows"] == [{"a": 1}]
+        assert meta["completed"] is False
+        assert meta["result_count"] == 1
+
+    def test_keyboard_interrupt_during_first_poll_preserves_empty_checkpoint(
+        self, tmp_path, mock_org,
+    ):
+        """Ctrl+C before any results are received creates an empty checkpoint."""
+        mock_org.client.request.side_effect = [
+            {"queryId": "q-ki-empty"},
+            KeyboardInterrupt(),
+            {},  # DELETE
+        ]
+        search = Search(mock_org)
+        data_path = str(tmp_path / "empty_ki.jsonl")
+
+        writer = CheckpointWriter(data_path, "test query", 1000, 2000,
+                                  "event", None, "test-oid")
+        with pytest.raises(KeyboardInterrupt):
+            with writer:
+                for item in search.execute("test query", 1000, 2000, stream="event"):
+                    writer.write_result(item)
+
+        # Checkpoint exists but is empty.
+        meta, results = CheckpointReader.read(data_path)
+        assert len(results) == 0
+        assert meta["completed"] is False
+
+    def test_resume_after_keyboard_interrupt(self, tmp_path, mock_org):
+        """Full flow: start -> Ctrl+C -> resume -> complete.
+
+        Simulates a real user workflow:
+        1. Start a search with checkpointing
+        2. Ctrl+C after getting some results
+        3. Resume and get remaining results
+        4. Verify all results are present and checkpoint is completed
+        """
+        # Step 1 & 2: Start search, interrupt after 2 results
+        call_count = 0
+
+        def side_effect_initial(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return {"queryId": "q-resume-ki"}
+            elif call_count == 2:
+                return {
+                    "results": [{"type": "events", "rows": [{"a": 1}], "nextToken": "tok1"}],
+                    "completed": True,
+                }
+            elif call_count == 3:
+                return {
+                    "results": [{"type": "events", "rows": [{"b": 2}], "nextToken": "tok2"}],
+                    "completed": True,
+                }
+            elif call_count == 4:
+                raise KeyboardInterrupt()
+            else:
+                return {}  # DELETE
+
+        mock_org.client.request.side_effect = side_effect_initial
+        search = Search(mock_org)
+        data_path = str(tmp_path / "resume_ki.jsonl")
+
+        writer = CheckpointWriter(data_path, "test query", 1000, 2000,
+                                  "event", None, "test-oid")
+        count = 0
+        with pytest.raises(KeyboardInterrupt):
+            with writer:
+                for item in search.execute("test query", 1000, 2000, stream="event"):
+                    writer.write_result(item)
+                    count += 1
+                    writer.update_progress(1, count, completed=False)
+
+        # Verify 2 results saved after interrupt.
+        meta, existing = CheckpointReader.read(data_path)
+        assert len(existing) == 2
+        assert meta["completed"] is False
+
+        # Step 3: Resume - server returns same data, we skip first 2
+        mock_org.client.request.side_effect = [
+            {"queryId": "q-resume-ki-2"},
+            {"results": [{"type": "events", "rows": [{"a": 1}], "nextToken": "tok1"}], "completed": True},
+            {"results": [{"type": "events", "rows": [{"b": 2}], "nextToken": "tok2"}], "completed": True},
+            {"results": [{"type": "events", "rows": [{"c": 3}]}], "completed": True},
+            {},  # DELETE
+        ]
+        search2 = Search(mock_org)
+
+        resumer = CheckpointResumer(data_path)
+        skip_count = resumer.existing_count
+        assert skip_count == 2
+
+        all_results = list(existing)
+        count = skip_count
+        skipped = 0
+        with resumer:
+            for item in search2.execute("test query", 1000, 2000, stream="event"):
+                if skipped < skip_count:
+                    skipped += 1
+                    continue
+                resumer.write_result(item)
+                all_results.append(item)
+                count += 1
+                resumer.update_progress(1, count, completed=False)
+            resumer.update_progress(1, count, completed=True)
+
+        # Step 4: Verify all 3 results present and completed.
+        meta, final_results = CheckpointReader.read(data_path)
+        assert len(final_results) == 3
+        assert final_results[0]["rows"] == [{"a": 1}]
+        assert final_results[1]["rows"] == [{"b": 2}]
+        assert final_results[2]["rows"] == [{"c": 3}]
+        assert meta["completed"] is True
+        assert meta["result_count"] == 3
+
+    def test_keyboard_interrupt_server_cancel_still_fires(self, tmp_path, mock_org):
+        """Server-side DELETE cancel is called even with checkpoint enabled.
+
+        The Search.execute() finally block calls _cancel_query regardless
+        of whether a checkpoint is in use - the checkpoint is a CLI concern,
+        the cancel is an SDK concern.
+        """
+        call_count = 0
+
+        def side_effect(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return {"queryId": "q-srv-cancel"}
+            elif call_count == 2:
+                return {
+                    "results": [{"type": "events", "rows": [{"a": 1}]}],
+                    "completed": False,
+                    "nextPollInMs": 500,
+                }
+            elif call_count == 3:
+                raise KeyboardInterrupt()
+            else:
+                return {}  # DELETE
+
+        mock_org.client.request.side_effect = side_effect
+        search = Search(mock_org)
+        data_path = str(tmp_path / "srv_cancel.jsonl")
+
+        writer = CheckpointWriter(data_path, "test query", 1000, 2000,
+                                  "event", None, "test-oid")
+        with pytest.raises(KeyboardInterrupt):
+            with writer:
+                for item in search.execute("test query", 1000, 2000, stream="event"):
+                    writer.write_result(item)
+
+        # Verify DELETE was called on the server
+        delete_calls = [c for c in mock_org.client.request.call_args_list
+                        if c[0][0] == "DELETE"]
+        assert len(delete_calls) == 1
+        assert "search/q-srv-cancel" in delete_calls[0][0][1]
+
+
+class TestCheckpointErrorRecovery:
+    """Tests for error handling during checkpointed searches.
+
+    Verifies that non-interrupt errors (SearchError, transport errors)
+    preserve checkpoint state for later resume.
+    """
+
+    def test_search_error_preserves_checkpoint(self, tmp_path, mock_org):
+        """SearchError after partial results preserves checkpoint data."""
+        mock_org.client.request.side_effect = [
+            {"queryId": "q-err-cp"},
+            {"results": [{"type": "events", "rows": [{"a": 1}], "nextToken": "tok1"}], "completed": True},
+            {"error": "context canceled"},  # Page 2 error
+            {},  # DELETE
+        ]
+        search = Search(mock_org)
+        data_path = str(tmp_path / "error_cp.jsonl")
+
+        writer = CheckpointWriter(data_path, "test query", 1000, 2000,
+                                  "event", None, "test-oid")
+        count = 0
+        with pytest.raises(SearchError, match="context canceled"):
+            with writer:
+                for item in search.execute("test query", 1000, 2000, stream="event"):
+                    writer.write_result(item)
+                    count += 1
+                    writer.update_progress(1, count, completed=False)
+
+        # Page 1 result should be preserved.
+        meta, results = CheckpointReader.read(data_path)
+        assert len(results) == 1
+        assert meta["completed"] is False
+
+    @patch("limacharlie.sdk.search.time.sleep")
+    def test_transient_error_with_checkpoint_recovers(self, mock_sleep, tmp_path, mock_org):
+        """Transient error during checkpointed search retries and completes.
+
+        Verifies that poll retry + checkpoint work together correctly -
+        the retry happens at the SDK level, the checkpoint captures all
+        results including those from retried pages.
+        """
+        mock_org.client.request.side_effect = [
+            {"queryId": "q-retry-cp"},
+            # Page 1: success
+            {"results": [{"type": "events", "rows": [{"a": 1}], "nextToken": "tok1"}], "completed": True},
+            # Page 2: transient 503, then success
+            ApiError("503", status_code=503),
+            {"results": [{"type": "events", "rows": [{"b": 2}]}], "completed": True},
+            {},  # DELETE
+        ]
+        search = Search(mock_org)
+        data_path = str(tmp_path / "retry_cp.jsonl")
+
+        with CheckpointWriter(data_path, "test query", 1000, 2000,
+                              "event", None, "test-oid") as writer:
+            count = 0
+            for item in search.execute("test query", 1000, 2000, stream="event"):
+                writer.write_result(item)
+                count += 1
+                writer.update_progress(1, count, completed=False)
+            writer.update_progress(1, count, completed=True)
+
+        # Both pages should be captured despite the transient error.
+        meta, results = CheckpointReader.read(data_path)
+        assert len(results) == 2
+        assert results[0]["rows"] == [{"a": 1}]
+        assert results[1]["rows"] == [{"b": 2}]
+        assert meta["completed"] is True
+
+    @patch("limacharlie.sdk.search.time.sleep")
+    def test_exhausted_retries_preserves_checkpoint(self, mock_sleep, tmp_path, mock_org):
+        """When retries exhaust during checkpointed search, partial checkpoint
+        is preserved for later resume."""
+        mock_org.client.request.side_effect = [
+            {"queryId": "q-exhaust-cp"},
+            # Page 1: success
+            {"results": [{"type": "events", "rows": [{"a": 1}], "nextToken": "tok1"}], "completed": True},
+            # Page 2: all retries fail
+            ApiError("503", status_code=503),
+            ApiError("503", status_code=503),
+            ApiError("503", status_code=503),
+            ApiError("503", status_code=503),  # Exhausted (3 retries + 1 initial)
+        ]
+        search = Search(mock_org)
+        data_path = str(tmp_path / "exhaust_cp.jsonl")
+
+        writer = CheckpointWriter(data_path, "test query", 1000, 2000,
+                                  "event", None, "test-oid")
+        count = 0
+        with pytest.raises(SearchError):
+            with writer:
+                for item in search.execute("test query", 1000, 2000, stream="event"):
+                    writer.write_result(item)
+                    count += 1
+                    writer.update_progress(1, count, completed=False)
+
+        # Page 1 result should be preserved.
+        meta, results = CheckpointReader.read(data_path)
+        assert len(results) == 1
+        assert meta["completed"] is False
+        assert meta["result_count"] == 1
+
+    def test_resume_after_search_error(self, tmp_path, mock_org):
+        """Resume works after a SearchError interrupted the previous run."""
+        # Step 1: Run that fails with SearchError after 1 result
+        mock_org.client.request.side_effect = [
+            {"queryId": "q-err-resume"},
+            {"results": [{"type": "events", "rows": [{"a": 1}], "nextToken": "tok1"}], "completed": True},
+            {"error": "server error"},
+            {},  # DELETE
+        ]
+        search = Search(mock_org)
+        data_path = str(tmp_path / "err_resume.jsonl")
+
+        writer = CheckpointWriter(data_path, "test query", 1000, 2000,
+                                  "event", None, "test-oid")
+        count = 0
+        with pytest.raises(SearchError):
+            with writer:
+                for item in search.execute("test query", 1000, 2000, stream="event"):
+                    writer.write_result(item)
+                    count += 1
+                    writer.update_progress(1, count, completed=False)
+
+        # Step 2: Resume succeeds
+        mock_org.client.request.side_effect = [
+            {"queryId": "q-err-resume-2"},
+            {"results": [{"type": "events", "rows": [{"a": 1}], "nextToken": "tok1"}], "completed": True},
+            {"results": [{"type": "events", "rows": [{"b": 2}]}], "completed": True},
+            {},  # DELETE
+        ]
+        search2 = Search(mock_org)
+
+        resumer = CheckpointResumer(data_path)
+        skip_count = resumer.existing_count
+        assert skip_count == 1
+
+        count = skip_count
+        skipped = 0
+        with resumer:
+            for item in search2.execute("test query", 1000, 2000, stream="event"):
+                if skipped < skip_count:
+                    skipped += 1
+                    continue
+                resumer.write_result(item)
+                count += 1
+                resumer.update_progress(1, count, completed=False)
+            resumer.update_progress(1, count, completed=True)
+
+        meta, final_results = CheckpointReader.read(data_path)
+        assert len(final_results) == 2
+        assert meta["completed"] is True
+
+
+class TestCheckpointWriterContextManager:
+    """Tests verifying CheckpointWriter context manager cleans up properly."""
+
+    def test_writer_closes_file_on_normal_exit(self, tmp_path):
+        """Context manager closes file handle on normal exit."""
+        data_path = str(tmp_path / "normal_exit.jsonl")
+        writer = CheckpointWriter(data_path, "query", 1000, 2000,
+                                  None, None, "oid")
+        with writer:
+            writer.write_result({"a": 1})
+            assert not writer._file.closed
+
+        assert writer._file.closed
+
+    def test_writer_closes_file_on_exception(self, tmp_path):
+        """Context manager closes file handle even on exception."""
+        data_path = str(tmp_path / "exception_exit.jsonl")
+        writer = CheckpointWriter(data_path, "query", 1000, 2000,
+                                  None, None, "oid")
+        with pytest.raises(ValueError):
+            with writer:
+                writer.write_result({"a": 1})
+                raise ValueError("boom")
+
+        assert writer._file.closed
+        # Data should still be flushed and readable.
+        meta, results = CheckpointReader.read(data_path)
+        assert len(results) == 1
+
+    def test_writer_closes_file_on_keyboard_interrupt(self, tmp_path):
+        """Context manager closes file handle on KeyboardInterrupt."""
+        data_path = str(tmp_path / "ki_exit.jsonl")
+        writer = CheckpointWriter(data_path, "query", 1000, 2000,
+                                  None, None, "oid")
+        with pytest.raises(KeyboardInterrupt):
+            with writer:
+                writer.write_result({"a": 1})
+                raise KeyboardInterrupt()
+
+        assert writer._file.closed
+        meta, results = CheckpointReader.read(data_path)
+        assert len(results) == 1
+
+    def test_double_close_is_safe(self, tmp_path):
+        """Calling close() multiple times does not raise."""
+        data_path = str(tmp_path / "double_close.jsonl")
+        writer = CheckpointWriter(data_path, "query", 1000, 2000,
+                                  None, None, "oid")
+        writer.close()
+        writer.close()  # Should not raise
+
+
+class TestCheckpointResumerContextManager:
+    """Tests verifying CheckpointResumer context manager cleans up properly."""
+
+    def _create_checkpoint(self, tmp_path, results):
+        """Helper to create a checkpoint with given results."""
+        data_path = str(tmp_path / "data.jsonl")
+        with CheckpointWriter(data_path, "test query", 1000, 2000,
+                              "event", None, "test-oid") as w:
+            for r in results:
+                w.write_result(r)
+            w.update_progress(1, len(results), completed=False)
+        return data_path
+
+    def test_resumer_closes_file_on_normal_exit(self, tmp_path):
+        """Context manager closes file handle on normal exit."""
+        data_path = self._create_checkpoint(tmp_path, [{"a": 1}])
+        resumer = CheckpointResumer(data_path)
+        with resumer:
+            resumer.write_result({"b": 2})
+            assert not resumer._file.closed
+
+        assert resumer._file.closed
+
+    def test_resumer_closes_file_on_keyboard_interrupt(self, tmp_path):
+        """Context manager closes file handle on KeyboardInterrupt."""
+        data_path = self._create_checkpoint(tmp_path, [{"a": 1}])
+        resumer = CheckpointResumer(data_path)
+        with pytest.raises(KeyboardInterrupt):
+            with resumer:
+                resumer.write_result({"b": 2})
+                raise KeyboardInterrupt()
+
+        assert resumer._file.closed
+        # Both original and new result should be in the file.
+        _, results = CheckpointReader.read(data_path)
+        assert len(results) == 2
+
+    def test_resumer_closes_file_on_exception(self, tmp_path):
+        """Context manager closes file handle on general exception."""
+        data_path = self._create_checkpoint(tmp_path, [{"a": 1}])
+        resumer = CheckpointResumer(data_path)
+        with pytest.raises(RuntimeError):
+            with resumer:
+                resumer.write_result({"b": 2})
+                raise RuntimeError("boom")
+
+        assert resumer._file.closed
+        _, results = CheckpointReader.read(data_path)
+        assert len(results) == 2


### PR DESCRIPTION
## Details

Adds several features to `search run`:

1. **SDK-level poll retry with exponential backoff** - Individual poll GET requests that fail with transient errors (5xx, connection reset, timeout, SSL errors) are now automatically retried with exponential backoff (1s, 2s, 4s... capped at 30s, default 3 retries). Permanent errors (401, 403, 404, 422, 429) and search-engine body errors (e.g. "context canceled") are NOT retried.

2. **CLI-level checkpoint/resume** - New `--checkpoint`, `--resume`, and `--force` flags allow incremental persistence of search results to a JSONL file. Resume uses server-side pagination tokens to skip directly to the next un-fetched page (no re-fetching). The server re-runs the query from the cursor position embedded in the token, so resume works even after long delays between sessions - no server-side TTL limitation.

3. **`search checkpoints`** - Lists all local checkpoints with pages, events, time range progress %, token, and timestamps. Automatically cleans up stale metadata when data files are deleted.

4. **`search checkpoint-show`** - Displays results from a checkpoint data file through the same output pipeline as a live search (table, JSON, expand, raw, JSONL). Streams lazily for JSONL output.

5. **Security hardening** - Checkpoint metadata directories (`~/.limacharlie.d/search_checkpoints/`) are created with 0o700 (owner-only) permissions via new `secure_makedirs()` helper. Data files use `O_EXCL|O_NOFOLLOW` for atomic creation with symlink rejection. Metadata reads use `safe_open_read()`. All files get 0o600.

Also fixes a pre-existing bug in `client.py` where `KeyboardInterrupt` during `u.read()` left the `data` variable unbound.

### Future: config directory migration

Currently all LimaCharlie config lives in a flat file at `~/.limacharlie`. This PR introduces `~/.limacharlie.d/` as a sibling directory for new persistent data (checkpoints). Eventually the plan is to migrate all LimaCharlie files to a proper config directory - either `~/.limacharlie.d/`, `~/.config/limacharlie/` (XDG on Linux), or the OS-recommended location (e.g. `%APPDATA%/limacharlie` on Windows). That migration requires more work to handle backward compatibility correctly (detecting old flat-file config, migrating credentials, ensuring no security regression). This PR establishes the `.d` pattern as a first step without breaking existing config.

## Example Usage

### Run a search with checkpointing

```bash
limacharlie search run \
    --query "* | NEW_PROCESS | event/COMMAND_LINE contains 'curl'" \
    --start 1700000000 --end 1700086400 \
    --stream event \
    --checkpoint /tmp/my_search.jsonl
```

<details>
<summary>Sample output (search completes successfully)</summary>

```
Running search... query_id: a22bb8e7-b233-491f-8f6c-b2707bfdb20a
Waiting for results... (page 1, 0 events, 0s elapsed)
Fetching page 2... (2,171 events, 9s elapsed, token=...YWdlIjoyNX0=)
Fetching page 3... (4,099 events, 17s elapsed, token=...ZXh0UGFnZSI6M30=)
Checkpoint complete: 3 results saved to /tmp/my_search.jsonl
time                 stream  routing.event_type  routing.hostname  event.FILE_PATH    event.COMMAND_LINE
2023-11-15 00:12:34  event   NEW_PROCESS         web-01            /usr/bin/curl       curl https://example.com
2023-11-15 00:15:02  event   NEW_PROCESS         web-02            /usr/bin/curl       curl -s https://api.test.io
...
(4,099 events)
Stats: matched: 4,099, scanned: 1,203,441, bytes: 2.1 GB, time: 18.3s, cost: $0.0042
```

</details>

### Interrupt a search (Ctrl+C)

```bash
limacharlie search run \
    --query "* | * | *" \
    --start 1771065591 --end 1773657591 \
    --checkpoint /tmp/big_search.jsonl
# ... press Ctrl+C after a while
```

<details>
<summary>Sample output (Ctrl+C mid-search)</summary>

```
Running search... query_id: 3454721a-50fb-4a25-abf6-21f3b5c3064f
Fetching page 2... (2,171 events, 9s elapsed, token=...YWdlIjoxfQ==)
Fetching page 3... (4,099 events, 17s elapsed, token=...YWdlIjoyNX0=)
Fetching page 4... (6,250 events, 25s elapsed, token=...ZXh0UGFnZSI6M30=)
^C
Search canceled. Checkpoint saved: /tmp/big_search.jsonl
  Pages fetched:  4
  Results:        4
  Total events:   6,250
  Resume token:   lc1:eyJ2IjoxLCJjb250ZXh0IjoiZXlKMmFXVjNJam9pWVhOamMwMTBaQ0lzSW5CaFoyVWlPak4w

  Resume with:    limacharlie search run --resume --checkpoint /tmp/big_search.jsonl
```

</details>

### Resume a search

```bash
limacharlie search run --resume --checkpoint /tmp/big_search.jsonl
```

<details>
<summary>Sample output (resume picks up from page 4)</summary>

```
Resuming from page 4 (4 results already fetched)...
Running search... query_id: 55dd0e29-494e-4d6e-8851-19aadd807b7f
Resuming from page 4 (token=...ZXh0UGFnZSI6M30=)
Fetching page 5... (8,412 events, 7s elapsed, token=...UGFnZSI6NX0=)
Fetching page 6... (10,583 events, 15s elapsed, token=...UGFnZSI6Nn0=)
Resume complete: 4 new results (8 total) saved to /tmp/big_search.jsonl
time                 stream  routing.event_type  routing.hostname  ...
...
(10,583 events)
```

Resume starts a fresh search session but passes the stored pagination cursor to the server, which re-runs the query from that position. No pages are re-fetched. Works even days after the original search.

</details>

### Display results from a checkpoint

```bash
# Table output (default)
limacharlie search checkpoint-show --checkpoint /tmp/my_search.jsonl
```

<details>
<summary>Sample table output</summary>

```
Checkpoint: completed, 3 pages, 4,099 events, 3 results
Query: * | NEW_PROCESS | event/COMMAND_LINE contains 'curl'
time                 stream  routing.event_type  routing.hostname  event.FILE_PATH    event.COMMAND_LINE
2023-11-15 00:12:34  event   NEW_PROCESS         web-01            /usr/bin/curl       curl https://example.com
2023-11-15 00:15:02  event   NEW_PROCESS         web-02            /usr/bin/curl       curl -s https://api.test.io
...
(4,099 events)
Stats: matched: 4,099, scanned: 1,203,441, bytes: 2.1 GB
```

</details>

```bash
# Expanded JSON events
limacharlie search checkpoint-show --checkpoint /tmp/my_search.jsonl --expand

# JSON for scripting
limacharlie search checkpoint-show --checkpoint /tmp/my_search.jsonl --output json

# JSONL - streams lazily without loading full file into memory
limacharlie search checkpoint-show --checkpoint /tmp/my_search.jsonl --output jsonl | jq '.rows[].data'

# Raw API result objects
limacharlie search checkpoint-show --checkpoint /tmp/my_search.jsonl --raw
```

### Force overwrite / context-aware errors

<details>
<summary>Completed checkpoint</summary>

```
Error: Checkpoint already exists and is completed (3 results, 4,099 events).
Use --force to overwrite with a new search, or delete the file and retry.

  View results:  limacharlie search checkpoint-show --checkpoint /tmp/my_search.jsonl
  Overwrite:     add --force to your command
```

</details>

<details>
<summary>In-progress checkpoint</summary>

```
Error: Checkpoint already exists and is in-progress (page 4, 4 results, 6,250 events).
Use --resume to continue from where it left off, --force to overwrite, or delete the file and retry.

  Resume:    limacharlie search run --resume --checkpoint /tmp/big_search.jsonl
  Overwrite: add --force to your command
```

</details>

### List checkpoints

```bash
limacharlie search checkpoints
```

<details>
<summary>Sample table output</summary>

```
data_file             query                 range                          pages  events  progress          status       token             created              updated
/tmp/big_search.jsonl * | * | *             2026-02-15 00:00 - 2026-03-16 4      6,250   42% (02-27 18:30) in-progress  ...YWdlIjoyNX0=   2026-03-16 10:30:00  2026-03-16 10:35:00
/tmp/my_search.jsonl  * | NEW_PROCESS | ... 2023-11-15 00:00 - 2023-11-16 3      4,099   100% (11-16 ...)  completed                      2026-03-16 09:00:00  2026-03-16 09:20:00
```

Stale checkpoints (deleted data files) and corrupt metadata are automatically cleaned up on listing.

</details>

### Automatic retry on transient errors

<details>
<summary>Sample output when a transient 502 occurs mid-search</summary>

```
Fetching page 2... (2,171 events, 12s elapsed, token=...YWdlIjoyNX0=)
Retrying poll (attempt 2/4, waiting 1s)...
Fetching page 3... (4,099 events, 20s elapsed, token=...ZXh0UGFnZSI6M30=)
```

Retries happen transparently with exponential backoff (1s, 2s, 4s... max 30s). Only transient errors (5xx, connection reset, timeout) are retried.

</details>

## Flag validation

| Scenario | Result |
|----------|--------|
| `--resume` without `--checkpoint` | Error |
| `--checkpoint existing.jsonl` without `--resume`/`--force` | Context-aware error (completed vs in-progress) |
| `--resume` with `--query/--start/--end/--stream` | Error (params from checkpoint) |
| `--resume` with `--limit` | Allowed |
| `--resume` on completed checkpoint | No-op, outputs existing results |
| `--force` with `--checkpoint` | Deletes existing, starts fresh |

## Architecture

### Server-side resume via pagination token

The pagination token contains a cursor encoding the position in the result set. On resume, a fresh search session is initiated (new `queryId`) and the stored token is passed to the first poll. The server extracts the cursor from the token and re-runs the query starting from that position. This means:

- Resume works even after long delays between sessions (no TTL limitation)
- No pages are re-fetched - the server jumps directly to the right position
- Falls back to re-fetch + skip only when no token is stored

### Two-file checkpoint design

- **Data file** (user-specified): Append-only JSONL with 0o600 permissions
- **Metadata file** (`~/.limacharlie.d/search_checkpoints/<sha256>.meta.json`): Atomic JSON with query params, progress, token. 0o600 permissions. Paired via SHA-256 of data file path.

### Security model

- Metadata directories: `0o700` via `secure_makedirs()` (also tightens existing dirs)
- Metadata files: `0o600` via `atomic_write()`, reads via `safe_open_read()` (symlink rejection)
- Data files: `0o600`, created with `O_EXCL|O_NOFOLLOW` (atomic TOCTOU prevention + symlink rejection)
- `list_checkpoints` validates `data_file` is absolute path (rejects path traversal from corrupt metadata)
- Shell-escaped suggested commands via `shlex.quote()`
- Cross-platform: Windows relies on home directory ACLs

### Performance model

- **Streaming JSONL**: `CheckpointReader.iter_results()` is a generator that streams one line at a time. `checkpoint-show --output jsonl` uses this to output results without loading the full file into memory.
- **Table/expand/JSON output**: requires the full result list in memory because table formatting needs all rows upfront for column width computation. For large checkpoints, use `--output jsonl` and pipe to `jq` or other streaming tools.
- **Resume loop**: does not accumulate results in memory during the search. After completion, reads the final data file for output.
- **Resumer init**: counts lines (`count_results`) without loading data.
- **Corrupt line detection**: uses one-line lookahead in the generator, not two-pass.

## Blast radius / isolation

- **SDK (`search.py`)**: Only poll loop affected. New `start_token`/`start_page` additive. Other operations unchanged.
- **CLI (`commands/search.py`)**: `run()` refactored. New `checkpoint-show` subcommand. Other search commands untouched.
- **New module (`checkpoint.py`)**: Self-contained.
- **`file_utils.py`**: Added `secure_dir_permissions()`/`secure_makedirs()` - additive.
- **Bug fix (`client.py`)**: Single line - `data=None` before try block.
- **NOT affected**: All other CLI commands, SDK modules, config, auth, JWT cache.

## Test plan

1634 total tests pass (170+ new), 2 pre-existing skips.

**SDK tests** (42): retry classification (18), retry behavior (15), cancellation (9)

**Checkpoint unit tests** (50): writer (11), reader (8 incl. iter_results, count_results, mid-file corruption), resumer (4), path derivation (3), listing/cleanup (6), permissions (6), checkpoint ID (3), context managers (7)

**File utils security tests** (7): dir permissions (3), makedirs (4)

**Integration tests** (32): end-to-end (2), resume with token (3), correctness (4), cancellation (4), error recovery (4), context managers (7), listing (1)

**CLI integration tests via CliRunner** (47): checkpoint creation (6), resume (2), resume validation (5), checkpoints listing (4), non-checkpoint search (3), cancel message (1), rejected token (3), checkpoint-show (9 incl. streaming JSONL), _is_token_expired_error classifier (10), _build_fresh_query_cmd (4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)