### PR TITLE
fix: require OID when using --check-perm in auth whoami

### DIFF
--- a/limacharlie/commands/auth.py
+++ b/limacharlie/commands/auth.py
@@ -270,6 +270,11 @@ register_explain("auth.whoami", _EXPLAIN_WHOAMI)
 @pass_context
 def whoami(ctx: click.Context, show_perms: bool, check_perm: str | None) -> None:
     client = _get_client(ctx)
+    # --check-perm requires a real OID — fail early before the fallback.
+    if check_perm is not None and client.oid is None:
+        raise click.UsageError(
+            "--check-perm requires an OID to be specified (use --oid or set the LC_OID environment variable)"
+        )
     # whoami works without a specific org — fall back to "-" if no OID resolved.
     if client.oid is None:
         client = _get_client(ctx, oid_override="-")

--- a/tests/unit/test_cli_commands.py
+++ b/tests/unit/test_cli_commands.py
@@ -267,6 +267,17 @@ class TestAuthCommands:
         assert parsed["has_perm"] is True
 
     @patch("limacharlie.commands.auth.Client")
+    def test_whoami_check_perm_requires_oid(self, mock_client_cls):
+        mock_client = MagicMock()
+        mock_client.oid = None
+        mock_client_cls.return_value = mock_client
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--output", "json", "auth", "whoami", "--check-perm", "ai_agent.operate"])
+        assert result.exit_code != 0
+        assert "--check-perm requires an OID" in result.output
+
+    @patch("limacharlie.commands.auth.Client")
     def test_auth_test_success(self, mock_client_cls):
         mock_client = MagicMock()
         mock_client_cls.return_value = mock_client


### PR DESCRIPTION
## Summary
- `limacharlie auth whoami --check-perm <perm>` now fails early with a clear error if no OID is specified
- Without an OID the permission check is ambiguous — this makes the requirement explicit

## Test plan
- [x] New unit test `test_whoami_check_perm_requires_oid` verifies the error
- [x] Existing `--check-perm` tests (with OID set) still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)