### PR TITLE
Add Cases class and CLI commands to documentation index

### DIFF
--- a/doc/cli/README.md
+++ b/doc/cli/README.md
@@ -121,7 +121,7 @@ limacharlie schema dr create
 | [Platform Administration](platform-admin.md) | org, user, group, api-key, ingestion-key, billing, audit |
 | [Hive & Data Stores](hive-data.md) | hive, secret, lookup, playbook, note, sop, adapter, cloud-sensor, extension |
 | [Infrastructure](infrastructure.md) | sync, output, artifact, payload, yara, integrity, logging, exfil |
-| [Other Commands](other-commands.md) | api, arl, usp, spotcheck, job, schema, completion, help/discover |
+| [Other Commands](other-commands.md) | api, arl, usp, spotcheck, job, schema, completion, help/discover, case |
 
 ## See Also
 

--- a/doc/sdk/README.md
+++ b/doc/sdk/README.md
@@ -59,6 +59,7 @@ org = Organization(client)
 | `Investigations` | `limacharlie.sdk.investigations` | Investigation tracking |
 | `AI` | `limacharlie.sdk.ai` | AI-assisted rule/query generation |
 | `Billing` | `limacharlie.sdk.billing` | Billing and usage details |
+| `Cases` | `limacharlie.sdk.cases` | SOC case management, investigation tracking, reporting |
 
 ## Raw API Requests
 
@@ -105,7 +106,7 @@ status, data = client.raw_request("GET", f"orgs/{client.oid}",
 | [Search & Insight](search-insight.md) | LCQL queries, IOC search, enrichment |
 | [Streaming](streaming.md) | Spout, Firehose |
 | [Configuration Sync](configs.md) | Infrastructure-as-code |
-| [Other Classes](other-classes.md) | Extensions, Artifacts, Payloads, Outputs, AI, Billing |
+| [Other Classes](other-classes.md) | Extensions, Artifacts, Payloads, Outputs, AI, Billing, Cases |
 
 ## See Also
 

--- a/doc/sdk/other-classes.md
+++ b/doc/sdk/other-classes.md
@@ -2,7 +2,7 @@
 
 # Other Classes
 
-Additional SDK classes for extensions, artifacts, payloads, outputs, AI, billing, and more.
+Additional SDK classes for extensions, artifacts, payloads, outputs, AI, billing, cases, and more.
 
 ## Extensions
 
@@ -87,8 +87,67 @@ from limacharlie.sdk.downloads import downloads
 
 Sensor installer and adapter binary downloads.
 
+## Cases
+
+```python
+from limacharlie.sdk.cases import Cases
+
+cases = Cases(org)
+
+# Create a case (with or without a detection)
+cases.create_case(severity="high")
+cases.create_case(detection=detection_dict, severity="critical")
+
+# List/filter cases
+cases.list_cases(status=["new", "acknowledged"], severity=["high", "critical"])
+cases.list_cases(assignee="analyst@company.com", tag=["apt", "ransomware"])
+cases.list_cases(sensor_id="sid-1234", search="mimikatz")
+
+# Update case fields (status, severity, assignee, classification, tags, etc.)
+cases.update_case(42, status="in_progress", assignee="analyst@company.com")
+cases.bulk_update([42, 43, 44], status="resolved", classification="true_positive")
+cases.merge(target_case_number=42, source_case_numbers=[43, 44])
+
+# Notes (types: general, analysis, remediation, escalation, handoff, to_stakeholder, from_stakeholder)
+cases.add_note(42, "Initial triage complete.", note_type="analysis")
+
+# Entities / IOCs (types: ip, domain, hash, url, user, email, file, process, registry, other)
+cases.add_entity(42, "ip", "10.0.0.1", verdict="malicious")
+cases.list_entities(42)
+cases.search_entities("domain", "evil.com")
+
+# Telemetry links
+cases.add_telemetry(42, event_dict, event_summary="Lateral movement observed")
+cases.list_telemetry(42)
+
+# Artifacts
+cases.add_artifact(42, "memory_dump", description="LSASS dump from host-01")
+cases.list_artifacts(42)
+
+# Detections
+cases.add_detection(42, detection_dict)
+cases.list_detections(42)
+
+# Export (bundles case + detections + entities + telemetry + artifacts)
+full_case = cases.export_case(42)
+
+# Dashboard and reporting
+cases.dashboard_counts()
+cases.report_summary(time_from="2026-01-01T00:00:00Z", time_to="2026-03-01T00:00:00Z")
+
+# Configuration
+cases.get_config()
+cases.set_config({"auto_acknowledge_minutes": 30})
+
+# Assignees
+cases.list_assignees()
+```
+
+SOC case lifecycle management, investigation tracking (entities, telemetry, artifacts), reporting with MTTA/MTTR metrics, and configuration.
+
 ## See Also
 
+- [CLI: case](../cli/other-commands.md#case) — Case CLI commands
 - [CLI: extension](../cli/hive-data.md#extension) — Extension CLI commands
 - [CLI: artifact, payload, output](../cli/infrastructure.md) — Infrastructure CLI commands
 - [Organization](organization.md) — Outputs and rules via Organization class


### PR DESCRIPTION
## Summary
- Add `Cases` to the SDK class reference table in `doc/sdk/README.md`
- Add comprehensive `Cases` section to `doc/sdk/other-classes.md` with usage examples covering case CRUD, notes, entities/IOCs, telemetry, artifacts, detections, export, dashboard, reporting, and configuration
- Add `case` command to the CLI command reference in `doc/cli/README.md`

## Test plan
- [ ] Verify markdown renders correctly on GitHub
- [ ] Verify all internal doc links resolve (e.g., `../cli/other-commands.md#case`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)