### PR TITLE
Make --summary required for case create

### DIFF
--- a/limacharlie/commands/case_cmd.py
+++ b/limacharlie/commands/case_cmd.py
@@ -416,17 +416,17 @@ If --severity is omitted, severity is derived from detect_mtd.level
 in the detection object (or defaults to 'medium').  Valid severities:
 critical, high, medium, low, info.
 
-Use --summary to set an initial case summary at creation time.  When
-provided, the summary is included in the 'created' audit event so
-D&R rules and webhooks can act on it immediately.
+--summary is required.  The summary is included in the 'created' audit
+event so D&R rules and webhooks can act on it immediately.
 
 Examples:
-  limacharlie case create --detection '<full detection JSON>'
+  limacharlie case create --summary "Investigating lateral movement"
   limacharlie case create --detection '<full detection JSON>' \\
-      --severity high
+      --summary "Triage detection"
+  limacharlie case create --detection '<full detection JSON>' \\
+      --severity high --summary "High severity lateral movement"
   limacharlie case create --severity medium \\
       --summary "Investigating lateral movement"
-  limacharlie case create
 """
 
 register_explain("case.create", _EXPLAIN_CREATE)
@@ -568,18 +568,19 @@ def group() -> None:
               help="Full detection JSON object (optional).")
 @click.option("--severity", default=None, type=_SEVERITY_CHOICES,
               help="Case severity override (default: derived from detection).")
-@click.option("--summary", default=None,
-              help="Case summary set at creation time (max 8192 chars).")
+@click.option("--summary", required=True,
+              help="Case summary (required, max 8192 chars).")
 @pass_context
 def create(ctx, detection_json, severity, summary) -> None:
     """Create a new case, optionally from a detection.
 
     Examples:
-        limacharlie case create --detection '<full detection JSON>'
+        limacharlie case create --summary "Investigating lateral movement"
         limacharlie case create --detection '<full detection JSON>' \\
-            --severity high
+            --summary "Triage detection"
+        limacharlie case create --detection '<full detection JSON>' \\
+            --severity high --summary "High severity lateral movement"
         limacharlie case create --severity medium --summary "Investigating lateral movement"
-        limacharlie case create
     """
     detection = None
     if detection_json is not None:

--- a/tests/unit/test_cli_case.py
+++ b/tests/unit/test_cli_case.py
@@ -115,7 +115,8 @@ class TestCaseCreate:
         p1, p2, p3 = _patch_cases()
         with p1, p2, p3 as mock_t_cls:
             result, mock_t = _invoke(
-                ["case", "create", "--detection", self._SAMPLE_DETECTION],
+                ["case", "create", "--detection", self._SAMPLE_DETECTION,
+                 "--summary", "Triage detection"],
                 mock_t_cls,
                 return_value={"created": 1, "case_id": "tid-new"},
             )
@@ -123,7 +124,7 @@ class TestCaseCreate:
             mock_t.create_case.assert_called_once_with(
                 json.loads(self._SAMPLE_DETECTION),
                 severity=None,
-                summary=None,
+                summary="Triage detection",
             )
 
     def test_create_with_severity_override(self):
@@ -132,7 +133,8 @@ class TestCaseCreate:
             result, mock_t = _invoke(
                 ["case", "create",
                  "--detection", self._SAMPLE_DETECTION,
-                 "--severity", "critical"],
+                 "--severity", "critical",
+                 "--summary", "Critical lateral movement"],
                 mock_t_cls,
                 return_value={"created": 1, "case_id": "tid-new"},
             )
@@ -140,14 +142,14 @@ class TestCaseCreate:
             mock_t.create_case.assert_called_once_with(
                 json.loads(self._SAMPLE_DETECTION),
                 severity="critical",
-                summary=None,
+                summary="Critical lateral movement",
             )
 
     def test_create_without_detection(self):
         p1, p2, p3 = _patch_cases()
         with p1, p2, p3 as mock_t_cls:
             result, mock_t = _invoke(
-                ["case", "create"],
+                ["case", "create", "--summary", "Manual investigation"],
                 mock_t_cls,
                 return_value={"created": 1, "case_id": "tid-new"},
             )
@@ -155,14 +157,15 @@ class TestCaseCreate:
             mock_t.create_case.assert_called_once_with(
                 None,
                 severity=None,
-                summary=None,
+                summary="Manual investigation",
             )
 
     def test_create_without_detection_with_severity(self):
         p1, p2, p3 = _patch_cases()
         with p1, p2, p3 as mock_t_cls:
             result, mock_t = _invoke(
-                ["case", "create", "--severity", "medium"],
+                ["case", "create", "--severity", "medium",
+                 "--summary", "Medium severity case"],
                 mock_t_cls,
                 return_value={"created": 1, "case_id": "tid-new"},
             )
@@ -170,7 +173,7 @@ class TestCaseCreate:
             mock_t.create_case.assert_called_once_with(
                 None,
                 severity="medium",
-                summary=None,
+                summary="Medium severity case",
             )
 
     def test_create_with_summary(self):
@@ -188,12 +191,21 @@ class TestCaseCreate:
                 summary="Lateral movement detected",
             )
 
+    def test_create_without_summary_rejected(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, [
+            "case", "create",
+            "--detection", self._SAMPLE_DETECTION,
+        ])
+        assert result.exit_code != 0
+
     def test_create_invalid_severity_rejected(self):
         runner = CliRunner()
         result = runner.invoke(cli, [
             "case", "create",
             "--detection", self._SAMPLE_DETECTION,
             "--severity", "extreme",
+            "--summary", "Test",
         ])
         assert result.exit_code != 0
 
@@ -201,6 +213,7 @@ class TestCaseCreate:
         runner = CliRunner()
         result = runner.invoke(cli, [
             "case", "create", "--detection", "not-json",
+            "--summary", "Test",
         ])
         assert result.exit_code != 0
 


### PR DESCRIPTION
## Summary
- Makes `--summary` a required option for `limacharlie case create` since cases require summaries
- Updates explain text and command examples to reflect the requirement
- Adds `test_create_without_summary_rejected` test; updates existing tests to always provide `--summary`

## Test plan
- [x] All 99 existing case CLI tests pass
- [ ] Manual: `limacharlie case create` without `--summary` should error
- [ ] Manual: `limacharlie case create --summary "test"` should succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)