### PR TITLE
fix: Use correct backend hive name 'org_notes' for note commands

### DIFF
--- a/limacharlie/commands/hive.py
+++ b/limacharlie/commands/hive.py
@@ -96,7 +96,7 @@ _KNOWN_HIVE_TYPES = [
     "ai_agent",
     "external_adapter",
     "sop",
-    "note",
+    "org_notes",
 ]
 
 
@@ -134,7 +134,7 @@ hold configuration data.  Common hive names include:
   query            - Saved LCQL queries
   playbook         - Playbooks
   sop              - Standard operating procedures
-  note             - Organization notes
+  org_notes        - Organization notes
   ai_agent         - AI agent configurations
 
 Each record returned contains:
@@ -423,7 +423,7 @@ Hives are key-value stores that hold different types of configuration
 data for a LimaCharlie organization.  Each hive type stores a specific
 kind of data.  Known types: dr-general, dr-managed, dr-service, fp,
 cloud_sensor, extension_config, yara, lookup, secret, query, playbook,
-ai_agent, external_adapter, sop, note.
+ai_agent, external_adapter, sop, org_notes.
 
 Use these names with --hive-name in other hive commands.  Some hive
 types also have dedicated shortcut commands (e.g. "limacharlie lookup",

--- a/limacharlie/commands/note.py
+++ b/limacharlie/commands/note.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from ._hive_shortcut import make_hive_group
 from ..discovery import register_explain
 
-group = make_hive_group("note", "note", "note")
+group = make_hive_group("note", "org_notes", "note")
 
 # Override the generic hive explains with note-specific documentation.
 


### PR DESCRIPTION
## Summary
- The `note` shortcut command passed `"note"` as the hive name to `Hive()`, but the backend hive is `"org_notes"`
- This caused `UNKNOWN_HIVE` errors when the SDK's `Hive` class hit the API directly at `/hive/note/...`
- Fixed `make_hive_group("note", "org_notes", "note")` in `note.py`
- Also fixed `_KNOWN_HIVE_TYPES` list and explain text in `hive.py`

## How it was found
The ai-sessions project uses the Python SDK's `Hive` class directly to persist Claude Code memories as org_notes. Every `hive.set()` call returned `UNKNOWN_HIVE`.

## Test plan
- [ ] `limacharlie note list` still works
- [ ] `limacharlie note set --key test --input-file ...` creates a record
- [ ] `limacharlie hive list --hive-name org_notes` matches `limacharlie note list`

🤖 Generated with [Claude Code](https://claude.com/claude-code)