### PR TITLE
chore: set 5.1.0 release date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 5.1.0 - TBD
+## 5.1.0 - March 18, 2026
 
 ### Search
 


### PR DESCRIPTION
## Summary

- Set the 5.1.0 changelog release date to March 18, 2026 (was TBD).

Needed before tagging 5.1.0 to trigger the release workflow.