### PR TITLE
feat: add summary parameter to case create

### DIFF
--- a/limacharlie/commands/case_cmd.py
+++ b/limacharlie/commands/case_cmd.py
@@ -418,11 +418,16 @@ If --severity is omitted, severity is derived from detect_mtd.level
 in the detection object (or defaults to 'medium').  Valid severities:
 critical, high, medium, low, info.
 
+Use --summary to set an initial case summary at creation time.  When
+provided, the summary is included in the 'created' audit event so
+D&R rules and webhooks can act on it immediately.
+
 Examples:
   limacharlie case create --detection '<full detection JSON>'
   limacharlie case create --detection '<full detection JSON>' \\
       --severity high
-  limacharlie case create --severity medium
+  limacharlie case create --severity medium \\
+      --summary "Investigating lateral movement"
   limacharlie case create
 """
 
@@ -564,15 +569,17 @@ def group() -> None:
               help="Full detection JSON object (optional).")
 @click.option("--severity", default=None, type=_SEVERITY_CHOICES,
               help="Case severity override (default: derived from detection).")
+@click.option("--summary", default=None,
+              help="Case summary set at creation time (max 8192 chars).")
 @pass_context
-def create(ctx, detection_json, severity) -> None:
+def create(ctx, detection_json, severity, summary) -> None:
     """Create a new case, optionally from a detection.
 
     Examples:
         limacharlie case create --detection '<full detection JSON>'
         limacharlie case create --detection '<full detection JSON>' \\
             --severity high
-        limacharlie case create --severity medium
+        limacharlie case create --severity medium --summary "Investigating lateral movement"
         limacharlie case create
     """
     detection = None
@@ -585,7 +592,7 @@ def create(ctx, detection_json, severity) -> None:
                 param_hint="--detection",
             )
     t = _get_cases(ctx)
-    data = t.create_case(detection, severity=severity)
+    data = t.create_case(detection, severity=severity, summary=summary)
     _output(ctx, data)
 
 

--- a/limacharlie/sdk/cases.py
+++ b/limacharlie/sdk/cases.py
@@ -39,6 +39,7 @@ class Cases:
         detection: dict | None = None,
         *,
         severity: str | None = None,
+        summary: str | None = None,
     ) -> dict[str, Any]:
         """Create a new case via the ext-cases extension.
 
@@ -53,6 +54,8 @@ class Cases:
                 Omit to create an empty investigation case.
             severity: Optional case severity override
                 (critical, high, medium, low, info).
+            summary: Optional case summary set at creation time
+                (max 8192 chars).
         """
         data: dict[str, Any] = {}
         if detection is not None:
@@ -61,6 +64,8 @@ class Cases:
             data["detection"] = json.dumps(detection)
         if severity is not None:
             data["severity"] = severity
+        if summary is not None:
+            data["summary"] = summary
         ext = Extensions(self._org)
         return ext.request(self._EXTENSION_NAME, "create_case", data=data)
 

--- a/tests/unit/test_cli_case.py
+++ b/tests/unit/test_cli_case.py
@@ -123,6 +123,7 @@ class TestCaseCreate:
             mock_t.create_case.assert_called_once_with(
                 json.loads(self._SAMPLE_DETECTION),
                 severity=None,
+                summary=None,
             )
 
     def test_create_with_severity_override(self):
@@ -139,6 +140,7 @@ class TestCaseCreate:
             mock_t.create_case.assert_called_once_with(
                 json.loads(self._SAMPLE_DETECTION),
                 severity="critical",
+                summary=None,
             )
 
     def test_create_without_detection(self):
@@ -153,6 +155,7 @@ class TestCaseCreate:
             mock_t.create_case.assert_called_once_with(
                 None,
                 severity=None,
+                summary=None,
             )
 
     def test_create_without_detection_with_severity(self):
@@ -167,6 +170,22 @@ class TestCaseCreate:
             mock_t.create_case.assert_called_once_with(
                 None,
                 severity="medium",
+                summary=None,
+            )
+
+    def test_create_with_summary(self):
+        p1, p2, p3 = _patch_cases()
+        with p1, p2, p3 as mock_t_cls:
+            result, mock_t = _invoke(
+                ["case", "create", "--summary", "Lateral movement detected"],
+                mock_t_cls,
+                return_value={"created": 1, "case_id": "tid-new"},
+            )
+            assert result.exit_code == 0
+            mock_t.create_case.assert_called_once_with(
+                None,
+                severity=None,
+                summary="Lateral movement detected",
             )
 
     def test_create_invalid_severity_rejected(self):

--- a/tests/unit/test_sdk_cases.py
+++ b/tests/unit/test_sdk_cases.py
@@ -93,11 +93,16 @@ class TestCreateCase:
             mock_ext = MagicMock()
             MockExt.return_value = mock_ext
             mock_ext.request.return_value = {"created": 1}
-            cases.create_case(self._SAMPLE_DETECTION, severity="high")
+            cases.create_case(
+                self._SAMPLE_DETECTION,
+                severity="high",
+                summary="Test summary",
+            )
             call_data = mock_ext.request.call_args[1]["data"]
             assert call_data == {
                 "detection": json.dumps(self._SAMPLE_DETECTION),
                 "severity": "high",
+                "summary": "Test summary",
             }
 
     def test_none_optional_fields_excluded(self, cases, mock_org):
@@ -126,6 +131,32 @@ class TestCreateCase:
             cases.create_case(severity="medium")
             call_data = mock_ext.request.call_args[1]["data"]
             assert call_data == {"severity": "medium"}
+
+    def test_with_summary(self, cases, mock_org):
+        with patch("limacharlie.sdk.cases.Extensions") as MockExt:
+            mock_ext = MagicMock()
+            MockExt.return_value = mock_ext
+            mock_ext.request.return_value = {"created": 1}
+            cases.create_case(
+                self._SAMPLE_DETECTION,
+                severity="high",
+                summary="Lateral movement detected",
+            )
+            call_data = mock_ext.request.call_args[1]["data"]
+            assert call_data == {
+                "detection": json.dumps(self._SAMPLE_DETECTION),
+                "severity": "high",
+                "summary": "Lateral movement detected",
+            }
+
+    def test_summary_none_excluded(self, cases, mock_org):
+        with patch("limacharlie.sdk.cases.Extensions") as MockExt:
+            mock_ext = MagicMock()
+            MockExt.return_value = mock_ext
+            mock_ext.request.return_value = {"created": 1}
+            cases.create_case(self._SAMPLE_DETECTION, summary=None)
+            call_data = mock_ext.request.call_args[1]["data"]
+            assert "summary" not in call_data
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add optional `summary` parameter to `Cases.create_case()` SDK method
- Add `--summary` CLI option to `limacharlie case create`
- Mirrors the ext-cases backend change that supports setting a summary at creation time, included in the `created` audit event metadata

## Test plan
- [x] Unit tests pass (60/60)
- [ ] Manual test: `limacharlie case create --summary "test"` creates case with summary
- [ ] Manual test: `limacharlie case create` (no summary) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)