### PR TITLE
fix: update broken documentation URL to new docs site

### DIFF
--- a/limacharlie/Query.py
+++ b/limacharlie/Query.py
@@ -499,7 +499,7 @@ class LCQuery( cmd.Cmd ):
         self._logOutput( f"Current env: time={self._timeFrame} sensors={self._sensors} events={self._events} format={self._format} output={self._outFile}" )
 
     def do_lcql( self, inp ):
-        '''See the official LCQL documentation here: https://doc.limacharlie.io/docs/documentation/b0915c7a5f598-lima-charlie-query-language'''
+        '''See the official LCQL documentation here: https://docs.limacharlie.io/4-data-queries/'''
         pass
 
 if '__main__' == __name__:


### PR DESCRIPTION
## Summary
- Updated broken documentation URL in `limacharlie/Query.py`
- Old Readme.io URL (`doc.limacharlie.io/docs/documentation/b0915c7a5f598-...`) → new docs site (`docs.limacharlie.io/4-data-queries/`)

## Test plan
- [ ] Verify the new URL resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)