### PR TITLE
fix: send feedback _content params as dicts instead of JSON strings

### DIFF
--- a/limacharlie/sdk/feedback.py
+++ b/limacharlie/sdk/feedback.py
@@ -8,7 +8,6 @@ channel configuration.
 
 from __future__ import annotations
 
-import json
 from typing import Any, TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -77,15 +76,15 @@ class Feedback:
         if playbook_name is not None:
             data["playbook_name"] = playbook_name
         if approved_content is not None:
-            data["approved_content"] = json.dumps(approved_content)
+            data["approved_content"] = approved_content
         if denied_content is not None:
-            data["denied_content"] = json.dumps(denied_content)
+            data["denied_content"] = denied_content
         if timeout_seconds is not None:
             data["timeout_seconds"] = timeout_seconds
         if timeout_choice is not None:
             data["timeout_choice"] = timeout_choice
         if timeout_content is not None:
-            data["timeout_content"] = json.dumps(timeout_content)
+            data["timeout_content"] = timeout_content
         ext = Extensions(self._org)
         return ext.request(_EXTENSION_NAME, "request_simple_approval", data=data)
 
@@ -127,11 +126,11 @@ class Feedback:
         if playbook_name is not None:
             data["playbook_name"] = playbook_name
         if acknowledged_content is not None:
-            data["acknowledged_content"] = json.dumps(acknowledged_content)
+            data["acknowledged_content"] = acknowledged_content
         if timeout_seconds is not None:
             data["timeout_seconds"] = timeout_seconds
         if timeout_content is not None:
-            data["timeout_content"] = json.dumps(timeout_content)
+            data["timeout_content"] = timeout_content
         ext = Extensions(self._org)
         return ext.request(_EXTENSION_NAME, "request_acknowledgement", data=data)
 
@@ -173,7 +172,7 @@ class Feedback:
         if timeout_seconds is not None:
             data["timeout_seconds"] = timeout_seconds
         if timeout_content is not None:
-            data["timeout_content"] = json.dumps(timeout_content)
+            data["timeout_content"] = timeout_content
         ext = Extensions(self._org)
         return ext.request(_EXTENSION_NAME, "request_question", data=data)
 


### PR DESCRIPTION
## Summary
- Stop double-encoding `_content` parameters (`approved_content`, `denied_content`, `acknowledged_content`, `timeout_content`) in the feedback SDK — send the actual dict instead of `json.dumps()` output.
- The ext-feedback backend now expects native JSON objects in these fields rather than JSON-encoded strings.
- No CLI changes needed — the CLI already parses JSON strings from `--*-content` flags into dicts before passing them to the SDK.

## Test plan
- [ ] Send a `request-approval` with `--approved-content` and verify the extension receives a proper JSON object
- [ ] Verify `request-ack` with `--acknowledged-content` works
- [ ] Verify `request-question` with `--timeout-content` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)