### PR TITLE
feat: add feedback CLI commands for ext-feedback

### DIFF
--- a/limacharlie/cli.py
+++ b/limacharlie/cli.py
@@ -113,6 +113,7 @@ _COMMAND_MODULE_MAP: dict[str, tuple[str, str]] = {
     "event": ("event", "group"),
     "exfil": ("exfil", "group"),
     "extension": ("extension", "group"),
+    "feedback": ("feedback", "group"),
     "external-adapter": ("adapter", "group"),
     "fp": ("fp", "group"),
     "group": ("group", "group"),

--- a/limacharlie/commands/feedback.py
+++ b/limacharlie/commands/feedback.py
@@ -221,36 +221,42 @@ def group() -> None:
 
 @group.command("request-approval")
 @click.option("--channel", required=True, help="Name of the configured feedback channel.")
-@click.option("--question", required=True, help="Prompt to present to the respondent.")
+@click.option("--question", required=True, help="Prompt text shown to the respondent.")
 @click.option("--destination", required=True, type=_DESTINATION_CHOICES,
-              help="Response destination: 'case' or 'playbook'.")
-@click.option("--case-id", default=None, help="Case number (required when destination is 'case').")
+              help="Where to send the response: 'case' (add note) or 'playbook' (trigger).")
+@click.option("--case-id", default=None, help="Case number to attach the response to. Required when --destination=case.")
 @click.option("--playbook", "playbook_name", default=None,
-              help="Playbook name (required when destination is 'playbook').")
+              help="Playbook name to trigger with the response. Required when --destination=playbook.")
 @click.option("--approved-content", default=None,
-              help="JSON data included when approved.")
+              help="JSON object string included in the response payload when approved, e.g. '{\"action\": \"isolate\"}'.")
 @click.option("--denied-content", default=None,
-              help="JSON data included when denied.")
+              help="JSON object string included in the response payload when denied, e.g. '{\"action\": \"skip\"}'.")
 @click.option("--timeout", "timeout_seconds", default=None, type=int,
-              help="Auto-respond after N seconds if no response (minimum 60).")
+              help="Auto-respond after this many seconds with no human response (minimum 60). Requires --timeout-choice.")
 @click.option("--timeout-choice", default=None, type=_TIMEOUT_CHOICE_CHOICES,
-              help="Choice on timeout: 'approved' or 'denied' (required with --timeout).")
+              help="Which choice to auto-select on timeout: 'approved' or 'denied'. Required when --timeout is set.")
 @click.option("--timeout-content", default=None,
-              help="JSON data for the timeout response (overrides choice content).")
+              help="JSON object string for the timeout response payload (overrides --approved-content/--denied-content for the timeout).")
 @pass_context
 def request_approval(ctx, channel, question, destination, case_id,
                      playbook_name, approved_content, denied_content,
                      timeout_seconds, timeout_choice, timeout_content) -> None:
-    """Send an Approve/Deny feedback request.
+    """Send an Approve/Deny feedback request to a channel.
 
+    The respondent sees Approve and Deny buttons. Their choice is
+    dispatched to the specified destination (case note or playbook).
+
+    \b
+    Dependencies:
+      --destination case     => --case-id is required
+      --destination playbook => --playbook is required
+      --timeout              => --timeout-choice is required
+
+    \b
     Examples:
-        limacharlie feedback request-approval \\
-            --channel ops-slack --question "Isolate host?" \\
-            --destination case --case-id 42
-        limacharlie feedback request-approval \\
-            --channel web-default --question "Approve?" \\
-            --destination playbook --playbook my-playbook \\
-            --timeout 300 --timeout-choice denied
+      limacharlie feedback request-approval --channel web --question "Isolate host-01?" --destination case --case-id 42
+      limacharlie feedback request-approval --channel ops-slack --question "Block IP?" --destination playbook --playbook block-ip --approved-content '{"ip":"10.0.0.1"}'
+      limacharlie feedback request-approval --channel web --question "Approve?" --destination case --case-id 7 --timeout 300 --timeout-choice denied
     """
     approved = None
     if approved_content is not None:
@@ -296,31 +302,36 @@ def request_approval(ctx, channel, question, destination, case_id,
 
 @group.command("request-ack")
 @click.option("--channel", required=True, help="Name of the configured feedback channel.")
-@click.option("--question", required=True, help="Prompt to present to the respondent.")
+@click.option("--question", required=True, help="Prompt text shown to the respondent.")
 @click.option("--destination", required=True, type=_DESTINATION_CHOICES,
-              help="Response destination: 'case' or 'playbook'.")
-@click.option("--case-id", default=None, help="Case number (required when destination is 'case').")
+              help="Where to send the response: 'case' (add note) or 'playbook' (trigger).")
+@click.option("--case-id", default=None, help="Case number to attach the response to. Required when --destination=case.")
 @click.option("--playbook", "playbook_name", default=None,
-              help="Playbook name (required when destination is 'playbook').")
+              help="Playbook name to trigger with the response. Required when --destination=playbook.")
 @click.option("--acknowledged-content", default=None,
-              help="JSON data included when acknowledged.")
+              help="JSON object string included in the response payload when acknowledged, e.g. '{\"status\": \"seen\"}'.")
 @click.option("--timeout", "timeout_seconds", default=None, type=int,
-              help="Auto-acknowledge after N seconds if no response (minimum 60).")
+              help="Auto-acknowledge after this many seconds with no human response (minimum 60).")
 @click.option("--timeout-content", default=None,
-              help="JSON data for the timeout response (overrides acknowledged_content).")
+              help="JSON object string for the timeout response payload (overrides --acknowledged-content for the timeout).")
 @pass_context
 def request_ack(ctx, channel, question, destination, case_id,
                 playbook_name, acknowledged_content,
                 timeout_seconds, timeout_content) -> None:
-    """Send an acknowledgement request.
+    """Send an acknowledgement request (single Acknowledge button).
 
+    The respondent sees a single Acknowledge button. When clicked (or
+    on timeout), the response is dispatched to the specified destination.
+
+    \b
+    Dependencies:
+      --destination case     => --case-id is required
+      --destination playbook => --playbook is required
+
+    \b
     Examples:
-        limacharlie feedback request-ack \\
-            --channel ops-slack --question "Ack alert X" \\
-            --destination case --case-id 42
-        limacharlie feedback request-ack \\
-            --channel ops-slack --question "Ack alert X" \\
-            --destination case --case-id 42 --timeout 600
+      limacharlie feedback request-ack --channel web --question "Alert: lateral movement on host-01" --destination case --case-id 42
+      limacharlie feedback request-ack --channel ops-slack --question "Ack incident #7" --destination playbook --playbook ack-handler --timeout 600
     """
     ack_content = None
     if acknowledged_content is not None:
@@ -356,29 +367,34 @@ def request_ack(ctx, channel, question, destination, case_id,
 
 @group.command("request-question")
 @click.option("--channel", required=True, help="Name of the configured feedback channel.")
-@click.option("--question", required=True, help="Question to present to the respondent.")
+@click.option("--question", required=True, help="Question text shown to the respondent (they reply with free-form text).")
 @click.option("--destination", required=True, type=_DESTINATION_CHOICES,
-              help="Response destination: 'case' or 'playbook'.")
-@click.option("--case-id", default=None, help="Case number (required when destination is 'case').")
+              help="Where to send the response: 'case' (add note) or 'playbook' (trigger).")
+@click.option("--case-id", default=None, help="Case number to attach the response to. Required when --destination=case.")
 @click.option("--playbook", "playbook_name", default=None,
-              help="Playbook name (required when destination is 'playbook').")
+              help="Playbook name to trigger with the response. Required when --destination=playbook.")
 @click.option("--timeout", "timeout_seconds", default=None, type=int,
-              help="Auto-answer after N seconds if no response (minimum 60).")
+              help="Auto-answer after this many seconds with no human response (minimum 60). Requires --timeout-content.")
 @click.option("--timeout-content", default=None,
-              help="JSON data for the timeout response (required with --timeout for questions).")
+              help="JSON object string used as the automatic answer on timeout, e.g. '{\"answer\": \"no response\"}'. Required when --timeout is set.")
 @pass_context
 def request_question(ctx, channel, question, destination, case_id,
                      playbook_name, timeout_seconds, timeout_content) -> None:
     """Send a question for free-form text response.
 
+    The respondent sees a text input field. Their typed answer is
+    dispatched to the specified destination.
+
+    \b
+    Dependencies:
+      --destination case     => --case-id is required
+      --destination playbook => --playbook is required
+      --timeout              => --timeout-content is required
+
+    \b
     Examples:
-        limacharlie feedback request-question \\
-            --channel ops-slack --question "Root cause?" \\
-            --destination case --case-id 42
-        limacharlie feedback request-question \\
-            --channel ops-slack --question "Root cause?" \\
-            --destination case --case-id 42 \\
-            --timeout 300 --timeout-content '{"answer": "no response"}'
+      limacharlie feedback request-question --channel web --question "What is the root cause?" --destination case --case-id 42
+      limacharlie feedback request-question --channel ops-slack --question "Remediation steps?" --destination playbook --playbook collect-input --timeout 300 --timeout-content '{"answer": "no response"}'
     """
     tc = None
     if timeout_content is not None:
@@ -405,11 +421,18 @@ def request_question(ctx, channel, question, destination, case_id,
 
 @group.group("channel")
 def channel_group() -> None:
-    """Manage feedback channels.
+    """Manage feedback channels (configure before sending requests).
 
-    Channels define where feedback requests are delivered.
-    Each channel has a name, type, and optional Tailored Output
-    with the channel's credentials.
+    Each channel has a name, a type, and (for non-web types) a
+    Tailored Output that holds credentials.
+
+    \b
+    Channel types:
+      web       Built-in web UI (no output needed, returns a shareable URL)
+      slack     Sends Block Kit message (output needs: slack_api_token, slack_channel)
+      email     Sends HTML email with link (output needs: dest_host, dest_email)
+      telegram  Sends inline keyboard (output needs: bot_token, chat_id)
+      ms_teams  Sends Adaptive Card (output needs: webhook_url)
     """
 
 
@@ -422,8 +445,7 @@ def channel_group() -> None:
 def channel_list(ctx) -> None:
     """List configured feedback channels.
 
-    Example:
-        limacharlie feedback channel list
+    Returns a JSON array of {name, channel_type, output_name} objects.
     """
     fb = _get_feedback(ctx)
     data = fb.list_channels()
@@ -435,19 +457,20 @@ def channel_list(ctx) -> None:
 # ---------------------------------------------------------------------------
 
 @channel_group.command("add")
-@click.option("--name", required=True, help="Unique channel name.")
+@click.option("--name", required=True, help="Unique channel name (used in --channel when sending requests).")
 @click.option("--type", "channel_type", required=True, type=_CHANNEL_TYPE_CHOICES,
-              help="Channel type.")
+              help="Channel type: web, slack, email, telegram, or ms_teams.")
 @click.option("--output-name", default=None,
-              help="Tailored Output name with channel credentials (required for non-web types).")
+              help="Tailored Output holding channel credentials. Required for all types except 'web'.")
 @pass_context
 def channel_add(ctx, name, channel_type, output_name) -> None:
-    """Add a feedback channel.
+    """Add a feedback channel to the organization config.
 
+    \b
     Examples:
-        limacharlie feedback channel add --name web-default --type web
-        limacharlie feedback channel add \\
-            --name ops-slack --type slack --output-name slack-soc
+      limacharlie feedback channel add --name web-default --type web
+      limacharlie feedback channel add --name ops-slack --type slack --output-name slack-soc
+      limacharlie feedback channel add --name tg-alerts --type telegram --output-name telegram-bot
     """
     fb = _get_feedback(ctx)
     data = fb.add_channel(name, channel_type, output_name=output_name)
@@ -464,10 +487,9 @@ def channel_add(ctx, name, channel_type, output_name) -> None:
 @click.option("--name", required=True, help="Channel name to remove.")
 @pass_context
 def channel_remove(ctx, name) -> None:
-    """Remove a feedback channel.
+    """Remove a feedback channel from the organization config.
 
-    Example:
-        limacharlie feedback channel remove --name ops-slack
+    Does not delete the associated Tailored Output.
     """
     fb = _get_feedback(ctx)
     data = fb.remove_channel(name)

--- a/limacharlie/commands/feedback.py
+++ b/limacharlie/commands/feedback.py
@@ -41,6 +41,11 @@ payload when the recipient approves or denies:
   --approved-content '{"action": "isolate"}'
   --denied-content '{"action": "skip"}'
 
+Timeout: use --timeout to auto-respond after N seconds if no human
+responds.  Requires --timeout-choice (approved or denied).
+  --timeout 300 --timeout-choice denied
+  --timeout 300 --timeout-choice denied --timeout-content '{"reason": "timeout"}'
+
 Examples:
   limacharlie feedback request-approval \\
       --channel ops-slack --question "Isolate host-01?" \\
@@ -52,6 +57,10 @@ Examples:
       --channel ops-slack --question "Block IP 10.0.0.1?" \\
       --destination playbook --playbook block-ip \\
       --approved-content '{"ip": "10.0.0.1"}'
+  limacharlie feedback request-approval \\
+      --channel ops-slack --question "Isolate host?" \\
+      --destination case --case-id 42 \\
+      --timeout 300 --timeout-choice denied
 """
 
 _EXPLAIN_REQUEST_ACK = """\
@@ -64,6 +73,11 @@ destination (case note or playbook trigger).
 Optionally attach JSON data included in the response payload:
   --acknowledged-content '{"status": "seen"}'
 
+Timeout: use --timeout to auto-acknowledge after N seconds if no
+human responds.
+  --timeout 300
+  --timeout 300 --timeout-content '{"status": "auto-ack", "reason": "timeout"}'
+
 Examples:
   limacharlie feedback request-ack \\
       --channel ops-slack --question "Alert: lateral movement detected" \\
@@ -71,6 +85,9 @@ Examples:
   limacharlie feedback request-ack \\
       --channel email-oncall --question "Acknowledge incident #7" \\
       --destination playbook --playbook ack-handler
+  limacharlie feedback request-ack \\
+      --channel ops-slack --question "Ack alert X" \\
+      --destination case --case-id 42 --timeout 600
 """
 
 _EXPLAIN_REQUEST_QUESTION = """\
@@ -78,6 +95,11 @@ Send a question with a free-form text input field to a channel.
 
 The respondent types a text answer which is dispatched to the
 specified destination (case note or playbook trigger).
+
+Timeout: use --timeout to auto-answer after N seconds if no human
+responds.  --timeout-content is required for question type (provides
+the automatic answer).
+  --timeout 300 --timeout-content '{"answer": "no response", "reason": "timeout"}'
 
 Examples:
   limacharlie feedback request-question \\
@@ -87,6 +109,10 @@ Examples:
       --channel web-default \\
       --question "Provide remediation steps for host-01" \\
       --destination playbook --playbook collect-input
+  limacharlie feedback request-question \\
+      --channel ops-slack --question "Root cause?" \\
+      --destination case --case-id 42 \\
+      --timeout 300 --timeout-content '{"answer": "no response"}'
 """
 
 _EXPLAIN_CHANNEL_LIST = """\
@@ -168,6 +194,7 @@ _CHANNEL_TYPE_CHOICES = click.Choice(
     ["web", "slack", "email", "telegram", "ms_teams"],
     case_sensitive=False,
 )
+_TIMEOUT_CHOICE_CHOICES = click.Choice(["approved", "denied"], case_sensitive=False)
 
 
 # ---------------------------------------------------------------------------
@@ -204,9 +231,16 @@ def group() -> None:
               help="JSON data included when approved.")
 @click.option("--denied-content", default=None,
               help="JSON data included when denied.")
+@click.option("--timeout", "timeout_seconds", default=None, type=int,
+              help="Auto-respond after N seconds if no response (minimum 60).")
+@click.option("--timeout-choice", default=None, type=_TIMEOUT_CHOICE_CHOICES,
+              help="Choice on timeout: 'approved' or 'denied' (required with --timeout).")
+@click.option("--timeout-content", default=None,
+              help="JSON data for the timeout response (overrides choice content).")
 @pass_context
 def request_approval(ctx, channel, question, destination, case_id,
-                     playbook_name, approved_content, denied_content) -> None:
+                     playbook_name, approved_content, denied_content,
+                     timeout_seconds, timeout_choice, timeout_content) -> None:
     """Send an Approve/Deny feedback request.
 
     Examples:
@@ -215,7 +249,8 @@ def request_approval(ctx, channel, question, destination, case_id,
             --destination case --case-id 42
         limacharlie feedback request-approval \\
             --channel web-default --question "Approve?" \\
-            --destination playbook --playbook my-playbook
+            --destination playbook --playbook my-playbook \\
+            --timeout 300 --timeout-choice denied
     """
     approved = None
     if approved_content is not None:
@@ -233,6 +268,14 @@ def request_approval(ctx, channel, question, destination, case_id,
             raise click.BadParameter(
                 f"invalid JSON: {exc}", param_hint="--denied-content",
             )
+    tc = None
+    if timeout_content is not None:
+        try:
+            tc = json.loads(timeout_content)
+        except json.JSONDecodeError as exc:
+            raise click.BadParameter(
+                f"invalid JSON: {exc}", param_hint="--timeout-content",
+            )
     fb = _get_feedback(ctx)
     data = fb.request_simple_approval(
         channel, question, destination,
@@ -240,6 +283,9 @@ def request_approval(ctx, channel, question, destination, case_id,
         playbook_name=playbook_name,
         approved_content=approved,
         denied_content=denied,
+        timeout_seconds=timeout_seconds,
+        timeout_choice=timeout_choice,
+        timeout_content=tc,
     )
     _output(ctx, data)
 
@@ -258,15 +304,23 @@ def request_approval(ctx, channel, question, destination, case_id,
               help="Playbook name (required when destination is 'playbook').")
 @click.option("--acknowledged-content", default=None,
               help="JSON data included when acknowledged.")
+@click.option("--timeout", "timeout_seconds", default=None, type=int,
+              help="Auto-acknowledge after N seconds if no response (minimum 60).")
+@click.option("--timeout-content", default=None,
+              help="JSON data for the timeout response (overrides acknowledged_content).")
 @pass_context
 def request_ack(ctx, channel, question, destination, case_id,
-                playbook_name, acknowledged_content) -> None:
+                playbook_name, acknowledged_content,
+                timeout_seconds, timeout_content) -> None:
     """Send an acknowledgement request.
 
     Examples:
         limacharlie feedback request-ack \\
             --channel ops-slack --question "Ack alert X" \\
             --destination case --case-id 42
+        limacharlie feedback request-ack \\
+            --channel ops-slack --question "Ack alert X" \\
+            --destination case --case-id 42 --timeout 600
     """
     ack_content = None
     if acknowledged_content is not None:
@@ -276,12 +330,22 @@ def request_ack(ctx, channel, question, destination, case_id,
             raise click.BadParameter(
                 f"invalid JSON: {exc}", param_hint="--acknowledged-content",
             )
+    tc = None
+    if timeout_content is not None:
+        try:
+            tc = json.loads(timeout_content)
+        except json.JSONDecodeError as exc:
+            raise click.BadParameter(
+                f"invalid JSON: {exc}", param_hint="--timeout-content",
+            )
     fb = _get_feedback(ctx)
     data = fb.request_acknowledgement(
         channel, question, destination,
         case_id=case_id,
         playbook_name=playbook_name,
         acknowledged_content=ack_content,
+        timeout_seconds=timeout_seconds,
+        timeout_content=tc,
     )
     _output(ctx, data)
 
@@ -298,21 +362,39 @@ def request_ack(ctx, channel, question, destination, case_id,
 @click.option("--case-id", default=None, help="Case number (required when destination is 'case').")
 @click.option("--playbook", "playbook_name", default=None,
               help="Playbook name (required when destination is 'playbook').")
+@click.option("--timeout", "timeout_seconds", default=None, type=int,
+              help="Auto-answer after N seconds if no response (minimum 60).")
+@click.option("--timeout-content", default=None,
+              help="JSON data for the timeout response (required with --timeout for questions).")
 @pass_context
 def request_question(ctx, channel, question, destination, case_id,
-                     playbook_name) -> None:
+                     playbook_name, timeout_seconds, timeout_content) -> None:
     """Send a question for free-form text response.
 
     Examples:
         limacharlie feedback request-question \\
             --channel ops-slack --question "Root cause?" \\
             --destination case --case-id 42
+        limacharlie feedback request-question \\
+            --channel ops-slack --question "Root cause?" \\
+            --destination case --case-id 42 \\
+            --timeout 300 --timeout-content '{"answer": "no response"}'
     """
+    tc = None
+    if timeout_content is not None:
+        try:
+            tc = json.loads(timeout_content)
+        except json.JSONDecodeError as exc:
+            raise click.BadParameter(
+                f"invalid JSON: {exc}", param_hint="--timeout-content",
+            )
     fb = _get_feedback(ctx)
     data = fb.request_question(
         channel, question, destination,
         case_id=case_id,
         playbook_name=playbook_name,
+        timeout_seconds=timeout_seconds,
+        timeout_content=tc,
     )
     _output(ctx, data)
 

--- a/limacharlie/commands/feedback.py
+++ b/limacharlie/commands/feedback.py
@@ -1,0 +1,394 @@
+"""Feedback commands for LimaCharlie CLI v2.
+
+Commands for sending interactive feedback requests (approval,
+acknowledgement, free-form question) to external channels and managing
+feedback channel configuration via the ext-feedback extension.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import click
+
+from ..cli import pass_context
+from ..client import Client
+from ..sdk.organization import Organization
+from ..sdk.feedback import Feedback
+from ..output import format_output, detect_output_format
+from ..discovery import register_explain
+
+
+# ---------------------------------------------------------------------------
+# Explain texts
+# ---------------------------------------------------------------------------
+
+_EXPLAIN_REQUEST_APPROVAL = """\
+Send a simple Approve/Deny feedback request to a channel.
+
+When the recipient responds, the result is dispatched to the
+specified destination: either added as a note to a case or used
+to trigger a playbook.
+
+Channels must be configured first (see 'feedback channel' commands).
+Channel types: web (built-in UI), slack, email, telegram, ms_teams.
+
+For web channels, the response includes a shareable URL.
+
+Optionally attach JSON data that will be included in the response
+payload when the recipient approves or denies:
+  --approved-content '{"action": "isolate"}'
+  --denied-content '{"action": "skip"}'
+
+Examples:
+  limacharlie feedback request-approval \\
+      --channel ops-slack --question "Isolate host-01?" \\
+      --destination case --case-id 42
+  limacharlie feedback request-approval \\
+      --channel web-default --question "Approve remediation?" \\
+      --destination playbook --playbook remediate-host
+  limacharlie feedback request-approval \\
+      --channel ops-slack --question "Block IP 10.0.0.1?" \\
+      --destination playbook --playbook block-ip \\
+      --approved-content '{"ip": "10.0.0.1"}'
+"""
+
+_EXPLAIN_REQUEST_ACK = """\
+Send an acknowledgement request (single Acknowledge button) to a
+channel.
+
+When acknowledged, the result is dispatched to the specified
+destination (case note or playbook trigger).
+
+Optionally attach JSON data included in the response payload:
+  --acknowledged-content '{"status": "seen"}'
+
+Examples:
+  limacharlie feedback request-ack \\
+      --channel ops-slack --question "Alert: lateral movement detected" \\
+      --destination case --case-id 42
+  limacharlie feedback request-ack \\
+      --channel email-oncall --question "Acknowledge incident #7" \\
+      --destination playbook --playbook ack-handler
+"""
+
+_EXPLAIN_REQUEST_QUESTION = """\
+Send a question with a free-form text input field to a channel.
+
+The respondent types a text answer which is dispatched to the
+specified destination (case note or playbook trigger).
+
+Examples:
+  limacharlie feedback request-question \\
+      --channel ops-slack --question "What is the root cause?" \\
+      --destination case --case-id 42
+  limacharlie feedback request-question \\
+      --channel web-default \\
+      --question "Provide remediation steps for host-01" \\
+      --destination playbook --playbook collect-input
+"""
+
+_EXPLAIN_CHANNEL_LIST = """\
+List all configured feedback channels for the organization.
+
+Channels define where feedback requests are sent. Each channel has
+a name, type (web, slack, email, telegram, ms_teams), and an optional
+Tailored Output name that holds the channel credentials.
+
+The web channel type is built-in and does not require a Tailored
+Output.
+
+Example:
+  limacharlie feedback channel list
+"""
+
+_EXPLAIN_CHANNEL_ADD = """\
+Add a feedback channel to the organization's ext-feedback config.
+
+Channel types and their Tailored Output requirements:
+  web       - No output needed (built-in web UI)
+  slack     - Output with slack_api_token, slack_channel
+  email     - Output with dest_host, dest_email, and optional SMTP creds
+  telegram  - Output with bot_token, chat_id
+  ms_teams  - Output with webhook_url
+
+The --output-name is required for all channel types except web.
+
+Examples:
+  limacharlie feedback channel add \\
+      --name web-default --type web
+  limacharlie feedback channel add \\
+      --name ops-slack --type slack --output-name slack-soc
+  limacharlie feedback channel add \\
+      --name email-oncall --type email --output-name smtp-oncall
+  limacharlie feedback channel add \\
+      --name tg-alerts --type telegram --output-name telegram-bot
+"""
+
+_EXPLAIN_CHANNEL_REMOVE = """\
+Remove a feedback channel from the organization's ext-feedback config.
+
+This does not delete the associated Tailored Output.
+
+Example:
+  limacharlie feedback channel remove --name ops-slack
+"""
+
+register_explain("feedback.request-approval", _EXPLAIN_REQUEST_APPROVAL)
+register_explain("feedback.request-ack", _EXPLAIN_REQUEST_ACK)
+register_explain("feedback.request-question", _EXPLAIN_REQUEST_QUESTION)
+register_explain("feedback.channel.list", _EXPLAIN_CHANNEL_LIST)
+register_explain("feedback.channel.add", _EXPLAIN_CHANNEL_ADD)
+register_explain("feedback.channel.remove", _EXPLAIN_CHANNEL_REMOVE)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _output(ctx: click.Context, data: Any) -> None:
+    fmt = ctx.obj.output_format or detect_output_format()
+    if not ctx.obj.quiet:
+        click.echo(format_output(data, fmt))
+
+
+def _get_feedback(ctx: click.Context) -> Feedback:
+    client = Client(oid=ctx.obj.oid, environment=ctx.obj.environment, print_debug_fn=ctx.obj.debug_fn, debug_full_response=ctx.obj.debug_full, debug_curl=ctx.obj.debug_curl, debug_verbose=ctx.obj.debug_verbose)
+    org = Organization(client)
+    return Feedback(org)
+
+
+# ---------------------------------------------------------------------------
+# Shared option values
+# ---------------------------------------------------------------------------
+
+_DESTINATION_CHOICES = click.Choice(["case", "playbook"], case_sensitive=False)
+_CHANNEL_TYPE_CHOICES = click.Choice(
+    ["web", "slack", "email", "telegram", "ms_teams"],
+    case_sensitive=False,
+)
+
+
+# ---------------------------------------------------------------------------
+# Group
+# ---------------------------------------------------------------------------
+
+@click.group("feedback")
+def group() -> None:
+    """Manage interactive feedback requests (ext-feedback).
+
+    Send approval prompts, acknowledgement requests, or free-form
+    questions to external channels (Slack, Email, Telegram, Teams,
+    or built-in Web UI).  Responses are dispatched to a case or
+    playbook.
+
+    Use 'feedback channel' subcommands to configure channels before
+    sending requests.
+    """
+
+
+# ---------------------------------------------------------------------------
+# request-approval
+# ---------------------------------------------------------------------------
+
+@group.command("request-approval")
+@click.option("--channel", required=True, help="Name of the configured feedback channel.")
+@click.option("--question", required=True, help="Prompt to present to the respondent.")
+@click.option("--destination", required=True, type=_DESTINATION_CHOICES,
+              help="Response destination: 'case' or 'playbook'.")
+@click.option("--case-id", default=None, help="Case number (required when destination is 'case').")
+@click.option("--playbook", "playbook_name", default=None,
+              help="Playbook name (required when destination is 'playbook').")
+@click.option("--approved-content", default=None,
+              help="JSON data included when approved.")
+@click.option("--denied-content", default=None,
+              help="JSON data included when denied.")
+@pass_context
+def request_approval(ctx, channel, question, destination, case_id,
+                     playbook_name, approved_content, denied_content) -> None:
+    """Send an Approve/Deny feedback request.
+
+    Examples:
+        limacharlie feedback request-approval \\
+            --channel ops-slack --question "Isolate host?" \\
+            --destination case --case-id 42
+        limacharlie feedback request-approval \\
+            --channel web-default --question "Approve?" \\
+            --destination playbook --playbook my-playbook
+    """
+    approved = None
+    if approved_content is not None:
+        try:
+            approved = json.loads(approved_content)
+        except json.JSONDecodeError as exc:
+            raise click.BadParameter(
+                f"invalid JSON: {exc}", param_hint="--approved-content",
+            )
+    denied = None
+    if denied_content is not None:
+        try:
+            denied = json.loads(denied_content)
+        except json.JSONDecodeError as exc:
+            raise click.BadParameter(
+                f"invalid JSON: {exc}", param_hint="--denied-content",
+            )
+    fb = _get_feedback(ctx)
+    data = fb.request_simple_approval(
+        channel, question, destination,
+        case_id=case_id,
+        playbook_name=playbook_name,
+        approved_content=approved,
+        denied_content=denied,
+    )
+    _output(ctx, data)
+
+
+# ---------------------------------------------------------------------------
+# request-ack
+# ---------------------------------------------------------------------------
+
+@group.command("request-ack")
+@click.option("--channel", required=True, help="Name of the configured feedback channel.")
+@click.option("--question", required=True, help="Prompt to present to the respondent.")
+@click.option("--destination", required=True, type=_DESTINATION_CHOICES,
+              help="Response destination: 'case' or 'playbook'.")
+@click.option("--case-id", default=None, help="Case number (required when destination is 'case').")
+@click.option("--playbook", "playbook_name", default=None,
+              help="Playbook name (required when destination is 'playbook').")
+@click.option("--acknowledged-content", default=None,
+              help="JSON data included when acknowledged.")
+@pass_context
+def request_ack(ctx, channel, question, destination, case_id,
+                playbook_name, acknowledged_content) -> None:
+    """Send an acknowledgement request.
+
+    Examples:
+        limacharlie feedback request-ack \\
+            --channel ops-slack --question "Ack alert X" \\
+            --destination case --case-id 42
+    """
+    ack_content = None
+    if acknowledged_content is not None:
+        try:
+            ack_content = json.loads(acknowledged_content)
+        except json.JSONDecodeError as exc:
+            raise click.BadParameter(
+                f"invalid JSON: {exc}", param_hint="--acknowledged-content",
+            )
+    fb = _get_feedback(ctx)
+    data = fb.request_acknowledgement(
+        channel, question, destination,
+        case_id=case_id,
+        playbook_name=playbook_name,
+        acknowledged_content=ack_content,
+    )
+    _output(ctx, data)
+
+
+# ---------------------------------------------------------------------------
+# request-question
+# ---------------------------------------------------------------------------
+
+@group.command("request-question")
+@click.option("--channel", required=True, help="Name of the configured feedback channel.")
+@click.option("--question", required=True, help="Question to present to the respondent.")
+@click.option("--destination", required=True, type=_DESTINATION_CHOICES,
+              help="Response destination: 'case' or 'playbook'.")
+@click.option("--case-id", default=None, help="Case number (required when destination is 'case').")
+@click.option("--playbook", "playbook_name", default=None,
+              help="Playbook name (required when destination is 'playbook').")
+@pass_context
+def request_question(ctx, channel, question, destination, case_id,
+                     playbook_name) -> None:
+    """Send a question for free-form text response.
+
+    Examples:
+        limacharlie feedback request-question \\
+            --channel ops-slack --question "Root cause?" \\
+            --destination case --case-id 42
+    """
+    fb = _get_feedback(ctx)
+    data = fb.request_question(
+        channel, question, destination,
+        case_id=case_id,
+        playbook_name=playbook_name,
+    )
+    _output(ctx, data)
+
+
+# ---------------------------------------------------------------------------
+# channel subgroup
+# ---------------------------------------------------------------------------
+
+@group.group("channel")
+def channel_group() -> None:
+    """Manage feedback channels.
+
+    Channels define where feedback requests are delivered.
+    Each channel has a name, type, and optional Tailored Output
+    with the channel's credentials.
+    """
+
+
+# ---------------------------------------------------------------------------
+# channel list
+# ---------------------------------------------------------------------------
+
+@channel_group.command("list")
+@pass_context
+def channel_list(ctx) -> None:
+    """List configured feedback channels.
+
+    Example:
+        limacharlie feedback channel list
+    """
+    fb = _get_feedback(ctx)
+    data = fb.list_channels()
+    _output(ctx, data)
+
+
+# ---------------------------------------------------------------------------
+# channel add
+# ---------------------------------------------------------------------------
+
+@channel_group.command("add")
+@click.option("--name", required=True, help="Unique channel name.")
+@click.option("--type", "channel_type", required=True, type=_CHANNEL_TYPE_CHOICES,
+              help="Channel type.")
+@click.option("--output-name", default=None,
+              help="Tailored Output name with channel credentials (required for non-web types).")
+@pass_context
+def channel_add(ctx, name, channel_type, output_name) -> None:
+    """Add a feedback channel.
+
+    Examples:
+        limacharlie feedback channel add --name web-default --type web
+        limacharlie feedback channel add \\
+            --name ops-slack --type slack --output-name slack-soc
+    """
+    fb = _get_feedback(ctx)
+    data = fb.add_channel(name, channel_type, output_name=output_name)
+    if not ctx.obj.quiet:
+        click.echo(f"Channel '{name}' added.")
+    _output(ctx, data)
+
+
+# ---------------------------------------------------------------------------
+# channel remove
+# ---------------------------------------------------------------------------
+
+@channel_group.command("remove")
+@click.option("--name", required=True, help="Channel name to remove.")
+@pass_context
+def channel_remove(ctx, name) -> None:
+    """Remove a feedback channel.
+
+    Example:
+        limacharlie feedback channel remove --name ops-slack
+    """
+    fb = _get_feedback(ctx)
+    data = fb.remove_channel(name)
+    if not ctx.obj.quiet:
+        click.echo(f"Channel '{name}' removed.")
+    _output(ctx, data)

--- a/limacharlie/sdk/feedback.py
+++ b/limacharlie/sdk/feedback.py
@@ -77,15 +77,15 @@ class Feedback:
         if playbook_name is not None:
             data["playbook_name"] = playbook_name
         if approved_content is not None:
-            data["approved_content"] = approved_content
+            data["approved_content"] = json.dumps(approved_content)
         if denied_content is not None:
-            data["denied_content"] = denied_content
+            data["denied_content"] = json.dumps(denied_content)
         if timeout_seconds is not None:
             data["timeout_seconds"] = timeout_seconds
         if timeout_choice is not None:
             data["timeout_choice"] = timeout_choice
         if timeout_content is not None:
-            data["timeout_content"] = timeout_content
+            data["timeout_content"] = json.dumps(timeout_content)
         ext = Extensions(self._org)
         return ext.request(_EXTENSION_NAME, "request_simple_approval", data=data)
 
@@ -127,11 +127,11 @@ class Feedback:
         if playbook_name is not None:
             data["playbook_name"] = playbook_name
         if acknowledged_content is not None:
-            data["acknowledged_content"] = acknowledged_content
+            data["acknowledged_content"] = json.dumps(acknowledged_content)
         if timeout_seconds is not None:
             data["timeout_seconds"] = timeout_seconds
         if timeout_content is not None:
-            data["timeout_content"] = timeout_content
+            data["timeout_content"] = json.dumps(timeout_content)
         ext = Extensions(self._org)
         return ext.request(_EXTENSION_NAME, "request_acknowledgement", data=data)
 
@@ -173,7 +173,7 @@ class Feedback:
         if timeout_seconds is not None:
             data["timeout_seconds"] = timeout_seconds
         if timeout_content is not None:
-            data["timeout_content"] = timeout_content
+            data["timeout_content"] = json.dumps(timeout_content)
         ext = Extensions(self._org)
         return ext.request(_EXTENSION_NAME, "request_question", data=data)
 

--- a/limacharlie/sdk/feedback.py
+++ b/limacharlie/sdk/feedback.py
@@ -1,0 +1,216 @@
+"""Feedback SDK for LimaCharlie v2.
+
+Wraps the ext-feedback extension for sending interactive feedback
+requests (approval, acknowledgement, question) to external channels
+(Slack, Email, Telegram, Teams, or built-in Web UI) and managing
+channel configuration.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .organization import Organization
+
+from .extensions import Extensions
+from .hive import Hive, HiveRecord
+
+_EXTENSION_NAME = "ext-feedback"
+
+
+class Feedback:
+    """Feedback system client for LimaCharlie."""
+
+    def __init__(self, org: Organization) -> None:
+        self._org = org
+
+    @property
+    def oid(self) -> str:
+        return self._org.oid
+
+    # ------------------------------------------------------------------
+    # Feedback requests
+    # ------------------------------------------------------------------
+
+    def request_simple_approval(
+        self,
+        channel: str,
+        question: str,
+        feedback_destination: str,
+        *,
+        case_id: str | None = None,
+        playbook_name: str | None = None,
+        approved_content: dict | None = None,
+        denied_content: dict | None = None,
+    ) -> dict[str, Any]:
+        """Send a simple approval (Approve/Deny) request to a channel.
+
+        Args:
+            channel: Name of the configured feedback channel.
+            question: The prompt to present to the respondent.
+            feedback_destination: "case" or "playbook".
+            case_id: Case number (required when destination is "case").
+            playbook_name: Playbook to trigger (required when destination is "playbook").
+            approved_content: JSON data included in the response when approved.
+            denied_content: JSON data included in the response when denied.
+
+        Returns:
+            dict with request_id and optionally url (for web channels).
+        """
+        data: dict[str, Any] = {
+            "channel": channel,
+            "question": question,
+            "feedback_destination": feedback_destination,
+        }
+        if case_id is not None:
+            data["case_id"] = case_id
+        if playbook_name is not None:
+            data["playbook_name"] = playbook_name
+        if approved_content is not None:
+            data["approved_content"] = approved_content
+        if denied_content is not None:
+            data["denied_content"] = denied_content
+        ext = Extensions(self._org)
+        return ext.request(_EXTENSION_NAME, "request_simple_approval", data=data)
+
+    def request_acknowledgement(
+        self,
+        channel: str,
+        question: str,
+        feedback_destination: str,
+        *,
+        case_id: str | None = None,
+        playbook_name: str | None = None,
+        acknowledged_content: dict | None = None,
+    ) -> dict[str, Any]:
+        """Send an acknowledgement request to a channel.
+
+        Args:
+            channel: Name of the configured feedback channel.
+            question: The prompt to present to the respondent.
+            feedback_destination: "case" or "playbook".
+            case_id: Case number (required when destination is "case").
+            playbook_name: Playbook to trigger (required when destination is "playbook").
+            acknowledged_content: JSON data included in the response when acknowledged.
+
+        Returns:
+            dict with request_id and optionally url (for web channels).
+        """
+        data: dict[str, Any] = {
+            "channel": channel,
+            "question": question,
+            "feedback_destination": feedback_destination,
+        }
+        if case_id is not None:
+            data["case_id"] = case_id
+        if playbook_name is not None:
+            data["playbook_name"] = playbook_name
+        if acknowledged_content is not None:
+            data["acknowledged_content"] = acknowledged_content
+        ext = Extensions(self._org)
+        return ext.request(_EXTENSION_NAME, "request_acknowledgement", data=data)
+
+    def request_question(
+        self,
+        channel: str,
+        question: str,
+        feedback_destination: str,
+        *,
+        case_id: str | None = None,
+        playbook_name: str | None = None,
+    ) -> dict[str, Any]:
+        """Send a question with free-form text input to a channel.
+
+        Args:
+            channel: Name of the configured feedback channel.
+            question: The question to present to the respondent.
+            feedback_destination: "case" or "playbook".
+            case_id: Case number (required when destination is "case").
+            playbook_name: Playbook to trigger (required when destination is "playbook").
+
+        Returns:
+            dict with request_id and optionally url (for web channels).
+        """
+        data: dict[str, Any] = {
+            "channel": channel,
+            "question": question,
+            "feedback_destination": feedback_destination,
+        }
+        if case_id is not None:
+            data["case_id"] = case_id
+        if playbook_name is not None:
+            data["playbook_name"] = playbook_name
+        ext = Extensions(self._org)
+        return ext.request(_EXTENSION_NAME, "request_question", data=data)
+
+    # ------------------------------------------------------------------
+    # Channel configuration
+    # ------------------------------------------------------------------
+
+    def _get_config(self) -> HiveRecord:
+        hive = Hive(self._org, "extension_config")
+        return hive.get(_EXTENSION_NAME)
+
+    def _set_config(self, record: HiveRecord) -> dict[str, Any]:
+        hive = Hive(self._org, "extension_config")
+        return hive.set(record)
+
+    def list_channels(self) -> list[dict[str, Any]]:
+        """List configured feedback channels.
+
+        Returns:
+            List of channel dicts with name, channel_type, and output_name.
+        """
+        record = self._get_config()
+        return record.data.get("channels", [])
+
+    def add_channel(
+        self,
+        name: str,
+        channel_type: str,
+        output_name: str | None = None,
+    ) -> dict[str, Any]:
+        """Add a feedback channel to the configuration.
+
+        Args:
+            name: Unique channel name.
+            channel_type: One of web, slack, email, telegram, ms_teams.
+            output_name: Tailored Output name with channel credentials
+                (required for all types except web).
+
+        Returns:
+            Hive set response.
+        """
+        record = self._get_config()
+        channels = record.data.get("channels", [])
+        for ch in channels:
+            if ch.get("name") == name:
+                raise ValueError(f"channel {name!r} already exists")
+        entry: dict[str, str] = {
+            "name": name,
+            "channel_type": channel_type,
+        }
+        if output_name is not None:
+            entry["output_name"] = output_name
+        channels.append(entry)
+        record.data["channels"] = channels
+        return self._set_config(record)
+
+    def remove_channel(self, name: str) -> dict[str, Any]:
+        """Remove a feedback channel from the configuration.
+
+        Args:
+            name: Channel name to remove.
+
+        Returns:
+            Hive set response.
+        """
+        record = self._get_config()
+        channels = record.data.get("channels", [])
+        new_channels = [ch for ch in channels if ch.get("name") != name]
+        if len(new_channels) == len(channels):
+            raise ValueError(f"channel {name!r} not found")
+        record.data["channels"] = new_channels
+        return self._set_config(record)

--- a/limacharlie/sdk/feedback.py
+++ b/limacharlie/sdk/feedback.py
@@ -44,6 +44,9 @@ class Feedback:
         playbook_name: str | None = None,
         approved_content: dict | None = None,
         denied_content: dict | None = None,
+        timeout_seconds: int | None = None,
+        timeout_choice: str | None = None,
+        timeout_content: dict | None = None,
     ) -> dict[str, Any]:
         """Send a simple approval (Approve/Deny) request to a channel.
 
@@ -55,6 +58,11 @@ class Feedback:
             playbook_name: Playbook to trigger (required when destination is "playbook").
             approved_content: JSON data included in the response when approved.
             denied_content: JSON data included in the response when denied.
+            timeout_seconds: Auto-respond after this many seconds (minimum 60).
+            timeout_choice: Choice to auto-select on timeout ("approved" or "denied");
+                required when timeout_seconds is set.
+            timeout_content: JSON data to include in the timeout response
+                (overrides the choice's content if set).
 
         Returns:
             dict with request_id and optionally url (for web channels).
@@ -72,6 +80,12 @@ class Feedback:
             data["approved_content"] = approved_content
         if denied_content is not None:
             data["denied_content"] = denied_content
+        if timeout_seconds is not None:
+            data["timeout_seconds"] = timeout_seconds
+        if timeout_choice is not None:
+            data["timeout_choice"] = timeout_choice
+        if timeout_content is not None:
+            data["timeout_content"] = timeout_content
         ext = Extensions(self._org)
         return ext.request(_EXTENSION_NAME, "request_simple_approval", data=data)
 
@@ -84,6 +98,8 @@ class Feedback:
         case_id: str | None = None,
         playbook_name: str | None = None,
         acknowledged_content: dict | None = None,
+        timeout_seconds: int | None = None,
+        timeout_content: dict | None = None,
     ) -> dict[str, Any]:
         """Send an acknowledgement request to a channel.
 
@@ -94,6 +110,9 @@ class Feedback:
             case_id: Case number (required when destination is "case").
             playbook_name: Playbook to trigger (required when destination is "playbook").
             acknowledged_content: JSON data included in the response when acknowledged.
+            timeout_seconds: Auto-acknowledge after this many seconds (minimum 60).
+            timeout_content: JSON data to include in the timeout response
+                (overrides acknowledged_content if set).
 
         Returns:
             dict with request_id and optionally url (for web channels).
@@ -109,6 +128,10 @@ class Feedback:
             data["playbook_name"] = playbook_name
         if acknowledged_content is not None:
             data["acknowledged_content"] = acknowledged_content
+        if timeout_seconds is not None:
+            data["timeout_seconds"] = timeout_seconds
+        if timeout_content is not None:
+            data["timeout_content"] = timeout_content
         ext = Extensions(self._org)
         return ext.request(_EXTENSION_NAME, "request_acknowledgement", data=data)
 
@@ -120,6 +143,8 @@ class Feedback:
         *,
         case_id: str | None = None,
         playbook_name: str | None = None,
+        timeout_seconds: int | None = None,
+        timeout_content: dict | None = None,
     ) -> dict[str, Any]:
         """Send a question with free-form text input to a channel.
 
@@ -129,6 +154,9 @@ class Feedback:
             feedback_destination: "case" or "playbook".
             case_id: Case number (required when destination is "case").
             playbook_name: Playbook to trigger (required when destination is "playbook").
+            timeout_seconds: Auto-answer after this many seconds (minimum 60).
+            timeout_content: JSON data to include in the timeout response
+                (required when timeout_seconds is set for question type).
 
         Returns:
             dict with request_id and optionally url (for web channels).
@@ -142,6 +170,10 @@ class Feedback:
             data["case_id"] = case_id
         if playbook_name is not None:
             data["playbook_name"] = playbook_name
+        if timeout_seconds is not None:
+            data["timeout_seconds"] = timeout_seconds
+        if timeout_content is not None:
+            data["timeout_content"] = timeout_content
         ext = Extensions(self._org)
         return ext.request(_EXTENSION_NAME, "request_question", data=data)
 

--- a/tests/unit/test_cli_lazy_loading_regression.py
+++ b/tests/unit/test_cli_lazy_loading_regression.py
@@ -47,7 +47,7 @@ del _ctx, _name
 EXPECTED_TOP_LEVEL_COMMANDS = frozenset({
     "ai", "api", "api-key", "arl", "artifact", "audit", "auth", "billing",
     "case", "cloud-adapter", "completion", "config", "detection", "download", "dr",
-    "endpoint-policy", "event", "exfil", "extension", "external-adapter",
+    "endpoint-policy", "event", "exfil", "extension", "external-adapter", "feedback",
     "fp", "group", "help", "hive", "ingestion-key", "installation-key",
     "integrity", "ioc", "job", "logging", "lookup", "note", "org", "output",
     "payload", "playbook", "replay", "schema", "search", "secret", "sensor",
@@ -78,6 +78,7 @@ EXPECTED_MODULE_MAP = {
     "event": ("group", "event"),
     "exfil": ("group", "exfil"),
     "extension": ("group", "extension"),
+    "feedback": ("group", "feedback"),
     "fp": ("group", "fp"),
     "group": ("group", "group"),
     "help_cmd": ("group", "help"),


### PR DESCRIPTION
## Summary

- Adds `limacharlie feedback` command group with CLI commands for the ext-feedback extension
- SDK class (`limacharlie/sdk/feedback.py`) wraps extension requests and channel configuration via the extension_config hive
- CLI commands (`limacharlie/commands/feedback.py`):
  - `feedback request-approval` -- send Approve/Deny prompts to a channel
  - `feedback request-ack` -- send acknowledgement requests
  - `feedback request-question` -- send free-form text questions
  - `feedback channel list/add/remove` -- manage channel configuration (web, slack, email, telegram, ms_teams)
- Responses are dispatched to a case (as a note) or trigger a playbook
- Timeout support: all three request commands accept `--timeout`, `--timeout-choice` (approval only), and `--timeout-content` to auto-respond after a deadline if no human responds

## Test plan

- [x] All 858 existing CLI regression tests pass (module mapping, command registration, lazy loading, help text)
- [ ] Manual test with a real org: configure a web channel, send an approval request, verify URL is returned
- [ ] Manual test: add/list/remove channels via CLI
- [ ] Manual test: send requests to slack/email/telegram channels with configured Tailored Outputs
- [ ] Manual test: send a request with --timeout and verify auto-response fires after deadline

🤖 Generated with [Claude Code](https://claude.com/claude-code)