### PR TITLE
docs: add shell completion setup instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,27 +32,37 @@ See [Authentication](doc/authentication.md) for OAuth, environments, and credent
 
 ## Shell Completion
 
-The CLI supports tab-completion for all commands, subcommands, and options. Run one of the following to enable it for your shell:
+The CLI supports tab-completion for all commands, subcommands, and options. Run the appropriate one-time setup command for your shell:
 
-**Bash** - add to `~/.bashrc`:
+**Bash** (run once):
 
 ```bash
-eval "$(limacharlie completion bash)"
+mkdir -p ~/.local/share/bash-completion/completions
+limacharlie completion bash > ~/.local/share/bash-completion/completions/limacharlie
 ```
 
-**Zsh** - add to `~/.zshrc`:
+**Zsh** (run once):
 
 ```bash
-eval "$(limacharlie completion zsh)"
+mkdir -p ~/.zfunc
+limacharlie completion zsh > ~/.zfunc/_limacharlie
 ```
 
-**Fish** - run once:
+Then ensure `~/.zfunc` is in your `fpath` by adding this to `~/.zshrc` (before `compinit`):
 
 ```bash
+fpath=(~/.zfunc $fpath)
+autoload -Uz compinit && compinit
+```
+
+**Fish** (run once):
+
+```bash
+mkdir -p ~/.config/fish/completions
 limacharlie completion fish > ~/.config/fish/completions/limacharlie.fish
 ```
 
-Restart your shell (or `source` the rc file) for completions to take effect.
+Open a new shell session for completions to take effect. Re-run the command after upgrading to pick up new commands and options.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -32,37 +32,53 @@ See [Authentication](doc/authentication.md) for OAuth, environments, and credent
 
 ## Shell Completion
 
-The CLI supports tab-completion for all commands, subcommands, and options. Run the appropriate one-time setup command for your shell:
+The CLI supports tab-completion for all commands, subcommands, and options.
 
-**Bash** (run once):
-
-```bash
-mkdir -p ~/.local/share/bash-completion/completions
-limacharlie completion bash > ~/.local/share/bash-completion/completions/limacharlie
-```
-
-**Zsh** (run once):
+**Bash** - add to `~/.bashrc`:
 
 ```bash
-mkdir -p ~/.zfunc
-limacharlie completion zsh > ~/.zfunc/_limacharlie
+eval "$(limacharlie completion bash)"
 ```
 
-Then ensure `~/.zfunc` is in your `fpath` by adding this to `~/.zshrc` (before `compinit`):
+**Zsh** - add to `~/.zshrc`:
 
 ```bash
-fpath=(~/.zfunc $fpath)
-autoload -Uz compinit && compinit
+eval "$(limacharlie completion zsh)"
 ```
 
-**Fish** (run once):
+**Fish** - run once:
 
 ```bash
 mkdir -p ~/.config/fish/completions
 limacharlie completion fish > ~/.config/fish/completions/limacharlie.fish
 ```
 
-Open a new shell session for completions to take effect. Re-run the command after upgrading to pick up new commands and options.
+Restart your shell (or `source` the rc file) for completions to take effect.
+
+### Static completion files
+
+If you prefer not to run `eval` on every shell start, you can write the completion script to a file once. This is slightly faster at shell startup but needs to be re-run after upgrading to pick up new commands and options.
+
+**Bash:**
+
+```bash
+mkdir -p ~/.local/share/bash-completion/completions
+limacharlie completion bash > ~/.local/share/bash-completion/completions/limacharlie
+```
+
+**Zsh:**
+
+```bash
+mkdir -p ~/.zfunc
+limacharlie completion zsh > ~/.zfunc/_limacharlie
+```
+
+Ensure `~/.zfunc` is in your `fpath` by adding this to `~/.zshrc` (before `compinit`):
+
+```bash
+fpath=(~/.zfunc $fpath)
+autoload -Uz compinit && compinit
+```
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,30 @@ limacharlie sensor list
 
 See [Authentication](doc/authentication.md) for OAuth, environments, and credential resolution.
 
+## Shell Completion
+
+The CLI supports tab-completion for all commands, subcommands, and options. Run one of the following to enable it for your shell:
+
+**Bash** - add to `~/.bashrc`:
+
+```bash
+eval "$(limacharlie completion bash)"
+```
+
+**Zsh** - add to `~/.zshrc`:
+
+```bash
+eval "$(limacharlie completion zsh)"
+```
+
+**Fish** - run once:
+
+```bash
+limacharlie completion fish > ~/.config/fish/completions/limacharlie.fish
+```
+
+Restart your shell (or `source` the rc file) for completions to take effect.
+
 ## Development
 
 ### Setup


### PR DESCRIPTION
## Details

Adds a "Shell Completion" section to the README documenting how to enable tab-completion for bash, zsh, and fish. The CLI already has a `limacharlie completion <shell>` command but the setup instructions were only discoverable via `limacharlie help completion` - not visible in the README or `--help` output.

## Blast radius / isolation

README.md only - no code changes.

## Test plan

- [x] Verify the documented commands work: `limacharlie completion bash`, `limacharlie completion zsh`, `limacharlie completion fish`

🤖 Generated with [Claude Code](https://claude.com/claude-code)