### PR TITLE
feat: ai session attach — live WebSocket streaming + interactive chat

### DIFF
--- a/limacharlie/commands/_ai_attach.py
+++ b/limacharlie/commands/_ai_attach.py
@@ -1,0 +1,437 @@
+"""Streaming + interactive runtime for `limacharlie ai session attach`.
+
+Kept in its own module so the main ``commands/ai.py`` file stays readable.
+Exposes :func:`run_attach` which is called by the Click command and
+handles both the passive "view the stream" and the interactive
+"chat with the session" modes.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from typing import Any
+
+import click
+
+from ..sdk.ai import AI as AISDK
+from ..sdk.ai_session import (
+    AttachmentForbidden,
+    MSG_ASK_USER_QUESTION,
+    MSG_ASSISTANT,
+    MSG_ERROR,
+    MSG_HISTORY,
+    MSG_RESULT,
+    MSG_SESSION_END,
+    MSG_SYSTEM,
+    MSG_TOOL_APPROVAL_REQUEST,
+    MSG_TOOL_RESULT,
+    MSG_TOOL_USE,
+    MSG_USER,
+    SessionAttachment,
+)
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+def run_attach(sdk: AISDK, session_id: str, *,
+               read_only: bool,
+               interactive: bool,
+               show_history: bool,
+               raw: bool) -> int:
+    """Run the attach session loop.
+
+    Returns the process exit code: 0 on clean disconnect, 1 on error.
+    """
+    try:
+        return asyncio.run(_attach(
+            sdk, session_id,
+            read_only=read_only,
+            interactive=interactive,
+            show_history=show_history,
+            raw=raw,
+        ))
+    except KeyboardInterrupt:
+        return 0
+
+
+# ---------------------------------------------------------------------------
+# Async core
+# ---------------------------------------------------------------------------
+
+async def _attach(sdk: AISDK, session_id: str, *,
+                  read_only: bool,
+                  interactive: bool,
+                  show_history: bool,
+                  raw: bool) -> int:
+    # Choose the endpoint.  If the user didn't force --read-only and the
+    # owner endpoint refuses us with 403, fall back transparently.
+    att = sdk.attach_session(session_id, read_only=read_only)
+    try:
+        await att.connect()
+    except AttachmentForbidden:
+        if read_only:
+            _err("Access denied: you do not have ai_agent.get on this org.")
+            return 1
+        _notice("Owner access denied; retrying in read-only mode.")
+        att = sdk.attach_session(session_id, read_only=True)
+        try:
+            await att.connect()
+        except AttachmentForbidden:
+            _err("Access denied for both owner and org-scoped endpoints.")
+            return 1
+        read_only = True
+
+    _notice(
+        f"Attached to session {session_id} "
+        f"({'read-only' if read_only else 'interactive'} mode). "
+        f"Ctrl+C to detach."
+    )
+
+    try:
+        async with att:
+            reader = asyncio.create_task(_reader_loop(
+                att,
+                interactive=interactive and not read_only,
+                show_history=show_history,
+                raw=raw,
+            ))
+            writer: asyncio.Task | None = None
+            if interactive and not read_only:
+                writer = asyncio.create_task(_input_loop(att))
+
+            try:
+                await reader
+            finally:
+                if writer is not None:
+                    writer.cancel()
+                    try:
+                        await writer
+                    except (asyncio.CancelledError, Exception):
+                        pass
+    except Exception as e:
+        _err(f"Connection error: {e}")
+        return 1
+
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Reader (server -> terminal)
+# ---------------------------------------------------------------------------
+
+async def _reader_loop(att: SessionAttachment, *,
+                       interactive: bool,
+                       show_history: bool,
+                       raw: bool) -> None:
+    async for msg in att.messages():
+        if raw:
+            click.echo(json.dumps(msg))
+            if msg.get("type") == MSG_SESSION_END:
+                return
+            continue
+
+        mtype = msg.get("type")
+        payload = msg.get("payload") or {}
+
+        if mtype == MSG_HISTORY:
+            if show_history:
+                messages = payload.get("messages") or []
+                _print_banner(f"History ({len(messages)} messages)")
+                for m in messages:
+                    _render_message(m)
+                _print_banner("Live stream")
+            continue
+
+        if mtype == MSG_TOOL_APPROVAL_REQUEST and interactive:
+            await _handle_approval(att, payload)
+            continue
+
+        if mtype == MSG_ASK_USER_QUESTION and interactive:
+            await _handle_question(att, payload)
+            continue
+
+        _render_message(msg)
+
+        if mtype == MSG_SESSION_END:
+            return
+
+
+# ---------------------------------------------------------------------------
+# Writer (terminal -> server)
+# ---------------------------------------------------------------------------
+
+async def _input_loop(att: SessionAttachment) -> None:
+    """Read stdin lines and send them as prompts.
+
+    Each line is sent as a ``prompt`` message.  An empty line is
+    ignored.  ``/interrupt`` is translated to a WebSocket interrupt
+    message; ``/quit`` ends the session loop.
+    """
+    loop = asyncio.get_running_loop()
+    while True:
+        try:
+            line = await loop.run_in_executor(None, _read_line_or_eof)
+        except (EOFError, KeyboardInterrupt):
+            return
+        if line is None:  # EOF
+            return
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped == "/quit":
+            return
+        if stripped == "/interrupt":
+            try:
+                await att.interrupt()
+                _notice("interrupt sent")
+            except Exception as e:
+                _err(f"failed to send interrupt: {e}")
+            continue
+        try:
+            await att.send_prompt(stripped)
+        except Exception as e:
+            _err(f"failed to send prompt: {e}")
+
+
+def _read_line_or_eof() -> str | None:
+    """Blocking stdin read returning ``None`` on EOF.
+
+    Printed to stderr so it doesn't interleave with stdout messages
+    when the terminal is being driven by another task.
+    """
+    try:
+        sys.stderr.write("> ")
+        sys.stderr.flush()
+    except Exception:
+        pass
+    line = sys.stdin.readline()
+    if not line:
+        return None
+    return line.rstrip("\n")
+
+
+# ---------------------------------------------------------------------------
+# Interactive approvals / questions
+# ---------------------------------------------------------------------------
+
+async def _handle_approval(att: SessionAttachment, payload: dict) -> None:
+    tool_use_id = payload.get("tool_use_id", "")
+    tool_name = payload.get("tool_name", "<unknown>")
+    tool_input = payload.get("tool_input")
+    click.echo(click.style(
+        f"\nTool approval requested: {tool_name}",
+        fg="yellow", bold=True,
+    ))
+    if tool_input is not None:
+        click.echo(click.style(
+            f"  input: {_oneline(json.dumps(tool_input))}",
+            fg="yellow",
+        ))
+
+    loop = asyncio.get_running_loop()
+    answer = await loop.run_in_executor(
+        None, lambda: click.prompt(
+            "Approve? [y/n/session]",
+            default="n", show_default=False,
+        ),
+    )
+    answer = answer.strip().lower()
+    if answer in ("y", "yes"):
+        await att.approve_tool(tool_use_id, True, scope="once")
+        _notice("approved (this call)")
+    elif answer in ("session", "s"):
+        await att.approve_tool(tool_use_id, True, scope="session")
+        _notice("approved (session)")
+    else:
+        await att.approve_tool(tool_use_id, False, scope="once",
+                               message="denied by CLI user")
+        _notice("denied")
+
+
+async def _handle_question(att: SessionAttachment, payload: dict) -> None:
+    question_id = payload.get("question_id", "")
+    questions = payload.get("questions") or []
+    answers: dict[str, str] = {}
+
+    loop = asyncio.get_running_loop()
+    for q in questions:
+        header = q.get("header") or q.get("question", "question")
+        prompt_text = q.get("question", header)
+        options = q.get("options") or []
+
+        click.echo(click.style(f"\nQuestion: {prompt_text}", fg="magenta", bold=True))
+        if options:
+            for i, opt in enumerate(options, 1):
+                label = opt.get("label") if isinstance(opt, dict) else str(opt)
+                desc = opt.get("description") if isinstance(opt, dict) else ""
+                line = f"  {i}. {label}"
+                if desc:
+                    line += f" - {desc}"
+                click.echo(click.style(line, fg="magenta"))
+            choice = await loop.run_in_executor(
+                None, lambda: click.prompt("Choose", type=str),
+            )
+            choice = choice.strip()
+            if choice.isdigit() and 1 <= int(choice) <= len(options):
+                opt = options[int(choice) - 1]
+                answer = opt.get("label") if isinstance(opt, dict) else str(opt)
+            else:
+                answer = choice
+        else:
+            answer = await loop.run_in_executor(
+                None, lambda: click.prompt("Answer", type=str),
+            )
+            answer = answer.strip()
+        answers[header] = answer
+
+    await att.answer_question(question_id, answers)
+
+
+# ---------------------------------------------------------------------------
+# Rendering
+# ---------------------------------------------------------------------------
+
+def _render_message(msg: dict[str, Any]) -> None:
+    mtype = msg.get("type")
+    payload = msg.get("payload") or {}
+    ts = msg.get("timestamp")
+    prefix = f"[{ts}] " if ts else ""
+
+    if mtype == MSG_ASSISTANT:
+        text = _extract_assistant_text(payload)
+        click.echo(click.style(f"{prefix}assistant:", fg="cyan", bold=True))
+        if text:
+            click.echo(_indent(text))
+        return
+
+    if mtype == MSG_USER:
+        text = payload.get("text", "")
+        click.echo(click.style(f"{prefix}user:", fg="green", bold=True))
+        if text:
+            click.echo(_indent(text))
+        return
+
+    if mtype == MSG_TOOL_USE:
+        name = payload.get("name", "<tool>")
+        tid = payload.get("id", "")
+        tool_in = _oneline(json.dumps(payload.get("input", {})))
+        click.echo(click.style(
+            f"{prefix}tool_use {name} ({tid}): {tool_in}",
+            fg="yellow",
+        ))
+        return
+
+    if mtype == MSG_TOOL_RESULT:
+        tid = payload.get("tool_use_id", "")
+        content = payload.get("content", "")
+        if isinstance(content, (dict, list)):
+            content = json.dumps(content)
+        click.echo(click.style(
+            f"{prefix}tool_result ({tid}):", fg="yellow", dim=True,
+        ))
+        if content:
+            click.echo(_indent(_truncate(str(content), 4000)))
+        return
+
+    if mtype == MSG_SYSTEM:
+        subtype = payload.get("subtype", "")
+        text = payload.get("message") or payload.get("text") or ""
+        tag = f"system[{subtype}]" if subtype else "system"
+        click.echo(click.style(f"{prefix}{tag}: {_oneline(str(text))}", dim=True))
+        return
+
+    if mtype == MSG_ERROR:
+        code = payload.get("code", "")
+        message = payload.get("message", "")
+        click.echo(click.style(
+            f"{prefix}error [{code}]: {message}", fg="red", bold=True,
+        ), err=True)
+        return
+
+    if mtype == MSG_SESSION_END:
+        reason = payload.get("reason", "")
+        exit_code = payload.get("exit_code")
+        extra = f" (exit_code={exit_code})" if exit_code is not None else ""
+        click.echo(click.style(
+            f"{prefix}session ended: {reason}{extra}",
+            fg="red", bold=True,
+        ))
+        return
+
+    if mtype == MSG_RESULT:
+        summary = payload.get("summary") or payload.get("message") or ""
+        click.echo(click.style(f"{prefix}result: {summary}", fg="blue"))
+        return
+
+    if mtype == MSG_TOOL_APPROVAL_REQUEST:
+        name = payload.get("tool_name", "<tool>")
+        tool_in = _oneline(json.dumps(payload.get("tool_input", {})))
+        click.echo(click.style(
+            f"{prefix}approval requested for {name}: {tool_in}",
+            fg="yellow", bold=True,
+        ))
+        return
+
+    if mtype == MSG_ASK_USER_QUESTION:
+        questions = payload.get("questions") or []
+        headers = ", ".join(q.get("question", "?") for q in questions) or "?"
+        click.echo(click.style(
+            f"{prefix}question: {headers}", fg="magenta", bold=True,
+        ))
+        return
+
+    # Unknown type: fall back to compact JSON.
+    click.echo(click.style(
+        f"{prefix}{mtype}: {_oneline(json.dumps(payload))}", dim=True,
+    ))
+
+
+def _extract_assistant_text(payload: dict) -> str:
+    content = payload.get("content")
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for block in content:
+            if isinstance(block, dict):
+                if block.get("type") == "text":
+                    parts.append(block.get("text", ""))
+                elif "text" in block:
+                    parts.append(str(block["text"]))
+        return "\n".join(p for p in parts if p)
+    return str(content or "")
+
+
+# ---------------------------------------------------------------------------
+# Small utilities
+# ---------------------------------------------------------------------------
+
+def _indent(text: str, prefix: str = "  ") -> str:
+    return "\n".join(prefix + line for line in text.splitlines() or [""])
+
+
+def _oneline(text: str, limit: int = 500) -> str:
+    collapsed = " ".join(text.split())
+    return _truncate(collapsed, limit)
+
+
+def _truncate(text: str, limit: int) -> str:
+    if len(text) <= limit:
+        return text
+    return text[:limit] + "..."
+
+
+def _print_banner(text: str) -> None:
+    click.echo(click.style(f"--- {text} ---", dim=True), err=True)
+
+
+def _notice(text: str) -> None:
+    click.echo(click.style(text, dim=True), err=True)
+
+
+def _err(text: str) -> None:
+    click.echo(click.style(text, fg="red", bold=True), err=True)

--- a/limacharlie/commands/_ai_attach.py
+++ b/limacharlie/commands/_ai_attach.py
@@ -41,8 +41,13 @@ def run_attach(sdk: AISDK, session_id: str, *,
                read_only: bool,
                interactive: bool,
                show_history: bool,
-               raw: bool) -> int:
+               raw: bool,
+               initial_prompt: str | None = None) -> int:
     """Run the attach session loop.
+
+    ``initial_prompt`` is sent as the first message after the WebSocket
+    connects.  Used by ``ai chat`` to seed a new session; attach leaves
+    it ``None``.
 
     Returns the process exit code: 0 on clean disconnect, 1 on error.
     """
@@ -53,6 +58,7 @@ def run_attach(sdk: AISDK, session_id: str, *,
             interactive=interactive,
             show_history=show_history,
             raw=raw,
+            initial_prompt=initial_prompt,
         ))
     except KeyboardInterrupt:
         return 0
@@ -66,7 +72,8 @@ async def _attach(sdk: AISDK, session_id: str, *,
                   read_only: bool,
                   interactive: bool,
                   show_history: bool,
-                  raw: bool) -> int:
+                  raw: bool,
+                  initial_prompt: str | None = None) -> int:
     # Choose the endpoint.  If the user didn't force --read-only and the
     # owner endpoint refuses us with 403, fall back transparently.
     att = sdk.attach_session(session_id, read_only=read_only)
@@ -93,6 +100,13 @@ async def _attach(sdk: AISDK, session_id: str, *,
 
     try:
         async with att:
+            if initial_prompt and not read_only:
+                try:
+                    await att.send_prompt(initial_prompt)
+                except Exception as e:
+                    _err(f"failed to send initial prompt: {e}")
+                    return 1
+
             reader = asyncio.create_task(_reader_loop(
                 att,
                 interactive=interactive and not read_only,

--- a/limacharlie/commands/_ai_attach.py
+++ b/limacharlie/commands/_ai_attach.py
@@ -42,12 +42,17 @@ def run_attach(sdk: AISDK, session_id: str, *,
                interactive: bool,
                show_history: bool,
                raw: bool,
+               verbose: bool = False,
                initial_prompt: str | None = None) -> int:
     """Run the attach session loop.
 
     ``initial_prompt`` is sent as the first message after the WebSocket
     connects.  Used by ``ai chat`` to seed a new session; attach leaves
     it ``None``.
+
+    ``verbose`` disables the default noise filter (plumbing system
+    subtypes, empty assistant/user/result frames, session_status pings)
+    and also prints full ISO timestamps instead of HH:MM:SS.
 
     Returns the process exit code: 0 on clean disconnect, 1 on error.
     """
@@ -58,6 +63,7 @@ def run_attach(sdk: AISDK, session_id: str, *,
             interactive=interactive,
             show_history=show_history,
             raw=raw,
+            verbose=verbose,
             initial_prompt=initial_prompt,
         ))
     except KeyboardInterrupt:
@@ -73,6 +79,7 @@ async def _attach(sdk: AISDK, session_id: str, *,
                   interactive: bool,
                   show_history: bool,
                   raw: bool,
+                  verbose: bool = False,
                   initial_prompt: str | None = None) -> int:
     # Choose the endpoint.  If the user didn't force --read-only and the
     # owner endpoint refuses us with 403, fall back transparently.
@@ -112,6 +119,7 @@ async def _attach(sdk: AISDK, session_id: str, *,
                 interactive=interactive and not read_only,
                 show_history=show_history,
                 raw=raw,
+                verbose=verbose,
             ))
             writer: asyncio.Task | None = None
             if interactive and not read_only:
@@ -140,7 +148,8 @@ async def _attach(sdk: AISDK, session_id: str, *,
 async def _reader_loop(att: SessionAttachment, *,
                        interactive: bool,
                        show_history: bool,
-                       raw: bool) -> None:
+                       raw: bool,
+                       verbose: bool = False) -> None:
     async for msg in att.messages():
         if raw:
             click.echo(json.dumps(msg))
@@ -156,7 +165,9 @@ async def _reader_loop(att: SessionAttachment, *,
                 messages = payload.get("messages") or []
                 _print_banner(f"History ({len(messages)} messages)")
                 for m in messages:
-                    _render_message(m)
+                    if _should_skip_message(m, verbose):
+                        continue
+                    _render_message(m, verbose=verbose)
                 _print_banner("Live stream")
             continue
 
@@ -168,7 +179,8 @@ async def _reader_loop(att: SessionAttachment, *,
             await _handle_question(att, payload)
             continue
 
-        _render_message(msg)
+        if not _should_skip_message(msg, verbose):
+            _render_message(msg, verbose=verbose)
 
         if mtype == MSG_SESSION_END:
             return
@@ -214,14 +226,16 @@ async def _input_loop(att: SessionAttachment) -> None:
 def _read_line_or_eof() -> str | None:
     """Blocking stdin read returning ``None`` on EOF.
 
-    Printed to stderr so it doesn't interleave with stdout messages
-    when the terminal is being driven by another task.
+    We intentionally do NOT print a prompt character before reading.
+    The reader task streams server messages to the terminal
+    concurrently, so any caret we print eagerly ends up on the same
+    line as the next incoming frame (``> [ts] assistant:``) or gets
+    overwritten — the result was inconsistent noise rather than a
+    helpful cue.  The terminal already echoes keystrokes, so users
+    can see what they're typing without a visible prompt; getting a
+    true persistent prompt would need a line-editor library such as
+    ``prompt_toolkit``.
     """
-    try:
-        sys.stderr.write("> ")
-        sys.stderr.flush()
-    except Exception:
-        pass
     line = sys.stdin.readline()
     if not line:
         return None
@@ -309,11 +323,113 @@ async def _handle_question(att: SessionAttachment, payload: dict) -> None:
 # Rendering
 # ---------------------------------------------------------------------------
 
-def _render_message(msg: dict[str, Any]) -> None:
+# System subtypes that are internal plumbing — noisy in the default
+# live stream.  The list matches what the ai-sessions sdk_bridge and
+# the Claude Code SDK emit as "this is what I just configured"
+# housekeeping.  ``ai.py`` also reuses this set for history filtering.
+_NOISY_SYSTEM_SUBTYPES: frozenset[str] = frozenset({
+    # ai-sessions bridge plumbing
+    "credential_diagnostics",
+    "init_received",
+    "claude_md_loaded",
+    "claude_md_error",
+    "user_mcp_servers_loaded",
+    "mcp_config_debug",
+    "mcp_servers_loaded",
+    "mcp_servers_set",
+    "oid_added_to_system_prompt",
+    "ttl_added_to_system_prompt",
+    "unknown_plugin",
+    "plugins_resolved",
+    "autoinit_loaded",
+    "autoinit_error",
+    "resuming_sdk_session",
+    "model_set",
+    "max_turns_set",
+    "max_budget_set",
+    "task_budget_set",
+    "one_shot_mode_set",
+    "permission_mode_set",
+    "tools_configured",
+    "system_prompt_set",
+    "sdk_session_id",
+    "session_patterns_loaded",
+    # Claude SDK passthrough noise
+    "hook_started",
+    "hook_response",
+    "hook_matched",
+})
+
+# Top-level message types treated as plumbing (not user-facing).
+_NOISY_TYPES: frozenset[str] = frozenset({
+    "session_status",
+    "usage_delta",
+    "sdk_session_id",
+})
+
+
+def _should_skip_message(msg: dict[str, Any], verbose: bool) -> bool:
+    """Return True when ``msg`` is plumbing noise we hide by default.
+
+    ``verbose=True`` disables every filter so the user can see the raw
+    firehose.  Skips:
+
+    * Known plumbing message types (session_status, usage_delta, ...).
+    * ``system`` messages whose subtype is in the noisy set.
+    * ``assistant`` frames with no extractable text (tool-use-only
+      turns — the accompanying ``tool_use`` message already renders).
+    * ``user`` frames with no extractable text (tool_result wrappers
+      — the accompanying ``tool_result`` message already renders).
+    * ``result`` frames without a human-readable summary/message.
+    """
+    if verbose:
+        return False
+
     mtype = msg.get("type")
     payload = msg.get("payload") or {}
-    ts = msg.get("timestamp")
-    prefix = f"[{ts}] " if ts else ""
+
+    if mtype in _NOISY_TYPES:
+        return True
+
+    if mtype == MSG_SYSTEM:
+        subtype = payload.get("subtype", "")
+        return subtype in _NOISY_SYSTEM_SUBTYPES
+
+    if mtype == MSG_ASSISTANT:
+        return not _extract_assistant_text(payload).strip()
+
+    if mtype == MSG_USER:
+        return not _extract_user_text(payload).strip()
+
+    if mtype == MSG_RESULT:
+        summary = payload.get("summary") or payload.get("message") or ""
+        return not str(summary).strip()
+
+    return False
+
+
+def _format_timestamp(ts: str | None, verbose: bool) -> str:
+    """Render the incoming ISO timestamp as a prefix.
+
+    Default: ``[HH:MM:SS]`` — enough to eyeball ordering without
+    swamping the line.  ``verbose=True`` preserves the full string so
+    precise correlation with server logs remains possible.
+    """
+    if not ts:
+        return ""
+    if verbose:
+        return f"[{ts}] "
+    # ISO-8601: "YYYY-MM-DDTHH:MM:SS[.frac][+-ZZ:ZZ|Z]".  Grab HH:MM:SS.
+    if "T" in ts:
+        time_part = ts.split("T", 1)[1]
+        return f"[{time_part[:8]}] "
+    return f"[{ts}] "
+
+
+def _render_message(msg: dict[str, Any], *, verbose: bool = False) -> None:
+    mtype = msg.get("type")
+    payload = msg.get("payload") or {}
+    prefix = _format_timestamp(msg.get("timestamp"), verbose)
 
     if mtype == MSG_ASSISTANT:
         text = _extract_assistant_text(payload)
@@ -323,7 +439,7 @@ def _render_message(msg: dict[str, Any]) -> None:
         return
 
     if mtype == MSG_USER:
-        text = payload.get("text", "")
+        text = _extract_user_text(payload)
         click.echo(click.style(f"{prefix}user:", fg="green", bold=True))
         if text:
             click.echo(_indent(text))
@@ -405,19 +521,45 @@ def _render_message(msg: dict[str, Any]) -> None:
 
 
 def _extract_assistant_text(payload: dict) -> str:
+    """Collapse an assistant/user content blocks array into text.
+
+    Returns the concatenation of ``text`` blocks; non-text blocks
+    (tool_use, tool_result, thinking) contribute nothing — a frame
+    that carries only those yields an empty string, which the noise
+    filter uses to drop the redundant "assistant:" header.
+
+    Whitespace-only blocks are dropped and leading/trailing whitespace
+    is stripped from the final result: Claude's first reply of a turn
+    often opens with a couple of ``\\n`` characters that otherwise
+    render as blank indented lines under the ``assistant:`` header.
+    """
     content = payload.get("content")
     if isinstance(content, str):
-        return content
+        return content.strip()
     if isinstance(content, list):
         parts: list[str] = []
         for block in content:
             if isinstance(block, dict):
                 if block.get("type") == "text":
                     parts.append(block.get("text", ""))
-                elif "text" in block:
+                elif "text" in block and block.get("type") not in {"tool_use", "tool_result"}:
                     parts.append(str(block["text"]))
-        return "\n".join(p for p in parts if p)
-    return str(content or "")
+        return "\n".join(p for p in parts if p.strip()).strip()
+    return str(content or "").strip()
+
+
+def _extract_user_text(payload: dict) -> str:
+    """Pull the human-readable text from a ``user`` payload.
+
+    The server wraps prompt turns as ``{"content": [blocks...]}`` (same
+    shape as assistant messages), but older tests and a few code paths
+    still pass ``{"text": "..."}``; accept both so nothing regresses.
+    Tool-result wrappers (no text blocks) collapse to ``""``, which
+    the noise filter uses to drop them.
+    """
+    if "text" in payload and "content" not in payload:
+        return str(payload.get("text") or "")
+    return _extract_assistant_text(payload)
 
 
 # ---------------------------------------------------------------------------

--- a/limacharlie/commands/ai.py
+++ b/limacharlie/commands/ai.py
@@ -464,12 +464,18 @@ group.add_command(session_group)
 # ---------------------------------------------------------------------------
 
 _EXPLAIN_SESSION_LIST = """\
-List AI sessions for the organization.  By default all sessions are
-returned; use --status to filter by state.
+List AI sessions for the organization.  By default every matching
+session is returned; pagination is drained automatically.
 
 Statuses: running, starting, ended.
 
-Pagination is supported via --limit and --cursor.
+Flags:
+  --status   Filter by session status.
+  --limit    Total cap on returned sessions (default: unlimited).
+  --cursor   Fetch a single page starting from this cursor.  Switches
+             output to a raw {sessions, next_cursor} dict so callers
+             can resume pagination explicitly.  Intended for scripted
+             / streaming access; most users should omit this flag.
 
 The initial_prompt field is truncated in the listing.  Use
 'ai session get --id <ID>' to see the full prompt.
@@ -478,23 +484,32 @@ Example:
   limacharlie ai session list
   limacharlie ai session list --status running
   limacharlie ai session list --limit 10
+  limacharlie ai session list --cursor <CURSOR>
 """
 register_explain("ai.session.list", _EXPLAIN_SESSION_LIST)
 
 
 @session_group.command("list")
 @click.option("--status", default=None, help="Filter by session status (running, starting, ended).")
-@click.option("--limit", default=None, type=int, help="Max results per page (1-200, default 50).")
-@click.option("--cursor", default=None, help="Pagination cursor from a previous response.")
+@click.option("--limit", default=None, type=int,
+              help="Total cap on returned sessions (or per-page size if --cursor is given).")
+@click.option("--cursor", default=None,
+              help="Fetch a single page from this cursor; disables auto-drain.")
 @pass_context
 def session_list(ctx, status, limit, cursor) -> None:
     org = _get_org(ctx)
     sdk = AISDK(org)
-    data = sdk.list_sessions(status=status, limit=limit, cursor=cursor)
-    # Truncate prompts in the listing to keep output readable.
-    if "sessions" in data:
-        data["sessions"] = [_clean_session_for_list(s) for s in data["sessions"]]
-    _output(ctx, data)
+    if cursor is not None:
+        # Explicit pagination: single page, raw response so the caller
+        # can grab next_cursor.
+        data = sdk.list_sessions_page(status=status, limit=limit, cursor=cursor)
+        if "sessions" in data:
+            data["sessions"] = [_clean_session_for_list(s) for s in data["sessions"]]
+        _output(ctx, data)
+        return
+    sessions = [_clean_session_for_list(s)
+                for s in sdk.list_sessions(status=status, limit=limit)]
+    _output(ctx, sessions)
 
 
 # ---------------------------------------------------------------------------
@@ -1037,18 +1052,30 @@ group.add_command(chats_group)
 @click.option("--status", default=None,
               help="Filter by session status (running, starting, ended).")
 @click.option("--limit", default=None, type=int,
-              help="Max results per page.")
+              help="Total cap on returned sessions (or per-page size if --cursor is given).")
 @click.option("--cursor", default=None,
-              help="Pagination cursor from a previous response.")
+              help="Fetch a single page from this cursor; disables auto-drain.")
 @pass_context
 def chats_list(ctx, status, limit, cursor) -> None:
-    """List the authenticated user's AI sessions."""
+    """List the authenticated user's AI sessions.
+
+    By default every matching session is returned; pagination is
+    drained automatically.  Pass --cursor to fetch a single page and
+    receive the raw {sessions, next_cursor} dict for explicit
+    pagination control (intended for scripted access).
+    """
     org = _get_org(ctx)
     sdk = AISDK(org)
-    data = sdk.list_user_sessions(status=status, limit=limit, cursor=cursor)
-    if "sessions" in data:
-        data["sessions"] = [_clean_session_for_list(s) for s in data["sessions"]]
-    _output(ctx, data)
+    if cursor is not None:
+        data = sdk.list_user_sessions_page(status=status, limit=limit,
+                                           cursor=cursor)
+        if "sessions" in data:
+            data["sessions"] = [_clean_session_for_list(s) for s in data["sessions"]]
+        _output(ctx, data)
+        return
+    sessions = [_clean_session_for_list(s)
+                for s in sdk.list_user_sessions(status=status, limit=limit)]
+    _output(ctx, sessions)
 
 
 # ---------------------------------------------------------------------------

--- a/limacharlie/commands/ai.py
+++ b/limacharlie/commands/ai.py
@@ -589,31 +589,20 @@ Example:
 """
 register_explain("ai.session.history", _EXPLAIN_SESSION_HISTORY)
 
-# System subtypes that are internal plumbing, not useful conversation.
-_SYSTEM_INIT_SUBTYPES = frozenset({
-    "credential_diagnostics",
-    "init_received",
-    "claude_md_loaded",
-    "mcp_config_debug",
-    "mcp_servers_set",
-    "model_set",
-    "max_turns_set",
-    "max_budget_set",
-    "oid_added_to_system_prompt",
-    "permission_mode_set",
-    "tools_configured",
-    "system_prompt_set",
-    "sdk_session_id",
-})
-
-
 def _filter_history(messages: list[dict]) -> list[dict]:
-    """Remove internal system init messages from history."""
+    """Remove internal system init messages from history.
+
+    Reuses the single source-of-truth noise set defined alongside the
+    live-stream renderer in ``_ai_attach`` so both surfaces hide the
+    same plumbing subtypes.
+    """
+    from ._ai_attach import _NOISY_SYSTEM_SUBTYPES
+
     filtered = []
     for m in messages:
         if m.get("type") == "system":
             payload = m.get("payload", {})
-            if isinstance(payload, dict) and payload.get("subtype") in _SYSTEM_INIT_SUBTYPES:
+            if isinstance(payload, dict) and payload.get("subtype") in _NOISY_SYSTEM_SUBTYPES:
                 continue
         filtered.append(m)
     return filtered
@@ -684,8 +673,10 @@ register_explain("ai.session.attach", _EXPLAIN_SESSION_ATTACH)
               help="Don't render the initial history block on connect.")
 @click.option("--raw", is_flag=True, default=False,
               help="Print raw JSON messages instead of pretty formatting.")
+@click.option("--verbose", "-v", is_flag=True, default=False,
+              help="Show plumbing system/status messages and full ISO timestamps.")
 @pass_context
-def session_attach(ctx, session_id, read_only, interactive, no_history, raw) -> None:
+def session_attach(ctx, session_id, read_only, interactive, no_history, raw, verbose) -> None:
     from ._ai_attach import run_attach
 
     org = _get_org(ctx)
@@ -696,6 +687,7 @@ def session_attach(ctx, session_id, read_only, interactive, no_history, raw) -> 
         interactive=interactive,
         show_history=not no_history,
         raw=raw,
+        verbose=verbose,
     )
     ctx.exit(exit_code)
 
@@ -959,10 +951,12 @@ register_explain("ai.chat", _EXPLAIN_CHAT)
               help="Repeatable. Plugin names to enable.")
 @click.option("--idempotent-key", default=None,
               help="Deduplication key for session creation.")
+@click.option("--verbose", "-v", is_flag=True, default=False,
+              help="Show plumbing system/status messages and full ISO timestamps.")
 @pass_context
 def chat(ctx, prompt, name, model, max_turns, max_budget_usd,
          task_budget_tokens, permission_mode,
-         allowed_tools, denied_tools, plugins, idempotent_key) -> None:
+         allowed_tools, denied_tools, plugins, idempotent_key, verbose) -> None:
     from ._ai_attach import run_attach
 
     org = _get_org(ctx)
@@ -1020,6 +1014,7 @@ def chat(ctx, prompt, name, model, max_turns, max_budget_usd,
         interactive=True,
         show_history=False,
         raw=False,
+        verbose=verbose,
         initial_prompt=initial_prompt,
     )
     ctx.exit(exit_code)

--- a/limacharlie/commands/ai.py
+++ b/limacharlie/commands/ai.py
@@ -948,7 +948,6 @@ register_explain("ai.chat", _EXPLAIN_CHAT)
 def chat(ctx, prompt, name, model, max_turns, max_budget_usd,
          task_budget_tokens, permission_mode,
          allowed_tools, denied_tools, plugins, idempotent_key) -> None:
-    import sys
     from ._ai_attach import run_attach
 
     org = _get_org(ctx)
@@ -969,13 +968,11 @@ def chat(ctx, prompt, name, model, max_turns, max_budget_usd,
     # set-key` without a separate step.
     sdk.register_user()
 
-    # If no prompt argument was supplied and stdin is a pipe, consume
-    # it as the opening prompt so `echo ... | ai chat` works.
+    # The opening prompt is the PROMPT argument; further turns come
+    # from interactive stdin once the session is attached.  We do NOT
+    # consume stdin as the prompt: piping multiple lines used to glue
+    # them into one prompt and then leave stdin empty for follow-ups.
     initial_prompt = prompt
-    if initial_prompt is None and not sys.stdin.isatty():
-        data = sys.stdin.read().strip()
-        if data:
-            initial_prompt = data
 
     plugins_override: list[str] | None = list(plugins) if plugins else None
 
@@ -1011,3 +1008,99 @@ def chat(ctx, prompt, name, model, max_turns, max_budget_usd,
         initial_prompt=initial_prompt,
     )
     ctx.exit(exit_code)
+
+
+# ===========================================================================
+# chats subgroup – manage user-owned sessions (the counterpart to
+# `ai session`, which manages org-owned sessions).  Mirrors the org
+# commands one-for-one but routes through the user-scoped REST API.
+# ===========================================================================
+
+@click.group("chats")
+def chats_group() -> None:
+    """Manage user-owned AI sessions (started via ``ai chat``).
+
+    The ``ai session`` group manages org-owned sessions (started via
+    ``ai start-session``); this group is the same surface for the
+    user-owned sessions that ``ai chat`` creates.  Sessions of one
+    kind are not visible from the other group's commands.
+    """
+
+group.add_command(chats_group)
+
+
+# ---------------------------------------------------------------------------
+# chats list
+# ---------------------------------------------------------------------------
+
+@chats_group.command("list")
+@click.option("--status", default=None,
+              help="Filter by session status (running, starting, ended).")
+@click.option("--limit", default=None, type=int,
+              help="Max results per page.")
+@click.option("--cursor", default=None,
+              help="Pagination cursor from a previous response.")
+@pass_context
+def chats_list(ctx, status, limit, cursor) -> None:
+    """List the authenticated user's AI sessions."""
+    org = _get_org(ctx)
+    sdk = AISDK(org)
+    data = sdk.list_user_sessions(status=status, limit=limit, cursor=cursor)
+    if "sessions" in data:
+        data["sessions"] = [_clean_session_for_list(s) for s in data["sessions"]]
+    _output(ctx, data)
+
+
+# ---------------------------------------------------------------------------
+# chats get
+# ---------------------------------------------------------------------------
+
+@chats_group.command("get")
+@click.option("--id", "session_id", required=True, help="Session ID.")
+@click.option("--full-prompt", is_flag=True, default=False,
+              help="Include the full initial_prompt text.")
+@pass_context
+def chats_get(ctx, session_id, full_prompt) -> None:
+    """Get details of one of the user's AI sessions."""
+    org = _get_org(ctx)
+    sdk = AISDK(org)
+    data = sdk.get_user_session(session_id)
+    if not full_prompt and "session" in data:
+        s = data["session"]
+        if isinstance(s, dict) and "initial_prompt" in s:
+            s["initial_prompt"] = _truncate_prompt(s["initial_prompt"])
+    _output(ctx, data)
+
+
+# ---------------------------------------------------------------------------
+# chats terminate
+# ---------------------------------------------------------------------------
+
+@chats_group.command("terminate")
+@click.option("--id", "session_id", required=True,
+              help="Session ID to terminate.")
+@pass_context
+def chats_terminate(ctx, session_id) -> None:
+    """Terminate one of the user's running AI sessions."""
+    org = _get_org(ctx)
+    sdk = AISDK(org)
+    _output(ctx, sdk.terminate_user_session(session_id))
+
+
+# ---------------------------------------------------------------------------
+# chats history
+# ---------------------------------------------------------------------------
+
+@chats_group.command("history")
+@click.option("--id", "session_id", required=True, help="Session ID.")
+@click.option("--raw", is_flag=True, default=False,
+              help="Include all messages including internal system init.")
+@pass_context
+def chats_history(ctx, session_id, raw) -> None:
+    """Show the conversation history of one of the user's AI sessions."""
+    org = _get_org(ctx)
+    sdk = AISDK(org)
+    data = sdk.get_user_session_history(session_id)
+    if not raw and "messages" in data:
+        data["messages"] = _filter_history(data["messages"])
+    _output(ctx, data)

--- a/limacharlie/commands/ai.py
+++ b/limacharlie/commands/ai.py
@@ -742,3 +742,268 @@ def usage_get(ctx, identity) -> None:
     sdk = AISDK(org)
     data = sdk.get_usage(identity)
     _output(ctx, data)
+
+
+# ===========================================================================
+# auth subgroup – per-user Claude credential management
+#
+# The `ai chat` command runs user-owned sessions, which require the
+# caller to have Claude credentials (OAuth token or Anthropic API key)
+# stored server-side.  `ai start-session` and its org-owned workflow
+# are unaffected — those use an anthropic_secret from the ai_agent
+# template and do not depend on these commands.
+# ===========================================================================
+
+@click.group("auth")
+def auth_group() -> None:
+    """Manage per-user credentials for AI sessions.
+
+    The ``claude`` subgroup stores the Anthropic credential that
+    user-owned sessions (``ai chat``) use to talk to Claude.  Org-owned
+    sessions (``ai start-session``) ignore these and use the template's
+    ``anthropic_secret`` instead.
+    """
+
+group.add_command(auth_group)
+
+
+@click.group("claude")
+def claude_auth_group() -> None:
+    """Manage the authenticated user's stored Anthropic credential."""
+
+auth_group.add_command(claude_auth_group)
+
+
+# ---------------------------------------------------------------------------
+# auth claude status
+# ---------------------------------------------------------------------------
+
+@claude_auth_group.command("status")
+@pass_context
+def claude_auth_status(ctx) -> None:
+    """Show whether the authenticated user has Claude credentials stored."""
+    org = _get_org(ctx)
+    sdk = AISDK(org)
+    _output(ctx, sdk.claude_auth_status())
+
+
+# ---------------------------------------------------------------------------
+# auth claude login  (interactive browser OAuth flow)
+# ---------------------------------------------------------------------------
+
+_CLAUDE_OAUTH_POLL_SECONDS = 2.0
+_CLAUDE_OAUTH_POLL_TIMEOUT = 120.0
+
+
+@claude_auth_group.command("login")
+@pass_context
+def claude_auth_login(ctx) -> None:
+    """Run the interactive browser OAuth flow to store a Claude token.
+
+    Starts a server-side OAuth job, prints the URL to visit in your
+    browser, and prompts for the authorization code returned by Claude.
+    On success the credential is stored server-side and usable by
+    ``ai chat``.
+    """
+    import time
+
+    org = _get_org(ctx)
+    sdk = AISDK(org)
+
+    start = sdk.claude_login_start()
+    oauth_session_id = start.get("oauth_session_id")
+    if not oauth_session_id:
+        raise click.ClickException(
+            f"server returned no oauth_session_id: {start}"
+        )
+
+    # Poll until the URL is ready.
+    url = None
+    deadline = time.monotonic() + _CLAUDE_OAUTH_POLL_TIMEOUT
+    while time.monotonic() < deadline:
+        resp = sdk.claude_login_get_url(oauth_session_id)
+        status = resp.get("status")
+        if status == "ready" and resp.get("url"):
+            url = resp["url"]
+            break
+        if status == "failed":
+            raise click.ClickException(
+                f"OAuth flow failed: {resp.get('error') or resp.get('message')}"
+            )
+        time.sleep(_CLAUDE_OAUTH_POLL_SECONDS)
+    if url is None:
+        raise click.ClickException(
+            "timed out waiting for OAuth URL from server"
+        )
+
+    click.echo("Open this URL in your browser, approve, then paste the code below:")
+    click.echo(f"  {url}")
+    code = click.prompt("Code", hide_input=True)
+
+    result = sdk.claude_login_submit_code(oauth_session_id, code)
+    if not result.get("success"):
+        raise click.ClickException(
+            f"server rejected OAuth code: {result.get('error') or result.get('message')}"
+        )
+    _output(ctx, result)
+
+
+# ---------------------------------------------------------------------------
+# auth claude set-key  (non-interactive, direct API key)
+# ---------------------------------------------------------------------------
+
+@claude_auth_group.command("set-key")
+@click.option("--key", default=None,
+              help="Anthropic API key. Literal value or hive://secret/<name>. "
+                   "Mutually exclusive with --key-from-stdin.")
+@click.option("--key-from-stdin", is_flag=True, default=False,
+              help="Read the API key from stdin (useful for piping).")
+@pass_context
+def claude_auth_set_key(ctx, key, key_from_stdin) -> None:
+    """Store a raw Anthropic API key for the authenticated user."""
+    import sys
+
+    if key and key_from_stdin:
+        raise click.UsageError("--key and --key-from-stdin are mutually exclusive")
+    if not key and not key_from_stdin:
+        raise click.UsageError("one of --key or --key-from-stdin is required")
+    if key_from_stdin:
+        key = sys.stdin.read().strip()
+    if not key:
+        raise click.UsageError("API key is empty")
+
+    org = _get_org(ctx)
+    sdk = AISDK(org)
+    _output(ctx, sdk.claude_set_apikey(key))
+
+
+# ---------------------------------------------------------------------------
+# auth claude logout
+# ---------------------------------------------------------------------------
+
+@claude_auth_group.command("logout")
+@pass_context
+def claude_auth_logout(ctx) -> None:
+    """Remove the authenticated user's stored Claude credential."""
+    org = _get_org(ctx)
+    sdk = AISDK(org)
+    _output(ctx, sdk.claude_logout())
+
+
+# ===========================================================================
+# chat – user-owned interactive session
+# ===========================================================================
+
+_EXPLAIN_CHAT = """\
+Create a fresh user-owned AI session and drop into an interactive
+chat.  Unlike 'ai start-session' (which runs an ai_agent template
+on behalf of the organization), this command starts a blank session
+owned by the authenticated user and streams an interactive WebSocket
+conversation over it.
+
+Prerequisites:
+  * The user must have stored a Claude credential.  Run one of:
+      limacharlie ai auth claude login        # browser OAuth
+      limacharlie ai auth claude set-key ...  # raw API key
+
+Billing and credentials:
+  * Sessions created here bill against the caller's registered Claude
+    credential (OAuth token or API key), not the org's anthropic_secret.
+
+Supplying a prompt on the command line (argument or via stdin) seeds
+the session; you can keep chatting afterwards by typing into stdin.
+'/interrupt' and '/quit' behave as in 'ai session attach'.
+
+Example:
+  limacharlie ai chat "what sensors do I have in the last 24h?"
+  echo "summarise today's detections" | limacharlie ai chat
+  limacharlie ai chat --model claude-sonnet-4-6 --max-budget-usd 1.00
+"""
+register_explain("ai.chat", _EXPLAIN_CHAT)
+
+
+@group.command("chat")
+@click.argument("prompt", required=False)
+@click.option("--name", default=None, help="Session name.")
+@click.option("--model", default=None,
+              help="Anthropic model (e.g. claude-sonnet-4-6).")
+@click.option("--max-turns", default=None, type=int,
+              help="Maximum number of agent turns before auto-stop.")
+@click.option("--max-budget-usd", default=None, type=float,
+              help="Hard USD cost cap for the session.")
+@click.option("--task-budget-tokens", default=None, type=int,
+              help="Per-task token budget.")
+@click.option("--permission-mode", default=None,
+              type=click.Choice(["acceptEdits", "plan", "bypassPermissions"]),
+              help="Permission mode for tool use.")
+@click.option("--allowed-tools", default=None,
+              help="Comma-separated list of allowed tool names.")
+@click.option("--denied-tools", default=None,
+              help="Comma-separated list of denied tool names.")
+@click.option("--plugin", "plugins", multiple=True,
+              help="Repeatable. Plugin names to enable.")
+@click.option("--idempotent-key", default=None,
+              help="Deduplication key for session creation.")
+@pass_context
+def chat(ctx, prompt, name, model, max_turns, max_budget_usd,
+         task_budget_tokens, permission_mode,
+         allowed_tools, denied_tools, plugins, idempotent_key) -> None:
+    import sys
+    from ._ai_attach import run_attach
+
+    org = _get_org(ctx)
+    sdk = AISDK(org)
+
+    # Verify the user has Claude credentials before spending effort
+    # creating a session that would immediately fail.
+    status = sdk.claude_auth_status()
+    if not status.get("has_credentials"):
+        raise click.ClickException(
+            "No Claude credentials registered for this user. Run one of:\n"
+            "  limacharlie ai auth claude login\n"
+            "  limacharlie ai auth claude set-key --key <ANTHROPIC_API_KEY>"
+        )
+
+    # Register is idempotent server-side; calling it here lets a
+    # first-time user run `ai chat` immediately after `auth claude
+    # set-key` without a separate step.
+    sdk.register_user()
+
+    # If no prompt argument was supplied and stdin is a pipe, consume
+    # it as the opening prompt so `echo ... | ai chat` works.
+    initial_prompt = prompt
+    if initial_prompt is None and not sys.stdin.isatty():
+        data = sys.stdin.read().strip()
+        if data:
+            initial_prompt = data
+
+    plugins_override: list[str] | None = list(plugins) if plugins else None
+
+    created = sdk.create_user_session(
+        name=name,
+        idempotent_key=idempotent_key,
+        model=model,
+        max_turns=max_turns,
+        max_budget_usd=max_budget_usd,
+        task_budget_tokens=task_budget_tokens,
+        permission_mode=permission_mode,
+        allowed_tools=_split_csv(allowed_tools),
+        denied_tools=_split_csv(denied_tools),
+        plugins=plugins_override,
+    )
+    session_id = created.get("id") or created.get("session_id")
+    if not session_id:
+        raise click.ClickException(
+            f"server response missing session id: {created}"
+        )
+    click.echo(f"Started session {session_id}", err=True)
+
+    exit_code = run_attach(
+        sdk, session_id,
+        read_only=False,
+        interactive=True,
+        show_history=False,
+        raw=False,
+        initial_prompt=initial_prompt,
+    )
+    ctx.exit(exit_code)

--- a/limacharlie/commands/ai.py
+++ b/limacharlie/commands/ai.py
@@ -991,7 +991,11 @@ def chat(ctx, prompt, name, model, max_turns, max_budget_usd,
         denied_tools=_split_csv(denied_tools),
         plugins=plugins_override,
     )
-    session_id = created.get("id") or created.get("session_id")
+    # The POST /v1/sessions handler returns the session under a
+    # "session" key (same shape as `ai session get`).  Fall back to a
+    # top-level id for forward compatibility if that ever changes.
+    session_obj = created.get("session") or created
+    session_id = session_obj.get("id") or session_obj.get("session_id")
     if not session_id:
         raise click.ClickException(
             f"server response missing session id: {created}"

--- a/limacharlie/commands/ai.py
+++ b/limacharlie/commands/ai.py
@@ -263,48 +263,169 @@ def summarize_detection(ctx, detection_id) -> None:
 # ---------------------------------------------------------------------------
 
 _EXPLAIN_START_SESSION = """\
-Start an AI session using an ai_agent Hive definition.  The definition
-contains the full session configuration including prompt, model,
-credentials (as hive://secret/ references), tool permissions, and
-MCP server configs.
+Start an AI session using an ai_agent Hive definition as a TEMPLATE.
 
-All hive://secret/ references in the definition are resolved
-automatically before the session is created.
+The hive record named by --definition supplies all the default session
+configuration: prompt, model, credentials (as hive://secret/
+references), tool permissions, MCP servers, environment, budgets, and
+so on.  Any --option flag below overrides the matching field from the
+template; the rest of the template is used as-is.
 
-When starting a session from the CLI (as opposed to a D&R rule),
-there is no event to apply the definition's data transform to.
-Use --data to supply a JSON dictionary that will be appended to
-the prompt as event data.
+This lets you reuse one ai_agent definition as a starting point and
+vary only the bits you need per-run (swap the prompt, cap the budget,
+change the model, add an env var, etc.).
 
-Example:
+Override rules:
+  * Scalars and lists REPLACE the template value when supplied.
+  * --env values are MERGED with the template's environment (override
+    values win on key collisions).
+  * Omitted flags leave the template's value untouched.
+  * Override values may be "hive://secret/<name>" refs (resolved
+    before sending), matching D&R rule semantics.
+
+All hive://secret/ references (in the template or in overrides) are
+resolved automatically before the request is sent.
+
+When starting a session from the CLI there is no D&R event; use --data
+to supply a JSON dictionary that will be appended to the prompt as
+event data.
+
+Examples:
   limacharlie ai start-session --definition my-security-analyst
 
+  # Reuse the template but swap the prompt.
   limacharlie ai start-session --definition my-agent \\
     --prompt "Investigate this specific alert" \\
     --name "Alert investigation"
 
+  # Cap budget and force a specific model on top of the template.
   limacharlie ai start-session --definition my-agent \\
-    --data '{"hostname": "srv-01", "alert_id": "abc-123"}'
+    --model claude-sonnet-4-6 --max-budget-usd 2.50
+
+  # Add an env var on top of the template.
+  limacharlie ai start-session --definition my-agent \\
+    --env SLACK_WEBHOOK=hive://secret/slack-webhook
+
+  # Restrict tools for this run only.
+  limacharlie ai start-session --definition my-agent \\
+    --allowed-tools Read,Grep --denied-tools Bash,Write
 """
 register_explain("ai.start-session", _EXPLAIN_START_SESSION)
 
 
+def _split_csv(value: str | None) -> list[str] | None:
+    """Split a comma-separated CLI value into a list.
+
+    Empty/whitespace-only segments are dropped.  Returns ``None`` when
+    the caller did not pass the flag at all, so the SDK sees "no
+    override" rather than "override with []".
+    """
+    if value is None:
+        return None
+    parts = [p.strip() for p in value.split(",")]
+    return [p for p in parts if p]
+
+
+def _parse_env_kv(items: tuple[str, ...]) -> dict[str, str] | None:
+    """Parse ``--env KEY=VALUE`` pairs into a dict.
+
+    Returns ``None`` when no ``--env`` flag was passed so the SDK
+    doesn't clobber the template's environment with an empty dict.
+    """
+    if not items:
+        return None
+    env: dict[str, str] = {}
+    for item in items:
+        if "=" not in item:
+            raise click.BadParameter(
+                f"--env value '{item}' must be in KEY=VALUE form",
+                param_hint="--env",
+            )
+        key, _, value = item.partition("=")
+        key = key.strip()
+        if not key:
+            raise click.BadParameter(
+                f"--env value '{item}' has empty key",
+                param_hint="--env",
+            )
+        env[key] = value
+    return env
+
+
 @group.command("start-session")
-@click.option("--definition", required=True, help="Name of the ai_agent hive record to use.")
-@click.option("--prompt", default=None, help="Override the prompt from the definition.")
-@click.option("--name", default=None, help="Override the session name.")
+@click.option("--definition", required=True,
+              help="Name of the ai_agent hive record to use as template.")
+@click.option("--prompt", default=None, help="Replace the prompt from the definition.")
+@click.option("--name", default=None, help="Replace the session name.")
 @click.option("--idempotent-key", default=None, help="Deduplication key for the session.")
 @click.option("--data", default=None, help="JSON dictionary of data to include with the session prompt.")
+# Profile field overrides.
+@click.option("--model", default=None,
+              help="Replace the Anthropic model (e.g. claude-sonnet-4-6).")
+@click.option("--max-turns", default=None, type=int,
+              help="Replace the maximum number of agent turns.")
+@click.option("--max-budget-usd", default=None, type=float,
+              help="Replace the hard USD cost cap (positive float).")
+@click.option("--task-budget-tokens", default=None, type=int,
+              help="Replace the per-task token budget.")
+@click.option("--ttl-seconds", default=None, type=int,
+              help="Replace the session time-to-live in seconds.")
+@click.option("--one-shot/--no-one-shot", "one_shot", default=None,
+              help="Force one_shot on or off; omit to keep the template value.")
+@click.option("--permission-mode", default=None,
+              type=click.Choice(["acceptEdits", "plan", "bypassPermissions"]),
+              help="Replace the permission mode.")
+@click.option("--allowed-tools", default=None,
+              help="Comma-separated list of tool names that REPLACES the template's allowed_tools.")
+@click.option("--denied-tools", default=None,
+              help="Comma-separated list of tool names that REPLACES the template's denied_tools.")
+@click.option("--plugin", "plugins", multiple=True,
+              help="Repeatable. Replaces the template's plugins list with the values given.")
+@click.option("--env", "env_pairs", multiple=True,
+              help="Repeatable KEY=VALUE pair merged into the template's environment. "
+                   "VALUE may be hive://secret/<name>.")
+# Credential overrides.
+@click.option("--anthropic-key", default=None,
+              help="Replace anthropic_secret. Literal key or hive://secret/<name>.")
+@click.option("--lc-api-key", default=None,
+              help="Replace lc_api_key_secret. Literal key or hive://secret/<name>.")
+@click.option("--lc-uid", default=None,
+              help="Replace lc_uid_secret. Literal UID or hive://secret/<name>.")
 @pass_context
-def start_session(ctx, definition, prompt, name, idempotent_key, data) -> None:
+def start_session(ctx, definition, prompt, name, idempotent_key, data,
+                  model, max_turns, max_budget_usd, task_budget_tokens,
+                  ttl_seconds, one_shot, permission_mode,
+                  allowed_tools, denied_tools, plugins, env_pairs,
+                  anthropic_key, lc_api_key, lc_uid) -> None:
     import json as _json
     parsed_data = None
     if data is not None:
         parsed_data = _json.loads(data)
+    plugins_override: list[str] | None = list(plugins) if plugins else None
+    environment_override = _parse_env_kv(env_pairs)
     org = _get_org(ctx)
     sdk = AISDK(org)
-    result = sdk.start_session(definition, prompt=prompt, name=name,
-                               idempotent_key=idempotent_key, data=parsed_data)
+    result = sdk.start_session(
+        definition,
+        prompt=prompt,
+        name=name,
+        idempotent_key=idempotent_key,
+        data=parsed_data,
+        model=model,
+        max_turns=max_turns,
+        max_budget_usd=max_budget_usd,
+        task_budget_tokens=task_budget_tokens,
+        ttl_seconds=ttl_seconds,
+        one_shot=one_shot,
+        permission_mode=permission_mode,
+        allowed_tools=_split_csv(allowed_tools),
+        denied_tools=_split_csv(denied_tools),
+        plugins=plugins_override,
+        environment=environment_override,
+        anthropic_key=anthropic_key,
+        lc_api_key=lc_api_key,
+        lc_uid=lc_uid,
+    )
     _output(ctx, result)
 
 

--- a/limacharlie/commands/ai.py
+++ b/limacharlie/commands/ai.py
@@ -496,6 +496,74 @@ def session_history(ctx, session_id, raw) -> None:
     _output(ctx, data)
 
 
+# ---------------------------------------------------------------------------
+# session attach
+# ---------------------------------------------------------------------------
+
+_EXPLAIN_SESSION_ATTACH = """\
+Attach to an AI session and stream its messages live over WebSocket.
+
+Two endpoints are exposed by ai-sessions:
+
+  * owner-interactive - /v1/sessions/{id}/ws
+    The authenticated user must own the session.  With --interactive
+    the terminal becomes a chat: type a line and press Enter to send
+    a prompt.  Tool approval requests and questions from the agent
+    are surfaced as interactive prompts.
+
+  * org-scoped read-only - /v1/org/sessions/{id}/ws
+    Requires the ai_agent.get permission on the session's owner org.
+    Use --read-only to connect here directly.  Input is disabled.
+
+If the owner endpoint returns 403 the command automatically falls
+back to the read-only endpoint.
+
+In the interactive input loop:
+  * an empty line is ignored
+  * '/interrupt' sends an interrupt message to the agent
+  * '/quit' detaches from the session
+
+Messages are colour-coded by type.  --raw dumps each message as JSON
+instead, which is useful for piping to another tool.
+
+By default a history block is rendered on connect (the messages that
+preceded your attach).  Use --no-history to skip it.
+
+Example:
+  limacharlie ai session attach --id <SESSION_ID>
+  limacharlie ai session attach --id <SESSION_ID> --interactive
+  limacharlie ai session attach --id <SESSION_ID> --read-only
+  limacharlie ai session attach --id <SESSION_ID> --raw | jq .
+"""
+register_explain("ai.session.attach", _EXPLAIN_SESSION_ATTACH)
+
+
+@session_group.command("attach")
+@click.option("--id", "session_id", required=True, help="Session ID to attach to.")
+@click.option("--read-only", is_flag=True, default=False,
+              help="Use the org-scoped read-only WebSocket endpoint.")
+@click.option("--interactive", "-i", is_flag=True, default=False,
+              help="Enable interactive input (sends stdin lines as prompts).")
+@click.option("--no-history", is_flag=True, default=False,
+              help="Don't render the initial history block on connect.")
+@click.option("--raw", is_flag=True, default=False,
+              help="Print raw JSON messages instead of pretty formatting.")
+@pass_context
+def session_attach(ctx, session_id, read_only, interactive, no_history, raw) -> None:
+    from ._ai_attach import run_attach
+
+    org = _get_org(ctx)
+    sdk = AISDK(org)
+    exit_code = run_attach(
+        sdk, session_id,
+        read_only=read_only,
+        interactive=interactive,
+        show_history=not no_history,
+        raw=raw,
+    )
+    ctx.exit(exit_code)
+
+
 # ===========================================================================
 # usage subgroup – AI session usage tracking
 # ===========================================================================

--- a/limacharlie/sdk/ai.py
+++ b/limacharlie/sdk/ai.py
@@ -40,54 +40,142 @@ class AI:
             return m
         return {k: self._resolve_secret(v) for k, v in m.items()}
 
+    # Fields copied verbatim from an ai_agent hive record into the
+    # request's ``profile`` section.  Every entry in this tuple maps
+    # one-to-one to a field on the server's ``ProfileContent`` type
+    # (see ai-sessions/pkg/api/types.go).
+    _PROFILE_SCALAR_FIELDS: tuple[str, ...] = (
+        "allowed_tools", "denied_tools", "permission_mode",
+        "model", "max_turns", "max_budget_usd", "task_budget_tokens",
+        "ttl_seconds", "one_shot", "plugins",
+    )
+
     def start_session(self, definition_name: str, prompt: str | None = None,
                       name: str | None = None,
                       idempotent_key: str | None = None,
-                      data: dict[str, Any] | None = None) -> dict[str, Any]:
-        """Start an AI session using an ai_agent Hive definition.
+                      data: dict[str, Any] | None = None,
+                      *,
+                      model: str | None = None,
+                      max_turns: int | None = None,
+                      max_budget_usd: float | None = None,
+                      task_budget_tokens: int | None = None,
+                      ttl_seconds: int | None = None,
+                      one_shot: bool | None = None,
+                      permission_mode: str | None = None,
+                      allowed_tools: list[str] | None = None,
+                      denied_tools: list[str] | None = None,
+                      plugins: list[str] | None = None,
+                      environment: dict[str, str] | None = None,
+                      anthropic_key: str | None = None,
+                      lc_api_key: str | None = None,
+                      lc_uid: str | None = None) -> dict[str, Any]:
+        """Start an AI session using an ai_agent Hive definition as template.
+
+        The definition stored in the ``ai_agent`` hive is treated as a
+        template.  Any keyword arguments supplied here override the
+        corresponding fields from the template.  ``environment`` is
+        *merged* (override values win for matching keys); all other
+        overrides *replace* the template value outright.
+
+        Override values may be literal strings or ``hive://secret/<name>``
+        references (same semantics as D&R rules); references are
+        resolved automatically before the request is sent.
 
         Args:
-            definition_name: Name of the ai_agent hive record.
-            prompt: Override the prompt from the definition.
-            name: Override the session name.
-            idempotent_key: Optional deduplication key.
-            data: Optional data dictionary to append to the prompt.
-                  When the session is started from a D&R rule the definition's
-                  ``data`` transform extracts fields from the event.  When
-                  starting standalone from the CLI there is no event, so this
-                  parameter lets the caller supply the data directly.
+            definition_name: Name of the ai_agent hive record to use as template.
+            prompt: Replace the prompt from the definition.
+            name: Replace the session name.
+            idempotent_key: Deduplication key.
+            data: Dict appended to the prompt as yaml event data (for
+                standalone CLI invocations that lack a D&R event).
+
+        Keyword Args:
+            model: Replace the Anthropic model (e.g. ``claude-sonnet-4-6``).
+            max_turns: Replace the maximum number of agent turns.
+            max_budget_usd: Replace the hard USD cost cap.
+            task_budget_tokens: Replace the per-task token budget.
+            ttl_seconds: Replace the session time-to-live.
+            one_shot: When True, session auto-terminates after the
+                initial prompt is complete.  Use ``False`` to force the
+                template's one_shot off.
+            permission_mode: Replace the permission mode
+                (``acceptEdits``, ``plan``, ``bypassPermissions``).
+            allowed_tools: Replace the allowed tools list.
+            denied_tools: Replace the denied tools list.
+            plugins: Replace the enabled plugins list.
+            environment: Env vars merged with the template's environment;
+                override values win on conflicts.  Values may be
+                ``hive://secret/<name>`` references.
+            anthropic_key: Replace the Anthropic API key.  May be a
+                literal key or a ``hive://secret/<name>`` reference.
+            lc_api_key: Replace the LC API key (literal or secret ref).
+            lc_uid: Replace the LC user ID (literal or secret ref).
 
         Returns:
             dict: Session creation response with session_id and status.
         """
         from .hive import Hive
 
-        # Fetch the ai_agent definition.
+        # Fetch the ai_agent definition; treat its fields as the template
+        # that overrides stack on top of.
         record = Hive(self._org, "ai_agent").get(definition_name)
         defn = record.data or {}
 
-        # Resolve credential secrets.
-        anthropic_key = self._resolve_secret(defn.get("anthropic_secret", ""))
-        lc_api_key = self._resolve_secret(defn.get("lc_api_key_secret", ""))
-        lc_uid = self._resolve_secret(defn.get("lc_uid_secret", ""))
+        # Credential resolution: override wins, otherwise pull from the
+        # hive record's *_secret field.  Override values are themselves
+        # passed through secret resolution so a caller can still supply
+        # a "hive://secret/..." reference.
+        anthropic_key_final = self._resolve_secret(
+            anthropic_key if anthropic_key is not None
+            else defn.get("anthropic_secret", "")
+        )
+        lc_api_key_final = self._resolve_secret(
+            lc_api_key if lc_api_key is not None
+            else defn.get("lc_api_key_secret", "")
+        )
+        lc_uid_final = self._resolve_secret(
+            lc_uid if lc_uid is not None
+            else defn.get("lc_uid_secret", "")
+        )
 
-        # Fall back to the caller's own API key if none specified.
-        if not lc_api_key:
-            lc_api_key = self.client._api_key
+        # Fall back to the caller's own API key if nothing else produced one.
+        if not lc_api_key_final:
+            lc_api_key_final = self.client._api_key
 
-        # Build the profile section.
+        # Build the profile section by copying template fields verbatim.
         profile: dict[str, Any] = {}
-        for field in ("allowed_tools", "denied_tools", "permission_mode",
-                       "model", "max_turns", "max_budget_usd",
-                       "ttl_seconds", "one_shot"):
+        for field in self._PROFILE_SCALAR_FIELDS:
             if field in defn:
                 profile[field] = defn[field]
 
-        # Resolve secrets in environment values.
-        if defn.get("environment"):
-            profile["environment"] = self._resolve_map_secrets(defn["environment"])
+        # Apply scalar / list overrides.  A None override means "keep template".
+        scalar_overrides: dict[str, Any] = {
+            "model": model,
+            "max_turns": max_turns,
+            "max_budget_usd": max_budget_usd,
+            "task_budget_tokens": task_budget_tokens,
+            "ttl_seconds": ttl_seconds,
+            "one_shot": one_shot,
+            "permission_mode": permission_mode,
+            "allowed_tools": allowed_tools,
+            "denied_tools": denied_tools,
+            "plugins": plugins,
+        }
+        for field, value in scalar_overrides.items():
+            if value is not None:
+                profile[field] = value
 
-        # Resolve secrets in MCP server configs.
+        # Environment: merge template + overrides (override wins on key collision).
+        template_env = defn.get("environment") or {}
+        if template_env or environment:
+            merged_env: dict[str, str] = {}
+            merged_env.update(template_env)
+            if environment:
+                merged_env.update(environment)
+            profile["environment"] = self._resolve_map_secrets(merged_env)
+
+        # Resolve secrets in MCP server configs (not currently overridable
+        # from the CLI -- the template wins).
         if defn.get("mcp_servers"):
             resolved_servers: dict[str, Any] = {}
             for srv_name, srv_cfg in defn["mcp_servers"].items():
@@ -108,13 +196,13 @@ class AI:
         # Build the request body.
         request_body: dict[str, Any] = {
             "prompt": final_prompt,
-            "anthropic_key": anthropic_key,
+            "anthropic_key": anthropic_key_final,
             "trigger_source": "cli",
         }
-        if lc_api_key:
-            request_body["lc_api_key"] = lc_api_key
-        if lc_uid:
-            request_body["lc_uid"] = lc_uid
+        if lc_api_key_final:
+            request_body["lc_api_key"] = lc_api_key_final
+        if lc_uid_final:
+            request_body["lc_uid"] = lc_uid_final
         if name or defn.get("name"):
             request_body["name"] = name or defn["name"]
         if idempotent_key:

--- a/limacharlie/sdk/ai.py
+++ b/limacharlie/sdk/ai.py
@@ -445,3 +445,176 @@ class AI:
             dict with ``identity`` string and ``usage`` list of data points.
         """
         return self._org_request("GET", f"v1/org/usage/identities/{identity}")
+
+    # ------------------------------------------------------------------
+    # User-scoped endpoints: registration, Claude credential management,
+    # and user-owned session creation.  Unlike the org endpoints above,
+    # these identify the caller by their JWT's UID only and never carry
+    # X-LC-OID.  They back the ``limacharlie ai chat`` and
+    # ``limacharlie ai auth claude`` commands.
+    # ------------------------------------------------------------------
+
+    def _user_request(self, verb: str, path: str,
+                      raw_body: bytes | None = None,
+                      query_params: dict[str, str] | None = None,
+                      ) -> dict[str, Any]:
+        """Call an ai-sessions user-scoped endpoint with the caller's JWT.
+
+        User-scoped endpoints on ai-sessions identify the caller via
+        ``claims.UID()`` alone; sending X-LC-OID is unnecessary here
+        and the routes don't accept raw API keys.
+        """
+        kwargs: dict[str, Any] = {"alt_root": _AI_SESSIONS_URL}
+        if raw_body is not None:
+            kwargs["raw_body"] = raw_body
+            kwargs["content_type"] = "application/json"
+        if query_params:
+            kwargs["query_params"] = query_params
+        return self.client.request(verb, path, **kwargs)
+
+    def register_user(self) -> dict[str, Any]:
+        """Register the authenticated user with ai-sessions (idempotent).
+
+        Required once per UID before creating user-owned sessions or
+        storing Claude credentials.  Safe to call repeatedly: the
+        server returns the same ``registered_at`` on subsequent calls.
+
+        Returns:
+            dict with ``registered: true`` and ``registered_at``.
+        """
+        return self._user_request("POST", "v1/register", raw_body=b"")
+
+    def claude_auth_status(self) -> dict[str, Any]:
+        """Return whether the authenticated user has Claude credentials stored.
+
+        Returns:
+            dict with ``has_credentials`` (bool) and, when True,
+            ``credential_type`` (``"oauth"`` or ``"apikey"``) and
+            ``created_at`` (ISO-8601 string).
+        """
+        return self._user_request("GET", "v1/auth/claude/status")
+
+    def claude_login_start(self) -> dict[str, Any]:
+        """Begin the browser OAuth flow for storing a Claude OAuth token.
+
+        Starts a pooled OAuth job on the server side; the returned
+        ``oauth_session_id`` must be passed to
+        :meth:`claude_login_get_url` (poll) and
+        :meth:`claude_login_submit_code`.
+
+        Returns:
+            dict with ``oauth_session_id``, ``expires_in`` (seconds),
+            and a user-facing ``message``.
+        """
+        return self._user_request("POST", "v1/auth/claude/start", raw_body=b"")
+
+    def claude_login_get_url(self, oauth_session_id: str) -> dict[str, Any]:
+        """Poll for the browser URL that completes the OAuth flow.
+
+        The server spins up a headless browser that produces the URL;
+        the first few calls typically return ``status="pending"`` until
+        the URL is ready.
+
+        Args:
+            oauth_session_id: The ID returned from :meth:`claude_login_start`.
+
+        Returns:
+            dict with ``status`` (``pending``/``ready``/``failed``) and
+            ``url`` when ``status="ready"``.
+        """
+        return self._user_request(
+            "GET", "v1/auth/claude/url",
+            query_params={"session_id": oauth_session_id},
+        )
+
+    def claude_login_submit_code(self, oauth_session_id: str,
+                                 code: str) -> dict[str, Any]:
+        """Complete the OAuth flow by submitting the code from the browser.
+
+        Args:
+            oauth_session_id: The ID returned from :meth:`claude_login_start`.
+            code: The authorization code copied from the browser.
+
+        Returns:
+            dict with ``success`` and ``status`` (``completed`` on success).
+        """
+        body = json.dumps({
+            "session_id": oauth_session_id,
+            "code": code,
+        }).encode()
+        return self._user_request("POST", "v1/auth/claude/code", raw_body=body)
+
+    def claude_set_apikey(self, api_key: str) -> dict[str, Any]:
+        """Store a raw Anthropic API key for the authenticated user.
+
+        Args:
+            api_key: A literal Anthropic API key.  ``hive://secret/<name>``
+                references are resolved before the request is sent.
+
+        Returns:
+            dict with ``success: true``.
+        """
+        resolved = self._resolve_secret(api_key)
+        body = json.dumps({"api_key": resolved}).encode()
+        return self._user_request("POST", "v1/auth/claude/apikey",
+                                  raw_body=body)
+
+    def claude_logout(self) -> dict[str, Any]:
+        """Remove the authenticated user's stored Claude credentials."""
+        return self._user_request("DELETE", "v1/auth/claude")
+
+    def create_user_session(self, *,
+                            name: str | None = None,
+                            idempotent_key: str | None = None,
+                            model: str | None = None,
+                            max_turns: int | None = None,
+                            max_budget_usd: float | None = None,
+                            task_budget_tokens: int | None = None,
+                            one_shot: bool | None = None,
+                            permission_mode: str | None = None,
+                            allowed_tools: list[str] | None = None,
+                            denied_tools: list[str] | None = None,
+                            plugins: list[str] | None = None,
+                            ) -> dict[str, Any]:
+        """Create a user-owned AI session (interactive chat).
+
+        Unlike :meth:`start_session` (org-scoped, runs an ai_agent
+        template), this creates a bare interactive session owned by the
+        authenticated UID.  Use :meth:`attach_session` to send prompts.
+
+        The caller must have Claude credentials stored
+        (:meth:`claude_set_apikey` or :meth:`claude_login_start`).
+
+        Keyword Args mirror the :class:`CreateSessionRequest` fields
+        accepted by ``POST /v1/sessions`` on ai-sessions (see
+        ``internal/sessionmanager/models.go``).
+
+        Returns:
+            dict representation of the created session (``id``,
+            ``status``, ``created_at``, ...).
+        """
+        body: dict[str, Any] = {}
+        if name is not None:
+            body["name"] = name
+        if idempotent_key is not None:
+            body["idempotent_key"] = idempotent_key
+        if model is not None:
+            body["model"] = model
+        if max_turns is not None:
+            body["max_turns"] = max_turns
+        if max_budget_usd is not None:
+            body["max_budget_usd"] = max_budget_usd
+        if task_budget_tokens is not None:
+            body["task_budget_tokens"] = task_budget_tokens
+        if one_shot is not None:
+            body["one_shot"] = one_shot
+        if permission_mode is not None:
+            body["permission_mode"] = permission_mode
+        if allowed_tools is not None:
+            body["allowed_tools"] = allowed_tools
+        if denied_tools is not None:
+            body["denied_tools"] = denied_tools
+        if plugins is not None:
+            body["plugins"] = plugins
+        return self._user_request("POST", "v1/sessions",
+                                  raw_body=json.dumps(body).encode())

--- a/limacharlie/sdk/ai.py
+++ b/limacharlie/sdk/ai.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from typing import Any, TYPE_CHECKING
+from typing import Any, Generator, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from .organization import Organization
@@ -348,14 +348,18 @@ class AI:
             extra_headers=extra,
         )
 
-    def list_sessions(self, status: str | None = None,
-                      limit: int | None = None,
-                      cursor: str | None = None) -> dict[str, Any]:
-        """List AI sessions for the organization.
+    def list_sessions_page(self, status: str | None = None,
+                           limit: int | None = None,
+                           cursor: str | None = None,
+                           ) -> dict[str, Any]:
+        """Fetch a single page of AI sessions for the organization.
+
+        Prefer :meth:`list_sessions` unless you specifically need raw
+        pagination control (e.g. resuming from a stored cursor).
 
         Args:
             status: Filter by session status (running, ended, starting).
-            limit: Maximum number of results (1-200, default 50).
+            limit: Max results per page (1-200, server default if unset).
             cursor: Pagination cursor from a previous response.
 
         Returns:
@@ -370,6 +374,35 @@ class AI:
             qp["cursor"] = cursor
         return self._org_request("GET", "v1/org/sessions",
                                  query_params=qp or None)
+
+    def list_sessions(self, status: str | None = None,
+                      limit: int | None = None,
+                      page_size: int | None = None,
+                      ) -> Generator[dict[str, Any], None, None]:
+        """Iterate AI sessions for the organization, draining pagination.
+
+        Args:
+            status: Filter by session status (running, ended, starting).
+            limit: Total cap on yielded sessions across all pages.
+            page_size: Per-request page size sent to the server
+                (1-200, server default if unset).
+
+        Yields:
+            dict: Session records.
+        """
+        cursor: str | None = None
+        n_returned = 0
+        while True:
+            resp = self.list_sessions_page(status=status, limit=page_size,
+                                           cursor=cursor)
+            for s in resp.get("sessions", []) or []:
+                yield s
+                n_returned += 1
+                if limit is not None and n_returned >= limit:
+                    return
+            cursor = resp.get("next_cursor") or None
+            if not cursor:
+                return
 
     def get_session(self, session_id: str) -> dict[str, Any]:
         """Get details of a specific AI session.
@@ -563,19 +596,18 @@ class AI:
         """Remove the authenticated user's stored Claude credentials."""
         return self._user_request("DELETE", "v1/auth/claude")
 
-    def list_user_sessions(self, status: str | None = None,
-                           limit: int | None = None,
-                           cursor: str | None = None) -> dict[str, Any]:
-        """List sessions owned by the authenticated user.
+    def list_user_sessions_page(self, status: str | None = None,
+                                limit: int | None = None,
+                                cursor: str | None = None,
+                                ) -> dict[str, Any]:
+        """Fetch a single page of user-owned sessions.
 
-        Mirrors :meth:`list_sessions` but hits the user-scoped
-        ``GET /v1/sessions`` route, so it sees sessions created via
-        :meth:`create_user_session` / ``ai chat`` instead of org-scoped
-        sessions started via :meth:`start_session` / ``ai start-session``.
+        Prefer :meth:`list_user_sessions` unless you specifically need
+        raw pagination control (e.g. resuming from a stored cursor).
 
         Args:
             status: Filter by session status (running, ended, starting).
-            limit: Maximum number of results.
+            limit: Max results per page.
             cursor: Pagination cursor from a previous response.
 
         Returns:
@@ -590,6 +622,40 @@ class AI:
             qp["cursor"] = cursor
         return self._user_request("GET", "v1/sessions",
                                   query_params=qp or None)
+
+    def list_user_sessions(self, status: str | None = None,
+                           limit: int | None = None,
+                           page_size: int | None = None,
+                           ) -> Generator[dict[str, Any], None, None]:
+        """Iterate sessions owned by the authenticated user.
+
+        Mirrors :meth:`list_sessions` but hits the user-scoped
+        ``GET /v1/sessions`` route, so it sees sessions created via
+        :meth:`create_user_session` / ``ai chat`` instead of org-scoped
+        sessions started via :meth:`start_session` / ``ai start-session``.
+
+        Args:
+            status: Filter by session status (running, ended, starting).
+            limit: Total cap on yielded sessions across all pages.
+            page_size: Per-request page size sent to the server
+                (server default if unset).
+
+        Yields:
+            dict: Session records.
+        """
+        cursor: str | None = None
+        n_returned = 0
+        while True:
+            resp = self.list_user_sessions_page(status=status, limit=page_size,
+                                                cursor=cursor)
+            for s in resp.get("sessions", []) or []:
+                yield s
+                n_returned += 1
+                if limit is not None and n_returned >= limit:
+                    return
+            cursor = resp.get("next_cursor") or None
+            if not cursor:
+                return
 
     def get_user_session(self, session_id: str) -> dict[str, Any]:
         """Get details of a user-owned session.

--- a/limacharlie/sdk/ai.py
+++ b/limacharlie/sdk/ai.py
@@ -563,6 +563,67 @@ class AI:
         """Remove the authenticated user's stored Claude credentials."""
         return self._user_request("DELETE", "v1/auth/claude")
 
+    def list_user_sessions(self, status: str | None = None,
+                           limit: int | None = None,
+                           cursor: str | None = None) -> dict[str, Any]:
+        """List sessions owned by the authenticated user.
+
+        Mirrors :meth:`list_sessions` but hits the user-scoped
+        ``GET /v1/sessions`` route, so it sees sessions created via
+        :meth:`create_user_session` / ``ai chat`` instead of org-scoped
+        sessions started via :meth:`start_session` / ``ai start-session``.
+
+        Args:
+            status: Filter by session status (running, ended, starting).
+            limit: Maximum number of results.
+            cursor: Pagination cursor from a previous response.
+
+        Returns:
+            dict with ``sessions`` list and ``next_cursor`` string.
+        """
+        qp: dict[str, str] = {}
+        if status:
+            qp["status"] = status
+        if limit is not None:
+            qp["limit"] = str(limit)
+        if cursor:
+            qp["cursor"] = cursor
+        return self._user_request("GET", "v1/sessions",
+                                  query_params=qp or None)
+
+    def get_user_session(self, session_id: str) -> dict[str, Any]:
+        """Get details of a user-owned session.
+
+        Args:
+            session_id: The session ID.
+
+        Returns:
+            dict with ``session`` object.
+        """
+        return self._user_request("GET", f"v1/sessions/{session_id}")
+
+    def terminate_user_session(self, session_id: str) -> dict[str, Any]:
+        """Terminate a running user-owned session.
+
+        Args:
+            session_id: The session ID to terminate.
+
+        Returns:
+            dict with ``terminated: true``.
+        """
+        return self._user_request("DELETE", f"v1/sessions/{session_id}")
+
+    def get_user_session_history(self, session_id: str) -> dict[str, Any]:
+        """Get the conversation history of a user-owned session.
+
+        Args:
+            session_id: The session ID.
+
+        Returns:
+            dict with ``messages`` list.
+        """
+        return self._user_request("GET", f"v1/sessions/{session_id}/history")
+
     def create_user_session(self, *,
                             name: str | None = None,
                             idempotent_key: str | None = None,

--- a/limacharlie/sdk/ai.py
+++ b/limacharlie/sdk/ai.py
@@ -316,6 +316,29 @@ class AI:
         """
         return self._org_request("GET", f"v1/org/sessions/{session_id}/history")
 
+    def attach_session(self, session_id: str, *,
+                       read_only: bool = False) -> "SessionAttachment":
+        """Open a WebSocket attachment to a running AI session.
+
+        The returned object is an async context manager yielding parsed
+        JSON messages from the session.  See
+        :mod:`limacharlie.sdk.ai_session` for the full protocol and
+        helper classes.
+
+        Args:
+            session_id: The session to attach to.
+            read_only: Use the org-scoped read-only endpoint instead of
+                the owner-interactive one.  Required when the caller
+                does not own the session.
+
+        Returns:
+            A :class:`SessionAttachment` instance.  Use ``async with``
+            to connect, and :meth:`~SessionAttachment.messages` to
+            iterate over streaming messages.
+        """
+        from .ai_session import SessionAttachment
+        return SessionAttachment(self, session_id, read_only=read_only)
+
     def list_usage_identities(self) -> dict[str, Any]:
         """List all API key identities with AI session usage data.
 

--- a/limacharlie/sdk/ai_session.py
+++ b/limacharlie/sdk/ai_session.py
@@ -1,0 +1,260 @@
+"""WebSocket attachment to AI sessions.
+
+Thin async wrapper around the ai-sessions WebSocket protocol defined in
+``ai-sessions/api/WEBSOCKET_PROTOCOL.md``.  The WS URL is derived from
+the same base host used for the AI sessions REST API and authenticated
+with the LimaCharlie JWT carried by :class:`limacharlie.Client`.
+
+Two endpoints are exposed by ai-sessions:
+
+* ``/v1/sessions/{id}/ws`` — owner-interactive.  The authenticated user
+  must own the session; they can send prompts, interrupts, tool
+  approvals, and question answers.
+* ``/v1/org/sessions/{id}/ws`` — org-scoped read-only view.  Requires
+  ``ai_agent.get`` on the session's owner org.  Write messages are
+  rejected locally.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any, AsyncIterator, TYPE_CHECKING
+from urllib.parse import urlparse
+
+if TYPE_CHECKING:
+    from .ai import AI
+
+
+DEFAULT_HEARTBEAT_SECONDS = 25
+DEFAULT_MAX_FRAME_BYTES = 10 * 1024 * 1024  # 10 MiB
+
+# Server -> client message types.
+MSG_ASSISTANT = "assistant"
+MSG_USER = "user"
+MSG_SYSTEM = "system"
+MSG_TOOL_USE = "tool_use"
+MSG_TOOL_RESULT = "tool_result"
+MSG_TOOL_APPROVAL_REQUEST = "tool_approval_request"
+MSG_ASK_USER_QUESTION = "ask_user_question"
+MSG_HISTORY = "history"
+MSG_ERROR = "error"
+MSG_SESSION_END = "session_end"
+MSG_RESULT = "result"
+
+# Client -> server message types.
+MSG_PROMPT = "prompt"
+MSG_INTERRUPT = "interrupt"
+MSG_HEARTBEAT = "heartbeat"
+MSG_TOOL_APPROVAL_RESPONSE = "tool_approval_response"
+MSG_ASK_USER_QUESTION_RESPONSE = "ask_user_question_response"
+
+
+class AttachmentForbidden(Exception):
+    """The server refused the WebSocket upgrade with 403.
+
+    Typically means the authenticated user is not the session owner.
+    Callers may want to retry against the org-scoped read-only endpoint.
+    """
+
+
+def _derive_ws_url(base_url: str, session_id: str, read_only: bool) -> str:
+    """Convert the AI sessions HTTP(S) base URL to a wss:// attach URL."""
+    parsed = urlparse(base_url)
+    scheme = "wss" if parsed.scheme == "https" else "ws"
+    host = parsed.netloc or parsed.path.strip("/")
+    sub = "org/sessions" if read_only else "sessions"
+    return f"{scheme}://{host}/v1/{sub}/{session_id}/ws"
+
+
+class SessionAttachment:
+    """Open WebSocket connection to an AI session.
+
+    Usage::
+
+        async with ai.attach_session(session_id) as att:
+            async for msg in att.messages():
+                print(msg)
+    """
+
+    def __init__(self, ai: "AI", session_id: str, *,
+                 read_only: bool = False,
+                 base_url: str | None = None) -> None:
+        from .ai import _AI_SESSIONS_URL
+
+        self._ai = ai
+        self._session_id = session_id
+        self._read_only = read_only
+        self._base_url = base_url or _AI_SESSIONS_URL
+        self._ws: Any = None
+        self._heartbeat_task: asyncio.Task | None = None
+
+    # ------------------------------------------------------------------
+    # Introspection
+    # ------------------------------------------------------------------
+
+    @property
+    def session_id(self) -> str:
+        return self._session_id
+
+    @property
+    def read_only(self) -> bool:
+        return self._read_only
+
+    def url(self) -> str:
+        return _derive_ws_url(self._base_url, self._session_id, self._read_only)
+
+    # ------------------------------------------------------------------
+    # Connection lifecycle
+    # ------------------------------------------------------------------
+
+    async def connect(self) -> None:
+        try:
+            import websockets
+        except ImportError as e:  # pragma: no cover - surfaced to the caller
+            raise ImportError(
+                "The 'websockets' package is required for AI session "
+                "attachment. Install it with: pip install websockets>=13"
+            ) from e
+        from websockets.exceptions import InvalidStatus, InvalidStatusCode
+
+        client = self._ai.client
+        jwt = client.get_jwt()
+        url = self.url()
+        headers = {"Authorization": f"Bearer {jwt}"}
+
+        connect = getattr(websockets, "connect")
+        try:
+            # ``websockets`` renamed the header kwarg between releases.
+            try:
+                self._ws = await connect(
+                    url,
+                    additional_headers=headers,
+                    max_size=DEFAULT_MAX_FRAME_BYTES,
+                )
+            except TypeError:
+                self._ws = await connect(
+                    url,
+                    extra_headers=headers,
+                    max_size=DEFAULT_MAX_FRAME_BYTES,
+                )
+        except (InvalidStatus, InvalidStatusCode) as e:
+            status = _extract_status_code(e)
+            if status == 403:
+                raise AttachmentForbidden(
+                    f"Server refused WebSocket upgrade with 403 for {url}"
+                ) from e
+            raise
+
+        self._heartbeat_task = asyncio.create_task(self._heartbeat_loop())
+
+    async def close(self) -> None:
+        if self._heartbeat_task is not None:
+            self._heartbeat_task.cancel()
+            try:
+                await self._heartbeat_task
+            except (asyncio.CancelledError, Exception):
+                pass
+            self._heartbeat_task = None
+        if self._ws is not None:
+            try:
+                await self._ws.close()
+            except Exception:
+                pass
+            self._ws = None
+
+    async def __aenter__(self) -> "SessionAttachment":
+        await self.connect()
+        return self
+
+    async def __aexit__(self, *exc: Any) -> None:
+        await self.close()
+
+    # ------------------------------------------------------------------
+    # Message stream
+    # ------------------------------------------------------------------
+
+    async def messages(self) -> AsyncIterator[dict]:
+        if self._ws is None:
+            raise RuntimeError("SessionAttachment is not connected")
+        async for raw in self._ws:
+            if isinstance(raw, bytes):
+                raw = raw.decode("utf-8", errors="replace")
+            try:
+                yield json.loads(raw)
+            except json.JSONDecodeError:
+                continue
+
+    # ------------------------------------------------------------------
+    # Outbound messages (owner endpoint only)
+    # ------------------------------------------------------------------
+
+    async def _send(self, msg: dict) -> None:
+        if self._ws is None:
+            raise RuntimeError("SessionAttachment is not connected")
+        if self._read_only and msg.get("type") != MSG_HEARTBEAT:
+            raise RuntimeError(
+                f"Cannot send '{msg.get('type')}' on a read-only attachment"
+            )
+        await self._ws.send(json.dumps(msg))
+
+    async def send_prompt(self, text: str) -> None:
+        await self._send({"type": MSG_PROMPT, "payload": {"text": text}})
+
+    async def interrupt(self) -> None:
+        await self._send({"type": MSG_INTERRUPT})
+
+    async def approve_tool(self, tool_use_id: str, approved: bool, *,
+                           scope: str = "once",
+                           pattern: str | None = None,
+                           updated_input: dict | None = None,
+                           message: str | None = None) -> None:
+        payload: dict[str, Any] = {
+            "tool_use_id": tool_use_id,
+            "approved": approved,
+            "approval_scope": scope,
+        }
+        if pattern:
+            payload["approval_pattern"] = pattern
+        if updated_input is not None:
+            payload["updated_input"] = updated_input
+        if message:
+            payload["message"] = message
+        await self._send({"type": MSG_TOOL_APPROVAL_RESPONSE, "payload": payload})
+
+    async def answer_question(self, question_id: str,
+                              answers: dict[str, str]) -> None:
+        await self._send({
+            "type": MSG_ASK_USER_QUESTION_RESPONSE,
+            "payload": {"question_id": question_id, "answers": answers},
+        })
+
+    # ------------------------------------------------------------------
+    # Internal
+    # ------------------------------------------------------------------
+
+    async def _heartbeat_loop(self) -> None:
+        while True:
+            await asyncio.sleep(DEFAULT_HEARTBEAT_SECONDS)
+            if self._ws is None:
+                return
+            try:
+                await self._ws.send(json.dumps({"type": MSG_HEARTBEAT}))
+            except Exception:
+                return
+
+
+def _extract_status_code(exc: Exception) -> int | None:
+    """Fetch the HTTP status from ``websockets`` upgrade exceptions.
+
+    The attribute moved across releases: older versions exposed
+    ``status_code`` on :class:`InvalidStatusCode`; newer versions use
+    :class:`InvalidStatus` which carries a ``response`` object.
+    """
+    status = getattr(exc, "status_code", None)
+    if status is not None:
+        return status
+    response = getattr(exc, "response", None)
+    if response is not None:
+        return getattr(response, "status_code", None)
+    return None

--- a/limacharlie/sdk/ai_session.py
+++ b/limacharlie/sdk/ai_session.py
@@ -7,12 +7,17 @@ with the LimaCharlie JWT carried by :class:`limacharlie.Client`.
 
 Two endpoints are exposed by ai-sessions:
 
-* ``/v1/sessions/{id}/ws`` — owner-interactive.  The authenticated user
+* ``/v1/ws/sessions/{id}`` — owner-interactive.  The authenticated user
   must own the session; they can send prompts, interrupts, tool
   approvals, and question answers.
-* ``/v1/org/sessions/{id}/ws`` — org-scoped read-only view.  Requires
+* ``/v1/ws/org/sessions/{id}`` — org-scoped read-only view.  Requires
   ``ai_agent.get`` on the session's owner org.  Write messages are
   rejected locally.
+
+The GCP load balancer routes ``/v1/ws/*`` to the interaction-proxy
+(which serves these WebSockets) and ``/v1/sessions/*`` to the
+session-manager (REST API); the ``/v1/ws/...`` prefix is what the LB
+URL Map actually forwards, so that is the form used here.
 """
 
 from __future__ import annotations
@@ -63,8 +68,8 @@ def _derive_ws_url(base_url: str, session_id: str, read_only: bool) -> str:
     parsed = urlparse(base_url)
     scheme = "wss" if parsed.scheme == "https" else "ws"
     host = parsed.netloc or parsed.path.strip("/")
-    sub = "org/sessions" if read_only else "sessions"
-    return f"{scheme}://{host}/v1/{sub}/{session_id}/ws"
+    sub = "ws/org/sessions" if read_only else "ws/sessions"
+    return f"{scheme}://{host}/v1/{sub}/{session_id}"
 
 
 class SessionAttachment:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
     "jmespath==1.1.0",
     "orjson>=3.10.0,<3.11; python_version < '3.10'",
     "orjson>=3.10.0; python_version >= '3.10'",
+    "websockets>=13.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/unit/test_ai_session_attach.py
+++ b/tests/unit/test_ai_session_attach.py
@@ -390,6 +390,37 @@ class TestExtractAssistantText:
 
         assert _extract_assistant_text({}) == ""
 
+    def test_leading_newlines_stripped(self):
+        """Claude frequently opens a turn with a text block that begins
+        with one or two bare newlines; when indented under the
+        ``assistant:`` header these render as empty "  " lines that
+        look like a bug.  The extractor strips them.
+        """
+        from limacharlie.commands._ai_attach import _extract_assistant_text
+
+        assert _extract_assistant_text({"content": [
+            {"type": "text", "text": "\n\nYes, I'm here."},
+        ]}) == "Yes, I'm here."
+
+    def test_whitespace_only_blocks_dropped(self):
+        from limacharlie.commands._ai_attach import _extract_assistant_text
+
+        assert _extract_assistant_text({"content": [
+            {"type": "text", "text": "\n"},
+            {"type": "text", "text": "  "},
+            {"type": "text", "text": "hello"},
+        ]}) == "hello"
+
+    def test_internal_paragraph_breaks_preserved(self):
+        """Stripping outer whitespace must not collapse intentional
+        paragraph breaks inside a single text block.
+        """
+        from limacharlie.commands._ai_attach import _extract_assistant_text
+
+        assert _extract_assistant_text({"content": [
+            {"type": "text", "text": "Paragraph 1\n\nParagraph 2"},
+        ]}) == "Paragraph 1\n\nParagraph 2"
+
 
 # ---------------------------------------------------------------------------
 # Utilities
@@ -441,6 +472,213 @@ class TestCliRegistration:
         # option is missing.
         assert result.exit_code != 0
         assert "--id" in result.output or "id" in result.output.lower()
+
+
+# ---------------------------------------------------------------------------
+# Noise filter + verbose-aware rendering
+# ---------------------------------------------------------------------------
+
+class TestShouldSkipMessage:
+    """Guard the rules that decide whether the live stream renders a
+    message.  These govern the signal-to-noise ratio the user sees in
+    ``ai chat`` / ``ai session attach`` — regressions here re-introduce
+    the firehose we explicitly suppressed.
+    """
+
+    def test_verbose_never_skips(self):
+        from limacharlie.commands._ai_attach import _should_skip_message
+
+        msg = {"type": "system", "payload": {"subtype": "init_received"}}
+        assert _should_skip_message(msg, verbose=True) is False
+
+    def test_skips_session_status_ping(self):
+        from limacharlie.commands._ai_attach import _should_skip_message
+
+        assert _should_skip_message(
+            {"type": "session_status", "payload": {"status": "running"}},
+            verbose=False,
+        )
+
+    def test_skips_usage_delta(self):
+        from limacharlie.commands._ai_attach import _should_skip_message
+
+        assert _should_skip_message(
+            {"type": "usage_delta", "payload": {"input_tokens": 3}},
+            verbose=False,
+        )
+
+    def test_skips_plumbing_system_subtypes(self):
+        from limacharlie.commands._ai_attach import (
+            _NOISY_SYSTEM_SUBTYPES, _should_skip_message,
+        )
+
+        # Spot-check a subtype from each source (bridge + Claude SDK).
+        for subtype in ("init_received", "model_set", "hook_started",
+                        "autoinit_loaded", "ttl_added_to_system_prompt"):
+            assert subtype in _NOISY_SYSTEM_SUBTYPES
+            assert _should_skip_message(
+                {"type": "system", "payload": {"subtype": subtype}},
+                verbose=False,
+            )
+
+    def test_keeps_unknown_system_subtype(self):
+        from limacharlie.commands._ai_attach import _should_skip_message
+
+        # Something we haven't explicitly marked as noise should still
+        # surface — e.g. a server-emitted warning the user needs to see.
+        assert not _should_skip_message(
+            {"type": "system", "payload": {"subtype": "budget_exceeded",
+                                            "message": "over cap"}},
+            verbose=False,
+        )
+
+    def test_skips_empty_assistant(self):
+        """Tool-use-only turns produce an ``assistant`` frame whose
+        content holds no text blocks; the separate ``tool_use`` message
+        already renders, so the bare "assistant:" header was pure
+        noise.
+        """
+        from limacharlie.commands._ai_attach import _should_skip_message
+
+        assert _should_skip_message(
+            {"type": "assistant", "payload": {"content": [
+                {"type": "tool_use", "id": "t1", "name": "Bash",
+                 "input": {"command": "ls"}},
+            ]}},
+            verbose=False,
+        )
+
+    def test_keeps_assistant_with_text(self):
+        from limacharlie.commands._ai_attach import _should_skip_message
+
+        assert not _should_skip_message(
+            {"type": "assistant", "payload": {"content": [
+                {"type": "text", "text": "hi"},
+            ]}},
+            verbose=False,
+        )
+
+    def test_skips_user_tool_result_wrapper(self):
+        """``user`` frames that carry only a tool_result block would
+        render as an empty "user:" line — skip them; the ``tool_result``
+        sibling already shows the output.
+        """
+        from limacharlie.commands._ai_attach import _should_skip_message
+
+        assert _should_skip_message(
+            {"type": "user", "payload": {"content": [
+                {"type": "tool_result", "tool_use_id": "t1", "content": "ok"},
+            ]}},
+            verbose=False,
+        )
+
+    def test_skips_empty_result_ping(self):
+        from limacharlie.commands._ai_attach import _should_skip_message
+
+        assert _should_skip_message(
+            {"type": "result", "payload": {"subtype": "success",
+                                            "num_turns": 1}},
+            verbose=False,
+        )
+
+    def test_keeps_result_with_summary(self):
+        from limacharlie.commands._ai_attach import _should_skip_message
+
+        assert not _should_skip_message(
+            {"type": "result", "payload": {"summary": "done"}},
+            verbose=False,
+        )
+
+
+class TestFormatTimestamp:
+
+    def test_default_shortens_to_hhmmss(self):
+        from limacharlie.commands._ai_attach import _format_timestamp
+
+        # Python isoformat with microseconds + offset.
+        assert _format_timestamp("2026-04-19T02:43:59.801738+00:00",
+                                  verbose=False) == "[02:43:59] "
+
+    def test_default_handles_nanoseconds_and_z_suffix(self):
+        from limacharlie.commands._ai_attach import _format_timestamp
+
+        # Go RFC3339Nano-ish shape with a 'Z' instead of an offset.
+        assert _format_timestamp("2026-04-19T02:43:59.162704816Z",
+                                  verbose=False) == "[02:43:59] "
+
+    def test_verbose_preserves_full_string(self):
+        from limacharlie.commands._ai_attach import _format_timestamp
+
+        ts = "2026-04-19T02:43:59.801738+00:00"
+        assert _format_timestamp(ts, verbose=True) == f"[{ts}] "
+
+    def test_empty_returns_empty(self):
+        from limacharlie.commands._ai_attach import _format_timestamp
+
+        assert _format_timestamp(None, verbose=False) == ""
+        assert _format_timestamp("", verbose=False) == ""
+
+
+class TestUserContentExtraction:
+    """The server sends ``user`` payloads as ``{"content": [blocks]}``
+    (same shape as assistant), not ``{"text": "..."}``; the renderer
+    needs to handle both so the user line isn't perpetually blank.
+    """
+
+    def test_content_blocks_extracted(self):
+        from limacharlie.commands._ai_attach import _extract_user_text
+
+        text = _extract_user_text({"content": [
+            {"type": "text", "text": "hello"},
+            {"type": "text", "text": "world"},
+        ]})
+        assert "hello" in text and "world" in text
+
+    def test_tool_result_wrapper_is_empty(self):
+        from limacharlie.commands._ai_attach import _extract_user_text
+
+        text = _extract_user_text({"content": [
+            {"type": "tool_result", "tool_use_id": "t1", "content": "ok"},
+        ]})
+        assert text == ""
+
+    def test_legacy_text_key_still_works(self):
+        from limacharlie.commands._ai_attach import _extract_user_text
+
+        assert _extract_user_text({"text": "list files"}) == "list files"
+
+
+class TestRenderTimestampFormatting:
+
+    def _render(self, msg: dict, verbose: bool = False) -> str:
+        from limacharlie.commands import _ai_attach
+
+        runner = click.testing.CliRunner()
+
+        @click.command()
+        def dump():
+            _ai_attach._render_message(msg, verbose=verbose)
+
+        result = runner.invoke(dump, [])
+        assert result.exit_code == 0, result.output
+        return result.output
+
+    def test_render_uses_short_timestamp_by_default(self):
+        out = self._render({
+            "type": "assistant",
+            "timestamp": "2026-04-19T02:43:59.801738+00:00",
+            "payload": {"content": [{"type": "text", "text": "hi"}]},
+        }, verbose=False)
+        assert "02:43:59" in out
+        assert "2026-04-19T" not in out
+
+    def test_render_uses_full_timestamp_in_verbose(self):
+        out = self._render({
+            "type": "assistant",
+            "timestamp": "2026-04-19T02:43:59.801738+00:00",
+            "payload": {"content": [{"type": "text", "text": "hi"}]},
+        }, verbose=True)
+        assert "2026-04-19T02:43:59.801738+00:00" in out
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_ai_session_attach.py
+++ b/tests/unit/test_ai_session_attach.py
@@ -1,0 +1,465 @@
+"""Tests for the AI session WebSocket attach feature.
+
+Covers:
+  * ``_derive_ws_url`` — HTTPS/HTTP -> wss/ws conversion and
+    owner-vs-org endpoint selection.
+  * ``SessionAttachment`` send/receive plumbing against a stub WS.
+  * ``_extract_status_code`` — status extraction across the two
+    ``websockets`` exception shapes.
+  * Pretty-printer rendering for each known message type.
+  * Click registration of ``limacharlie ai session attach``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from types import SimpleNamespace
+from typing import Any
+
+import click
+import click.testing
+import pytest
+
+from limacharlie.sdk import ai_session
+from limacharlie.sdk.ai_session import (
+    AttachmentForbidden,
+    SessionAttachment,
+    _derive_ws_url,
+    _extract_status_code,
+)
+
+
+# ---------------------------------------------------------------------------
+# URL derivation
+# ---------------------------------------------------------------------------
+
+class TestDeriveWsUrl:
+
+    def test_https_base_maps_to_wss_owner_endpoint(self):
+        url = _derive_ws_url("https://ai.limacharlie.io", "sid-1", read_only=False)
+        assert url == "wss://ai.limacharlie.io/v1/sessions/sid-1/ws"
+
+    def test_https_base_maps_to_wss_org_endpoint(self):
+        url = _derive_ws_url("https://ai.limacharlie.io", "sid-1", read_only=True)
+        assert url == "wss://ai.limacharlie.io/v1/org/sessions/sid-1/ws"
+
+    def test_http_base_maps_to_ws(self):
+        url = _derive_ws_url("http://localhost:8080", "sid-2", read_only=False)
+        assert url == "ws://localhost:8080/v1/sessions/sid-2/ws"
+
+    def test_staging_host_preserved(self):
+        url = _derive_ws_url(
+            "https://ai-sessions-staging.limacharlie.io", "abc", read_only=False,
+        )
+        assert url.startswith("wss://ai-sessions-staging.limacharlie.io/")
+
+
+# ---------------------------------------------------------------------------
+# Status-code extraction (websockets API stability helper)
+# ---------------------------------------------------------------------------
+
+class TestExtractStatusCode:
+
+    def test_reads_legacy_status_code_attr(self):
+        err = SimpleNamespace(status_code=403)
+        assert _extract_status_code(err) == 403
+
+    def test_reads_new_response_status_code(self):
+        err = SimpleNamespace(response=SimpleNamespace(status_code=401))
+        assert _extract_status_code(err) == 401
+
+    def test_returns_none_when_unavailable(self):
+        assert _extract_status_code(ValueError("boom")) is None
+
+
+# ---------------------------------------------------------------------------
+# SessionAttachment plumbing (no real network)
+# ---------------------------------------------------------------------------
+
+class FakeWebSocket:
+    """Minimal async WS stand-in driven by a pre-seeded message list."""
+
+    def __init__(self, incoming: list[str] | None = None) -> None:
+        self._incoming = list(incoming or [])
+        self.sent: list[str] = []
+        self.closed = False
+
+    async def send(self, data: str) -> None:
+        self.sent.append(data)
+
+    async def close(self) -> None:
+        self.closed = True
+
+    def __aiter__(self):
+        return self._iter()
+
+    async def _iter(self):
+        for item in self._incoming:
+            yield item
+
+
+def _make_attachment(ws: FakeWebSocket, *, read_only: bool = False) -> SessionAttachment:
+    ai_stub = SimpleNamespace(client=SimpleNamespace(get_jwt=lambda: "jwt"))
+    att = SessionAttachment(ai_stub, "sid-xyz", read_only=read_only)
+    att._ws = ws
+    return att
+
+
+class TestSessionAttachmentSend:
+
+    def test_send_prompt_writes_json(self):
+        ws = FakeWebSocket()
+        att = _make_attachment(ws)
+        asyncio.run(att.send_prompt("hello world"))
+        assert len(ws.sent) == 1
+        payload = json.loads(ws.sent[0])
+        assert payload == {
+            "type": "prompt", "payload": {"text": "hello world"},
+        }
+
+    def test_interrupt(self):
+        ws = FakeWebSocket()
+        att = _make_attachment(ws)
+        asyncio.run(att.interrupt())
+        assert json.loads(ws.sent[0]) == {"type": "interrupt"}
+
+    def test_approve_tool_once_minimal(self):
+        ws = FakeWebSocket()
+        att = _make_attachment(ws)
+        asyncio.run(att.approve_tool("tu-1", True))
+        msg = json.loads(ws.sent[0])
+        assert msg["type"] == "tool_approval_response"
+        assert msg["payload"] == {
+            "tool_use_id": "tu-1",
+            "approved": True,
+            "approval_scope": "once",
+        }
+
+    def test_approve_tool_session_with_pattern(self):
+        ws = FakeWebSocket()
+        att = _make_attachment(ws)
+        asyncio.run(att.approve_tool(
+            "tu-1", True, scope="session", pattern="Bash(git:*)",
+            updated_input={"command": "git status"},
+            message="auto-approve",
+        ))
+        msg = json.loads(ws.sent[0])
+        assert msg["payload"] == {
+            "tool_use_id": "tu-1",
+            "approved": True,
+            "approval_scope": "session",
+            "approval_pattern": "Bash(git:*)",
+            "updated_input": {"command": "git status"},
+            "message": "auto-approve",
+        }
+
+    def test_approve_tool_denied(self):
+        ws = FakeWebSocket()
+        att = _make_attachment(ws)
+        asyncio.run(att.approve_tool("tu-1", False, message="no"))
+        msg = json.loads(ws.sent[0])
+        assert msg["payload"]["approved"] is False
+        assert msg["payload"]["message"] == "no"
+
+    def test_answer_question(self):
+        ws = FakeWebSocket()
+        att = _make_attachment(ws)
+        asyncio.run(att.answer_question("q-1", {"Which database": "staging"}))
+        msg = json.loads(ws.sent[0])
+        assert msg == {
+            "type": "ask_user_question_response",
+            "payload": {
+                "question_id": "q-1",
+                "answers": {"Which database": "staging"},
+            },
+        }
+
+    def test_read_only_rejects_writes(self):
+        ws = FakeWebSocket()
+        att = _make_attachment(ws, read_only=True)
+        with pytest.raises(RuntimeError, match="read-only"):
+            asyncio.run(att.send_prompt("x"))
+        assert ws.sent == []
+
+    def test_read_only_allows_heartbeat(self):
+        ws = FakeWebSocket()
+        att = _make_attachment(ws, read_only=True)
+        # Direct _send call mimics what the heartbeat task does.
+        asyncio.run(att._send({"type": "heartbeat"}))
+        assert json.loads(ws.sent[0]) == {"type": "heartbeat"}
+
+
+class TestSessionAttachmentReceive:
+
+    def test_messages_yields_parsed_json_and_skips_garbage(self):
+        ws = FakeWebSocket(incoming=[
+            json.dumps({"type": "assistant", "payload": {"content": "hi"}}),
+            "not json",
+            json.dumps({"type": "session_end", "payload": {"reason": "done"}}),
+        ])
+        att = _make_attachment(ws)
+
+        async def drain():
+            return [m async for m in att.messages()]
+
+        got = asyncio.run(drain())
+        assert [m["type"] for m in got] == ["assistant", "session_end"]
+
+    def test_messages_decodes_bytes(self):
+        ws = FakeWebSocket(incoming=[
+            json.dumps({"type": "system", "payload": {"message": "hi"}}).encode(),
+        ])
+        att = _make_attachment(ws)
+
+        async def drain():
+            return [m async for m in att.messages()]
+
+        got = asyncio.run(drain())
+        assert got == [{"type": "system", "payload": {"message": "hi"}}]
+
+
+class TestSessionAttachmentUrl:
+
+    def test_url_uses_base_url_override(self):
+        att = SessionAttachment(
+            SimpleNamespace(client=None),
+            "sid-42",
+            base_url="https://example.test",
+        )
+        assert att.url() == "wss://example.test/v1/sessions/sid-42/ws"
+
+    def test_url_read_only_uses_org_endpoint(self):
+        att = SessionAttachment(
+            SimpleNamespace(client=None),
+            "sid-42",
+            read_only=True,
+            base_url="https://example.test",
+        )
+        assert att.url() == "wss://example.test/v1/org/sessions/sid-42/ws"
+
+
+# ---------------------------------------------------------------------------
+# Pretty-printer
+# ---------------------------------------------------------------------------
+
+class TestRenderMessage:
+    """Verify every known message type produces human-readable output.
+
+    We assert on substrings rather than exact formatting so that
+    colour/layout tweaks in the future don't invalidate the tests.
+    """
+
+    def _render(self, msg: dict) -> str:
+        from limacharlie.commands import _ai_attach
+
+        runner = click.testing.CliRunner()
+
+        @click.command()
+        def dump():
+            _ai_attach._render_message(msg)
+
+        result = runner.invoke(dump, [])
+        assert result.exit_code == 0, result.output
+        return result.output
+
+    def test_assistant_text(self):
+        out = self._render({
+            "type": "assistant",
+            "timestamp": "t1",
+            "payload": {"content": [
+                {"type": "text", "text": "hello from claude"},
+            ]},
+        })
+        assert "assistant" in out
+        assert "hello from claude" in out
+
+    def test_user_text(self):
+        out = self._render({
+            "type": "user",
+            "payload": {"text": "list files"},
+        })
+        assert "user" in out
+        assert "list files" in out
+
+    def test_tool_use_includes_tool_name_and_input(self):
+        out = self._render({
+            "type": "tool_use",
+            "payload": {"id": "t1", "name": "Bash", "input": {"command": "ls"}},
+        })
+        assert "tool_use" in out
+        assert "Bash" in out
+        assert "ls" in out
+
+    def test_tool_result_includes_content(self):
+        out = self._render({
+            "type": "tool_result",
+            "payload": {"tool_use_id": "t1", "content": "file1\nfile2"},
+        })
+        assert "tool_result" in out
+        assert "file1" in out
+
+    def test_system_message_inlined(self):
+        out = self._render({
+            "type": "system",
+            "payload": {"subtype": "init_received", "message": "ready"},
+        })
+        assert "system" in out
+        assert "init_received" in out or "ready" in out
+
+    def test_error_renders_code_and_message(self):
+        out = self._render({
+            "type": "error",
+            "payload": {"code": "session_not_running", "message": "nope"},
+        })
+        assert "error" in out
+        assert "session_not_running" in out
+        assert "nope" in out
+
+    def test_session_end_shows_reason(self):
+        out = self._render({
+            "type": "session_end",
+            "payload": {"reason": "completed", "exit_code": 0},
+        })
+        assert "session ended" in out
+        assert "completed" in out
+        assert "exit_code" in out
+
+    def test_result_shows_summary(self):
+        out = self._render({
+            "type": "result",
+            "payload": {"summary": "task done"},
+        })
+        assert "result" in out
+        assert "task done" in out
+
+    def test_approval_request_renders_tool_and_input(self):
+        out = self._render({
+            "type": "tool_approval_request",
+            "payload": {
+                "tool_use_id": "t1",
+                "tool_name": "Bash",
+                "tool_input": {"command": "rm -rf /"},
+            },
+        })
+        assert "approval" in out
+        assert "Bash" in out
+
+    def test_ask_user_question_renders_questions(self):
+        out = self._render({
+            "type": "ask_user_question",
+            "payload": {
+                "question_id": "q1",
+                "questions": [{"question": "Which env?", "header": "env"}],
+            },
+        })
+        assert "question" in out
+        assert "Which env?" in out
+
+    def test_unknown_type_falls_back_to_compact_json(self):
+        out = self._render({
+            "type": "brand_new_type",
+            "payload": {"foo": "bar"},
+        })
+        assert "brand_new_type" in out
+        assert "foo" in out
+
+
+# ---------------------------------------------------------------------------
+# Assistant content extraction
+# ---------------------------------------------------------------------------
+
+class TestExtractAssistantText:
+
+    def test_text_content_blocks_concatenated(self):
+        from limacharlie.commands._ai_attach import _extract_assistant_text
+
+        text = _extract_assistant_text({"content": [
+            {"type": "text", "text": "hello "},
+            {"type": "text", "text": "world"},
+        ]})
+        assert "hello " in text and "world" in text
+
+    def test_string_content_passthrough(self):
+        from limacharlie.commands._ai_attach import _extract_assistant_text
+
+        assert _extract_assistant_text({"content": "plain"}) == "plain"
+
+    def test_missing_content(self):
+        from limacharlie.commands._ai_attach import _extract_assistant_text
+
+        assert _extract_assistant_text({}) == ""
+
+
+# ---------------------------------------------------------------------------
+# Utilities
+# ---------------------------------------------------------------------------
+
+class TestTruncation:
+
+    def test_truncate_preserves_short_strings(self):
+        from limacharlie.commands._ai_attach import _truncate
+
+        assert _truncate("abc", 10) == "abc"
+
+    def test_truncate_appends_ellipsis(self):
+        from limacharlie.commands._ai_attach import _truncate
+
+        out = _truncate("x" * 20, 5)
+        assert out.endswith("...")
+        assert len(out) == 5 + 3
+
+    def test_oneline_collapses_whitespace(self):
+        from limacharlie.commands._ai_attach import _oneline
+
+        assert _oneline("a\n  b\t\tc") == "a b c"
+
+
+# ---------------------------------------------------------------------------
+# CLI registration
+# ---------------------------------------------------------------------------
+
+class TestCliRegistration:
+
+    def test_attach_command_registered_under_ai_session(self):
+        from limacharlie.cli import cli
+
+        runner = click.testing.CliRunner()
+        result = runner.invoke(cli, ["ai", "session", "attach", "--help"])
+        assert result.exit_code == 0, result.output
+        assert "--id" in result.output
+        assert "--read-only" in result.output
+        assert "--interactive" in result.output
+        assert "--raw" in result.output
+
+    def test_attach_requires_session_id(self):
+        from limacharlie.cli import cli
+
+        runner = click.testing.CliRunner()
+        result = runner.invoke(cli, ["ai", "session", "attach"])
+        # Click prints usage error and exits non-zero when required
+        # option is missing.
+        assert result.exit_code != 0
+        assert "--id" in result.output or "id" in result.output.lower()
+
+
+# ---------------------------------------------------------------------------
+# Module-level constants sanity check
+# ---------------------------------------------------------------------------
+
+def test_exported_message_constants_match_protocol():
+    """Defensive: the canonical message-type strings must match what the
+    server actually sends.  If ai-sessions ever renames one of these,
+    every downstream check in this CLI breaks silently.  Fail loudly.
+    """
+    assert ai_session.MSG_ASSISTANT == "assistant"
+    assert ai_session.MSG_TOOL_USE == "tool_use"
+    assert ai_session.MSG_TOOL_APPROVAL_REQUEST == "tool_approval_request"
+    assert ai_session.MSG_ASK_USER_QUESTION == "ask_user_question"
+    assert ai_session.MSG_SESSION_END == "session_end"
+    assert ai_session.MSG_HISTORY == "history"
+    assert ai_session.MSG_PROMPT == "prompt"
+    assert ai_session.MSG_INTERRUPT == "interrupt"
+    assert ai_session.MSG_HEARTBEAT == "heartbeat"
+    assert ai_session.MSG_TOOL_APPROVAL_RESPONSE == "tool_approval_response"
+    assert ai_session.MSG_ASK_USER_QUESTION_RESPONSE == "ask_user_question_response"

--- a/tests/unit/test_ai_session_attach.py
+++ b/tests/unit/test_ai_session_attach.py
@@ -38,15 +38,15 @@ class TestDeriveWsUrl:
 
     def test_https_base_maps_to_wss_owner_endpoint(self):
         url = _derive_ws_url("https://ai.limacharlie.io", "sid-1", read_only=False)
-        assert url == "wss://ai.limacharlie.io/v1/sessions/sid-1/ws"
+        assert url == "wss://ai.limacharlie.io/v1/ws/sessions/sid-1"
 
     def test_https_base_maps_to_wss_org_endpoint(self):
         url = _derive_ws_url("https://ai.limacharlie.io", "sid-1", read_only=True)
-        assert url == "wss://ai.limacharlie.io/v1/org/sessions/sid-1/ws"
+        assert url == "wss://ai.limacharlie.io/v1/ws/org/sessions/sid-1"
 
     def test_http_base_maps_to_ws(self):
         url = _derive_ws_url("http://localhost:8080", "sid-2", read_only=False)
-        assert url == "ws://localhost:8080/v1/sessions/sid-2/ws"
+        assert url == "ws://localhost:8080/v1/ws/sessions/sid-2"
 
     def test_staging_host_preserved(self):
         url = _derive_ws_url(
@@ -227,7 +227,7 @@ class TestSessionAttachmentUrl:
             "sid-42",
             base_url="https://example.test",
         )
-        assert att.url() == "wss://example.test/v1/sessions/sid-42/ws"
+        assert att.url() == "wss://example.test/v1/ws/sessions/sid-42"
 
     def test_url_read_only_uses_org_endpoint(self):
         att = SessionAttachment(
@@ -236,7 +236,7 @@ class TestSessionAttachmentUrl:
             read_only=True,
             base_url="https://example.test",
         )
-        assert att.url() == "wss://example.test/v1/org/sessions/sid-42/ws"
+        assert att.url() == "wss://example.test/v1/ws/org/sessions/sid-42"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_cli_lazy_loading_regression.py
+++ b/tests/unit/test_cli_lazy_loading_regression.py
@@ -114,7 +114,7 @@ EXPECTED_MODULE_MAP = {
 # Every (group, subcommand) pair that must exist.
 EXPECTED_SUBCOMMANDS: dict[str, frozenset[str]] = {
     "ai": frozenset({
-        "auth", "chat",
+        "auth", "chat", "chats",
         "generate-detection", "generate-playbook", "generate-query",
         "generate-response", "generate-rule", "generate-selector",
         "session", "start-session", "summarize-detection", "usage",

--- a/tests/unit/test_cli_lazy_loading_regression.py
+++ b/tests/unit/test_cli_lazy_loading_regression.py
@@ -114,6 +114,7 @@ EXPECTED_MODULE_MAP = {
 # Every (group, subcommand) pair that must exist.
 EXPECTED_SUBCOMMANDS: dict[str, frozenset[str]] = {
     "ai": frozenset({
+        "auth", "chat",
         "generate-detection", "generate-playbook", "generate-query",
         "generate-response", "generate-rule", "generate-selector",
         "session", "start-session", "summarize-detection", "usage",

--- a/tests/unit/test_sdk_ai_sessions.py
+++ b/tests/unit/test_sdk_ai_sessions.py
@@ -674,6 +674,63 @@ class TestClaudeAuthSDK:
         )
 
 
+class TestUserSessionManagementSDK:
+    """list/get/terminate/history mirror their org counterparts but
+    target the user-scoped routes."""
+
+    def test_list_user_sessions_no_filters(self, ai, mock_org):
+        mock_org.client.request.return_value = {
+            "sessions": [], "next_cursor": "",
+        }
+
+        ai.list_user_sessions()
+
+        call_args = mock_org.client.request.call_args
+        assert call_args[0] == ("GET", "v1/sessions")
+        # No qp argument when no filters were passed.
+        assert "query_params" not in call_args[1] or call_args[1]["query_params"] is None
+
+    def test_list_user_sessions_passes_filters(self, ai, mock_org):
+        mock_org.client.request.return_value = {
+            "sessions": [], "next_cursor": "",
+        }
+
+        ai.list_user_sessions(status="running", limit=25, cursor="c-1")
+
+        call_args = mock_org.client.request.call_args
+        assert call_args[0] == ("GET", "v1/sessions")
+        assert call_args[1]["query_params"] == {
+            "status": "running", "limit": "25", "cursor": "c-1",
+        }
+
+    def test_get_user_session(self, ai, mock_org):
+        mock_org.client.request.return_value = {"session": {"id": "u-1"}}
+
+        ai.get_user_session("u-1")
+
+        assert mock_org.client.request.call_args[0] == (
+            "GET", "v1/sessions/u-1",
+        )
+
+    def test_terminate_user_session(self, ai, mock_org):
+        mock_org.client.request.return_value = {"terminated": True}
+
+        ai.terminate_user_session("u-1")
+
+        assert mock_org.client.request.call_args[0] == (
+            "DELETE", "v1/sessions/u-1",
+        )
+
+    def test_get_user_session_history(self, ai, mock_org):
+        mock_org.client.request.return_value = {"messages": []}
+
+        ai.get_user_session_history("u-1")
+
+        assert mock_org.client.request.call_args[0] == (
+            "GET", "v1/sessions/u-1/history",
+        )
+
+
 class TestCreateUserSession:
 
     def test_omits_fields_when_none(self, ai, mock_org):
@@ -898,3 +955,170 @@ class TestChatCommand:
             "--idempotent-key",
         ):
             assert flag in result.output, f"missing flag in chat --help: {flag}"
+
+    def test_does_not_consume_stdin_as_prompt(self):
+        """Piping stdin must NOT become the initial prompt — gap-2 fix.
+
+        Previously `echo 'hello' | ai chat` would silently use 'hello'
+        as the opening prompt; now stdin is reserved for the
+        interactive input loop after attach.
+        """
+        import click.testing
+        from limacharlie.cli import cli
+
+        runner = click.testing.CliRunner()
+        with patch("limacharlie.commands.ai._get_org") as mock_get_org, \
+             patch("limacharlie.commands.ai.AISDK") as MockSDK, \
+             patch("limacharlie.commands._ai_attach.run_attach", return_value=0) as mock_run:
+            mock_get_org.return_value = MagicMock()
+            sdk = MockSDK.return_value
+            sdk.claude_auth_status.return_value = {"has_credentials": True}
+            sdk.register_user.return_value = {"registered": True}
+            sdk.create_user_session.return_value = {
+                "session": {"id": "s-1", "status": "starting"},
+            }
+
+            result = runner.invoke(
+                cli, ["ai", "chat"], input="should-not-become-prompt\n",
+            )
+            assert result.exit_code == 0, result.output
+            assert mock_run.call_args.kwargs["initial_prompt"] is None
+
+
+class TestChatsGroup:
+    """`ai chats` subgroup mirrors `ai session` for user-owned sessions."""
+
+    def _patched(self):
+        return (
+            patch("limacharlie.commands.ai._get_org"),
+            patch("limacharlie.commands.ai.AISDK"),
+        )
+
+    def test_list_calls_user_endpoint(self):
+        import click.testing
+        from limacharlie.cli import cli
+
+        runner = click.testing.CliRunner()
+        with patch("limacharlie.commands.ai._get_org") as mock_get_org, \
+             patch("limacharlie.commands.ai.AISDK") as MockSDK:
+            mock_get_org.return_value = MagicMock()
+            sdk = MockSDK.return_value
+            sdk.list_user_sessions.return_value = {
+                "sessions": [], "next_cursor": "",
+            }
+
+            result = runner.invoke(
+                cli, ["--output", "json", "ai", "chats", "list",
+                      "--status", "running", "--limit", "10"],
+            )
+            assert result.exit_code == 0, result.output
+            sdk.list_user_sessions.assert_called_once_with(
+                status="running", limit=10, cursor=None,
+            )
+
+    def test_get_truncates_prompt_by_default(self):
+        import click.testing
+        from limacharlie.cli import cli
+
+        runner = click.testing.CliRunner()
+        long_prompt = "x" * 500
+        with patch("limacharlie.commands.ai._get_org") as mock_get_org, \
+             patch("limacharlie.commands.ai.AISDK") as MockSDK:
+            mock_get_org.return_value = MagicMock()
+            sdk = MockSDK.return_value
+            sdk.get_user_session.return_value = {
+                "session": {"id": "u-1", "initial_prompt": long_prompt},
+            }
+
+            result = runner.invoke(
+                cli, ["--output", "json", "ai", "chats", "get", "--id", "u-1"],
+            )
+            assert result.exit_code == 0, result.output
+            # Truncation marker present, full text not.
+            assert "..." in result.output
+            assert long_prompt not in result.output
+            sdk.get_user_session.assert_called_once_with("u-1")
+
+    def test_get_full_prompt_flag_disables_truncation(self):
+        import click.testing
+        from limacharlie.cli import cli
+
+        runner = click.testing.CliRunner()
+        long_prompt = "y" * 500
+        with patch("limacharlie.commands.ai._get_org") as mock_get_org, \
+             patch("limacharlie.commands.ai.AISDK") as MockSDK:
+            mock_get_org.return_value = MagicMock()
+            sdk = MockSDK.return_value
+            sdk.get_user_session.return_value = {
+                "session": {"id": "u-1", "initial_prompt": long_prompt},
+            }
+
+            result = runner.invoke(cli, [
+                "--output", "json", "ai", "chats", "get",
+                "--id", "u-1", "--full-prompt",
+            ])
+            assert result.exit_code == 0, result.output
+            assert long_prompt in result.output
+
+    def test_terminate_calls_sdk(self):
+        import click.testing
+        from limacharlie.cli import cli
+
+        runner = click.testing.CliRunner()
+        with patch("limacharlie.commands.ai._get_org") as mock_get_org, \
+             patch("limacharlie.commands.ai.AISDK") as MockSDK:
+            mock_get_org.return_value = MagicMock()
+            sdk = MockSDK.return_value
+            sdk.terminate_user_session.return_value = {"terminated": True}
+
+            result = runner.invoke(cli, [
+                "--output", "json", "ai", "chats", "terminate", "--id", "u-1",
+            ])
+            assert result.exit_code == 0, result.output
+            sdk.terminate_user_session.assert_called_once_with("u-1")
+
+    def test_history_filters_internal_subtypes(self):
+        import click.testing
+        from limacharlie.cli import cli
+
+        runner = click.testing.CliRunner()
+        with patch("limacharlie.commands.ai._get_org") as mock_get_org, \
+             patch("limacharlie.commands.ai.AISDK") as MockSDK:
+            mock_get_org.return_value = MagicMock()
+            sdk = MockSDK.return_value
+            sdk.get_user_session_history.return_value = {
+                "messages": [
+                    {"type": "system", "payload": {"subtype": "model_set"}},
+                    {"type": "assistant", "payload": {"text": "hi"}},
+                ],
+            }
+
+            result = runner.invoke(
+                cli, ["--output", "json", "ai", "chats", "history", "--id", "u-1"],
+            )
+            assert result.exit_code == 0, result.output
+            # Internal model_set subtype filtered out, assistant kept.
+            assert "model_set" not in result.output
+            assert "assistant" in result.output
+
+    def test_history_raw_keeps_everything(self):
+        import click.testing
+        from limacharlie.cli import cli
+
+        runner = click.testing.CliRunner()
+        with patch("limacharlie.commands.ai._get_org") as mock_get_org, \
+             patch("limacharlie.commands.ai.AISDK") as MockSDK:
+            mock_get_org.return_value = MagicMock()
+            sdk = MockSDK.return_value
+            sdk.get_user_session_history.return_value = {
+                "messages": [
+                    {"type": "system", "payload": {"subtype": "model_set"}},
+                ],
+            }
+
+            result = runner.invoke(cli, [
+                "--output", "json", "ai", "chats", "history",
+                "--id", "u-1", "--raw",
+            ])
+            assert result.exit_code == 0, result.output
+            assert "model_set" in result.output

--- a/tests/unit/test_sdk_ai_sessions.py
+++ b/tests/unit/test_sdk_ai_sessions.py
@@ -855,8 +855,12 @@ class TestChatCommand:
                 "has_credentials": True, "credential_type": "apikey",
             }
             sdk.register_user.return_value = {"registered": True}
+            # POST /v1/sessions wraps the session under "session" — same
+            # shape as `ai session get`.
             sdk.create_user_session.return_value = {
-                "id": "sess-user-9", "status": "starting",
+                "session": {
+                    "id": "sess-user-9", "status": "starting",
+                },
             }
 
             result = runner.invoke(cli, [

--- a/tests/unit/test_sdk_ai_sessions.py
+++ b/tests/unit/test_sdk_ai_sessions.py
@@ -555,3 +555,342 @@ class TestStartSessionCliHelp:
             "--plugin", "--env", "--anthropic-key", "--lc-api-key", "--lc-uid",
         ):
             assert flag in result.output, f"missing flag in help: {flag}"
+
+
+# ---------------------------------------------------------------------------
+# User-scoped SDK methods backing `ai chat` and `ai auth claude`
+# ---------------------------------------------------------------------------
+
+class TestUserScopedRequestShape:
+    """_user_request routes through client.request with JWT auth only."""
+
+    def test_get_omits_oid_header_and_body(self, ai, mock_org):
+        mock_org.client.request.return_value = {"has_credentials": False}
+
+        result = ai.claude_auth_status()
+
+        assert result == {"has_credentials": False}
+        call_args = mock_org.client.request.call_args
+        assert call_args[0] == ("GET", "v1/auth/claude/status")
+        assert call_args[1]["alt_root"] == _AI_SESSIONS_URL
+        # User-scoped routes must NOT send X-LC-OID and must use JWT auth
+        # (is_no_auth is absent → client.request attaches the JWT).
+        assert "extra_headers" not in call_args[1]
+        assert "is_no_auth" not in call_args[1]
+        assert "raw_body" not in call_args[1]
+
+    def test_post_sets_content_type_and_body(self, ai, mock_org):
+        mock_org.client.request.return_value = {"success": True}
+
+        ai.claude_set_apikey("sk-ant-literal")
+
+        call_args = mock_org.client.request.call_args
+        assert call_args[0] == ("POST", "v1/auth/claude/apikey")
+        assert call_args[1]["content_type"] == "application/json"
+        body = json.loads(call_args[1]["raw_body"])
+        assert body == {"api_key": "sk-ant-literal"}
+
+
+class TestClaudeAuthSDK:
+
+    def test_register_user_sends_empty_body(self, ai, mock_org):
+        mock_org.client.request.return_value = {
+            "registered": True,
+            "registered_at": "2026-04-18T00:00:00Z",
+        }
+
+        result = ai.register_user()
+
+        assert result["registered"] is True
+        call_args = mock_org.client.request.call_args
+        assert call_args[0] == ("POST", "v1/register")
+        # Empty raw_body triggers the JSON content-type path.
+        assert call_args[1]["raw_body"] == b""
+        assert call_args[1]["content_type"] == "application/json"
+
+    def test_claude_login_start(self, ai, mock_org):
+        mock_org.client.request.return_value = {
+            "oauth_session_id": "os-1",
+            "expires_in": 300,
+            "message": "Poll /auth/claude/url for the OAuth URL",
+        }
+
+        result = ai.claude_login_start()
+
+        assert result["oauth_session_id"] == "os-1"
+        call_args = mock_org.client.request.call_args
+        assert call_args[0] == ("POST", "v1/auth/claude/start")
+
+    def test_claude_login_get_url_passes_query_param(self, ai, mock_org):
+        mock_org.client.request.return_value = {
+            "status": "ready",
+            "url": "https://claude.ai/oauth/authorize?code=...",
+        }
+
+        result = ai.claude_login_get_url("os-1")
+
+        assert result["status"] == "ready"
+        call_args = mock_org.client.request.call_args
+        assert call_args[0] == ("GET", "v1/auth/claude/url")
+        assert call_args[1]["query_params"] == {"session_id": "os-1"}
+
+    def test_claude_login_submit_code_body(self, ai, mock_org):
+        mock_org.client.request.return_value = {
+            "success": True,
+            "status": "completed",
+        }
+
+        ai.claude_login_submit_code("os-1", "code-abc")
+
+        body = json.loads(mock_org.client.request.call_args[1]["raw_body"])
+        assert body == {"session_id": "os-1", "code": "code-abc"}
+
+    def test_claude_set_apikey_resolves_hive_secret(self, ai, mock_org):
+        """A hive://secret/<name> API key is resolved before sending."""
+        mock_org.client.request.return_value = {"success": True}
+
+        with patch("limacharlie.sdk.hive.Hive") as MockHive:
+            hive_instance = MagicMock()
+            MockHive.return_value = hive_instance
+            hive_instance.get.return_value = _make_hive_record(
+                {"secret": "sk-ant-resolved"},
+            )
+
+            ai.claude_set_apikey("hive://secret/anthropic")
+
+            MockHive.assert_called_with(mock_org, "secret")
+            hive_instance.get.assert_called_with("anthropic")
+
+        body = json.loads(mock_org.client.request.call_args[1]["raw_body"])
+        assert body == {"api_key": "sk-ant-resolved"}
+
+    def test_claude_logout_deletes(self, ai, mock_org):
+        mock_org.client.request.return_value = {"success": True}
+
+        ai.claude_logout()
+
+        assert mock_org.client.request.call_args[0] == (
+            "DELETE", "v1/auth/claude",
+        )
+
+
+class TestCreateUserSession:
+
+    def test_omits_fields_when_none(self, ai, mock_org):
+        """Unset kwargs must not appear in the POST body at all, so the
+        server applies its own defaults."""
+        mock_org.client.request.return_value = {
+            "id": "sess-user-1",
+            "status": "starting",
+        }
+
+        ai.create_user_session()
+
+        call_args = mock_org.client.request.call_args
+        assert call_args[0] == ("POST", "v1/sessions")
+        body = json.loads(call_args[1]["raw_body"])
+        assert body == {}
+
+    def test_sends_all_supplied_overrides(self, ai, mock_org):
+        mock_org.client.request.return_value = {"id": "sess-1"}
+
+        ai.create_user_session(
+            name="chat test",
+            idempotent_key="key-1",
+            model="claude-sonnet-4-6",
+            max_turns=10,
+            max_budget_usd=0.5,
+            task_budget_tokens=5000,
+            one_shot=False,
+            permission_mode="acceptEdits",
+            allowed_tools=["Read", "Grep"],
+            denied_tools=["Bash"],
+            plugins=["lc-essentials"],
+        )
+
+        body = json.loads(mock_org.client.request.call_args[1]["raw_body"])
+        assert body == {
+            "name": "chat test",
+            "idempotent_key": "key-1",
+            "model": "claude-sonnet-4-6",
+            "max_turns": 10,
+            "max_budget_usd": 0.5,
+            "task_budget_tokens": 5000,
+            "one_shot": False,
+            "permission_mode": "acceptEdits",
+            "allowed_tools": ["Read", "Grep"],
+            "denied_tools": ["Bash"],
+            "plugins": ["lc-essentials"],
+        }
+
+
+# ---------------------------------------------------------------------------
+# CLI: `ai auth claude` and `ai chat`
+# ---------------------------------------------------------------------------
+
+class TestAuthClaudeCommands:
+    """CLI surface around Claude credential management."""
+
+    def test_status_calls_sdk(self):
+        import click.testing
+        from limacharlie.cli import cli
+
+        runner = click.testing.CliRunner()
+        with patch("limacharlie.commands.ai._get_org") as mock_get_org, \
+             patch("limacharlie.commands.ai.AISDK") as MockSDK:
+            mock_get_org.return_value = MagicMock()
+            sdk = MockSDK.return_value
+            sdk.claude_auth_status.return_value = {"has_credentials": False}
+
+            result = runner.invoke(
+                cli, ["--output", "json", "ai", "auth", "claude", "status"],
+            )
+            assert result.exit_code == 0, result.output
+            sdk.claude_auth_status.assert_called_once_with()
+
+    def test_set_key_rejects_both_sources(self):
+        import click.testing
+        from limacharlie.cli import cli
+
+        runner = click.testing.CliRunner()
+        with patch("limacharlie.commands.ai._get_org") as mock_get_org, \
+             patch("limacharlie.commands.ai.AISDK") as MockSDK:
+            mock_get_org.return_value = MagicMock()
+            MockSDK.return_value = MagicMock()
+
+            result = runner.invoke(cli, [
+                "ai", "auth", "claude", "set-key",
+                "--key", "sk-literal", "--key-from-stdin",
+            ])
+            # Mutually exclusive flags must fail fast with a usage error.
+            assert result.exit_code != 0
+            assert "mutually exclusive" in result.output.lower()
+
+    def test_set_key_requires_one_source(self):
+        import click.testing
+        from limacharlie.cli import cli
+
+        runner = click.testing.CliRunner()
+        with patch("limacharlie.commands.ai._get_org") as mock_get_org, \
+             patch("limacharlie.commands.ai.AISDK") as MockSDK:
+            mock_get_org.return_value = MagicMock()
+            MockSDK.return_value = MagicMock()
+
+            result = runner.invoke(cli, ["ai", "auth", "claude", "set-key"])
+            assert result.exit_code != 0
+            assert "required" in result.output.lower()
+
+    def test_set_key_reads_stdin(self):
+        import click.testing
+        from limacharlie.cli import cli
+
+        runner = click.testing.CliRunner()
+        with patch("limacharlie.commands.ai._get_org") as mock_get_org, \
+             patch("limacharlie.commands.ai.AISDK") as MockSDK:
+            mock_get_org.return_value = MagicMock()
+            sdk = MockSDK.return_value
+            sdk.claude_set_apikey.return_value = {"success": True}
+
+            result = runner.invoke(
+                cli,
+                ["--output", "json", "ai", "auth", "claude", "set-key",
+                 "--key-from-stdin"],
+                input="sk-ant-piped\n",
+            )
+            assert result.exit_code == 0, result.output
+            sdk.claude_set_apikey.assert_called_once_with("sk-ant-piped")
+
+    def test_logout_calls_sdk(self):
+        import click.testing
+        from limacharlie.cli import cli
+
+        runner = click.testing.CliRunner()
+        with patch("limacharlie.commands.ai._get_org") as mock_get_org, \
+             patch("limacharlie.commands.ai.AISDK") as MockSDK:
+            mock_get_org.return_value = MagicMock()
+            sdk = MockSDK.return_value
+            sdk.claude_logout.return_value = {"success": True}
+
+            result = runner.invoke(
+                cli, ["--output", "json", "ai", "auth", "claude", "logout"],
+            )
+            assert result.exit_code == 0, result.output
+            sdk.claude_logout.assert_called_once_with()
+
+
+class TestChatCommand:
+    """CLI surface around the interactive chat command."""
+
+    def test_fails_fast_when_no_claude_credentials(self):
+        import click.testing
+        from limacharlie.cli import cli
+
+        runner = click.testing.CliRunner()
+        with patch("limacharlie.commands.ai._get_org") as mock_get_org, \
+             patch("limacharlie.commands.ai.AISDK") as MockSDK:
+            mock_get_org.return_value = MagicMock()
+            sdk = MockSDK.return_value
+            sdk.claude_auth_status.return_value = {"has_credentials": False}
+
+            result = runner.invoke(cli, ["ai", "chat", "hello"])
+
+            assert result.exit_code != 0
+            assert "No Claude credentials" in result.output
+            # Must not attempt to create a session if creds missing.
+            sdk.create_user_session.assert_not_called()
+            sdk.register_user.assert_not_called()
+
+    def test_happy_path_creates_and_attaches(self):
+        import click.testing
+        from limacharlie.cli import cli
+
+        runner = click.testing.CliRunner()
+        with patch("limacharlie.commands.ai._get_org") as mock_get_org, \
+             patch("limacharlie.commands.ai.AISDK") as MockSDK, \
+             patch("limacharlie.commands.ai._split_csv", side_effect=lambda v: None if v is None else v.split(",")), \
+             patch("limacharlie.commands._ai_attach.run_attach", return_value=0) as mock_run:
+            mock_get_org.return_value = MagicMock()
+            sdk = MockSDK.return_value
+            sdk.claude_auth_status.return_value = {
+                "has_credentials": True, "credential_type": "apikey",
+            }
+            sdk.register_user.return_value = {"registered": True}
+            sdk.create_user_session.return_value = {
+                "id": "sess-user-9", "status": "starting",
+            }
+
+            result = runner.invoke(cli, [
+                "ai", "chat", "hello there",
+                "--model", "claude-sonnet-4-6",
+                "--max-budget-usd", "0.10",
+            ])
+
+            assert result.exit_code == 0, result.output
+            sdk.register_user.assert_called_once_with()
+            # Overrides propagate as kwargs to create_user_session.
+            create_kwargs = sdk.create_user_session.call_args.kwargs
+            assert create_kwargs["model"] == "claude-sonnet-4-6"
+            assert create_kwargs["max_budget_usd"] == 0.10
+            # run_attach called with the created session id, interactive
+            # mode on, initial_prompt from the CLI arg.
+            mock_run.assert_called_once()
+            kwargs = mock_run.call_args.kwargs
+            assert mock_run.call_args.args[1] == "sess-user-9"
+            assert kwargs["interactive"] is True
+            assert kwargs["read_only"] is False
+            assert kwargs["initial_prompt"] == "hello there"
+
+    def test_help_lists_flags(self):
+        import click.testing
+        from limacharlie.cli import cli
+
+        runner = click.testing.CliRunner()
+        result = runner.invoke(cli, ["ai", "chat", "--help"])
+        assert result.exit_code == 0, result.output
+        for flag in (
+            "--name", "--model", "--max-turns", "--max-budget-usd",
+            "--task-budget-tokens", "--permission-mode",
+            "--allowed-tools", "--denied-tools", "--plugin",
+            "--idempotent-key",
+        ):
+            assert flag in result.output, f"missing flag in chat --help: {flag}"

--- a/tests/unit/test_sdk_ai_sessions.py
+++ b/tests/unit/test_sdk_ai_sessions.py
@@ -678,29 +678,87 @@ class TestUserSessionManagementSDK:
     """list/get/terminate/history mirror their org counterparts but
     target the user-scoped routes."""
 
-    def test_list_user_sessions_no_filters(self, ai, mock_org):
+    # --- single-page (list_user_sessions_page) ---
+
+    def test_list_user_sessions_page_no_filters(self, ai, mock_org):
         mock_org.client.request.return_value = {
             "sessions": [], "next_cursor": "",
         }
 
-        ai.list_user_sessions()
+        ai.list_user_sessions_page()
 
         call_args = mock_org.client.request.call_args
         assert call_args[0] == ("GET", "v1/sessions")
         # No qp argument when no filters were passed.
         assert "query_params" not in call_args[1] or call_args[1]["query_params"] is None
 
-    def test_list_user_sessions_passes_filters(self, ai, mock_org):
+    def test_list_user_sessions_page_passes_filters(self, ai, mock_org):
         mock_org.client.request.return_value = {
             "sessions": [], "next_cursor": "",
         }
 
-        ai.list_user_sessions(status="running", limit=25, cursor="c-1")
+        ai.list_user_sessions_page(status="running", limit=25, cursor="c-1")
 
         call_args = mock_org.client.request.call_args
         assert call_args[0] == ("GET", "v1/sessions")
         assert call_args[1]["query_params"] == {
             "status": "running", "limit": "25", "cursor": "c-1",
+        }
+
+    # --- auto-drain generator (list_user_sessions) ---
+
+    def test_list_user_sessions_drains_cursor(self, ai, mock_org):
+        mock_org.client.request.side_effect = [
+            {"sessions": [{"id": "s1"}, {"id": "s2"}], "next_cursor": "c-2"},
+            {"sessions": [{"id": "s3"}], "next_cursor": None},
+        ]
+
+        result = list(ai.list_user_sessions())
+
+        assert [s["id"] for s in result] == ["s1", "s2", "s3"]
+        assert mock_org.client.request.call_count == 2
+        # Second request carries the cursor from the first response.
+        second_qp = mock_org.client.request.call_args_list[1][1]["query_params"]
+        assert second_qp == {"cursor": "c-2"}
+
+    def test_list_user_sessions_limit_stops_iteration(self, ai, mock_org):
+        # Even when the server offers a next_cursor, reaching the total
+        # limit on the current page stops draining and does not issue
+        # another request.
+        mock_org.client.request.return_value = {
+            "sessions": [{"id": "s1"}, {"id": "s2"}, {"id": "s3"}],
+            "next_cursor": "more",
+        }
+
+        result = list(ai.list_user_sessions(limit=2))
+
+        assert [s["id"] for s in result] == ["s1", "s2"]
+        assert mock_org.client.request.call_count == 1
+
+    def test_list_user_sessions_empty_cursor_stops(self, ai, mock_org):
+        # next_cursor == "" is treated the same as None: done.
+        mock_org.client.request.return_value = {
+            "sessions": [{"id": "s1"}],
+            "next_cursor": "",
+        }
+
+        result = list(ai.list_user_sessions())
+
+        assert [s["id"] for s in result] == ["s1"]
+        assert mock_org.client.request.call_count == 1
+
+    def test_list_user_sessions_page_size_maps_to_server_limit(self, ai, mock_org):
+        # page_size is the server-side per-page cap; `limit` is the
+        # client-side total cap and must not leak into the request qp.
+        mock_org.client.request.return_value = {
+            "sessions": [], "next_cursor": "",
+        }
+
+        list(ai.list_user_sessions(status="running", page_size=25))
+
+        call_args = mock_org.client.request.call_args
+        assert call_args[1]["query_params"] == {
+            "status": "running", "limit": "25",
         }
 
     def test_get_user_session(self, ai, mock_org):
@@ -994,7 +1052,8 @@ class TestChatsGroup:
             patch("limacharlie.commands.ai.AISDK"),
         )
 
-    def test_list_calls_user_endpoint(self):
+    def test_list_drains_by_default(self):
+        # Default `chats list` auto-drains via the generator API.
         import click.testing
         from limacharlie.cli import cli
 
@@ -1003,9 +1062,7 @@ class TestChatsGroup:
              patch("limacharlie.commands.ai.AISDK") as MockSDK:
             mock_get_org.return_value = MagicMock()
             sdk = MockSDK.return_value
-            sdk.list_user_sessions.return_value = {
-                "sessions": [], "next_cursor": "",
-            }
+            sdk.list_user_sessions.return_value = iter([])
 
             result = runner.invoke(
                 cli, ["--output", "json", "ai", "chats", "list",
@@ -1013,8 +1070,39 @@ class TestChatsGroup:
             )
             assert result.exit_code == 0, result.output
             sdk.list_user_sessions.assert_called_once_with(
-                status="running", limit=10, cursor=None,
+                status="running", limit=10,
             )
+            # Must not have touched the single-page path.
+            sdk.list_user_sessions_page.assert_not_called()
+
+    def test_list_with_cursor_uses_single_page(self):
+        # Explicit --cursor opts into the single-page API so callers
+        # can resume pagination themselves; output is the raw dict.
+        import click.testing
+        from limacharlie.cli import cli
+
+        runner = click.testing.CliRunner()
+        with patch("limacharlie.commands.ai._get_org") as mock_get_org, \
+             patch("limacharlie.commands.ai.AISDK") as MockSDK:
+            mock_get_org.return_value = MagicMock()
+            sdk = MockSDK.return_value
+            sdk.list_user_sessions_page.return_value = {
+                "sessions": [], "next_cursor": "c-next",
+            }
+
+            result = runner.invoke(
+                cli, ["--output", "json", "ai", "chats", "list",
+                      "--status", "running", "--limit", "10",
+                      "--cursor", "c-here"],
+            )
+            assert result.exit_code == 0, result.output
+            sdk.list_user_sessions_page.assert_called_once_with(
+                status="running", limit=10, cursor="c-here",
+            )
+            # Must not have fallen back to the auto-drain path.
+            sdk.list_user_sessions.assert_not_called()
+            # Raw pagination response preserved for the caller.
+            assert "c-next" in result.output
 
     def test_get_truncates_prompt_by_default(self):
         import click.testing

--- a/tests/unit/test_sdk_ai_sessions.py
+++ b/tests/unit/test_sdk_ai_sessions.py
@@ -297,3 +297,261 @@ class TestStartSessionEnvironmentSecrets:
         body = json.loads(mock_org.client.request.call_args[1]["raw_body"])
         assert body["profile"]["environment"]["EXTERNAL_KEY"] == "ext-resolved"
         assert body["profile"]["environment"]["PLAIN"] == "plain-value"
+
+
+# ---------------------------------------------------------------------------
+# Profile field overrides (template-on-top-of-hive-record semantics)
+# ---------------------------------------------------------------------------
+
+def _minimal_defn(**extra):
+    """A hive record with just enough to pass validation."""
+    base = {
+        "prompt": "template prompt",
+        "anthropic_secret": "sk-template",
+        "lc_api_key_secret": "lc-template",
+    }
+    base.update(extra)
+    return base
+
+
+def _run_start(ai, mock_org, defn, extra_records=None, **kwargs):
+    """Run start_session with a stubbed hive and return the posted body."""
+    records = {"agent": _make_hive_record(defn)}
+    if extra_records:
+        for name, data in extra_records.items():
+            records[name] = _make_hive_record(data)
+
+    with patch("limacharlie.sdk.hive.Hive") as MockHive:
+        hive_instance = MagicMock()
+        MockHive.return_value = hive_instance
+        hive_instance.get.side_effect = lambda n: records[n]
+        mock_org.client.request.return_value = {"session_id": "s1"}
+        ai.start_session("agent", **kwargs)
+
+    return json.loads(mock_org.client.request.call_args[1]["raw_body"])
+
+
+class TestStartSessionScalarOverrides:
+    """Individual scalar overrides replace matching template fields."""
+
+    def test_model_override_replaces_template(self, ai, mock_org):
+        defn = _minimal_defn(model="claude-opus-4-6", max_turns=50)
+        body = _run_start(ai, mock_org, defn, model="claude-sonnet-4-6")
+        assert body["profile"]["model"] == "claude-sonnet-4-6"
+        # max_turns stays from template.
+        assert body["profile"]["max_turns"] == 50
+
+    def test_max_budget_override(self, ai, mock_org):
+        defn = _minimal_defn(max_budget_usd=10.0)
+        body = _run_start(ai, mock_org, defn, max_budget_usd=2.5)
+        assert body["profile"]["max_budget_usd"] == 2.5
+
+    def test_max_turns_override(self, ai, mock_org):
+        defn = _minimal_defn(max_turns=100)
+        body = _run_start(ai, mock_org, defn, max_turns=5)
+        assert body["profile"]["max_turns"] == 5
+
+    def test_task_budget_tokens_override(self, ai, mock_org):
+        defn = _minimal_defn()
+        body = _run_start(ai, mock_org, defn, task_budget_tokens=50000)
+        assert body["profile"]["task_budget_tokens"] == 50000
+
+    def test_ttl_seconds_override(self, ai, mock_org):
+        defn = _minimal_defn(ttl_seconds=3600)
+        body = _run_start(ai, mock_org, defn, ttl_seconds=60)
+        assert body["profile"]["ttl_seconds"] == 60
+
+    def test_permission_mode_override(self, ai, mock_org):
+        defn = _minimal_defn(permission_mode="plan")
+        body = _run_start(ai, mock_org, defn, permission_mode="acceptEdits")
+        assert body["profile"]["permission_mode"] == "acceptEdits"
+
+    def test_one_shot_forced_on(self, ai, mock_org):
+        defn = _minimal_defn(one_shot=False)
+        body = _run_start(ai, mock_org, defn, one_shot=True)
+        assert body["profile"]["one_shot"] is True
+
+    def test_one_shot_forced_off(self, ai, mock_org):
+        defn = _minimal_defn(one_shot=True)
+        body = _run_start(ai, mock_org, defn, one_shot=False)
+        assert body["profile"]["one_shot"] is False
+
+    def test_none_overrides_keep_template(self, ai, mock_org):
+        """Passing no overrides leaves every template field intact."""
+        defn = _minimal_defn(
+            model="claude-opus-4-6",
+            max_turns=10,
+            max_budget_usd=5.0,
+            permission_mode="plan",
+            one_shot=True,
+            ttl_seconds=120,
+        )
+        body = _run_start(ai, mock_org, defn)
+        p = body["profile"]
+        assert p["model"] == "claude-opus-4-6"
+        assert p["max_turns"] == 10
+        assert p["max_budget_usd"] == 5.0
+        assert p["permission_mode"] == "plan"
+        assert p["one_shot"] is True
+        assert p["ttl_seconds"] == 120
+
+
+class TestStartSessionListOverrides:
+    """List fields replace (not merge) when overridden."""
+
+    def test_allowed_tools_replaces(self, ai, mock_org):
+        defn = _minimal_defn(allowed_tools=["Read", "Grep", "Bash", "Write"])
+        body = _run_start(ai, mock_org, defn, allowed_tools=["Read"])
+        assert body["profile"]["allowed_tools"] == ["Read"]
+
+    def test_denied_tools_replaces(self, ai, mock_org):
+        defn = _minimal_defn(denied_tools=["Bash"])
+        body = _run_start(ai, mock_org, defn, denied_tools=["Bash", "Write"])
+        assert body["profile"]["denied_tools"] == ["Bash", "Write"]
+
+    def test_plugins_replaces(self, ai, mock_org):
+        defn = _minimal_defn(plugins=["lc-essentials"])
+        body = _run_start(ai, mock_org, defn,
+                          plugins=["lc-essentials", "lc-advanced-skills"])
+        assert body["profile"]["plugins"] == ["lc-essentials", "lc-advanced-skills"]
+
+    def test_empty_list_override_replaces_with_empty(self, ai, mock_org):
+        """Passing [] is distinct from not passing anything.
+
+        An explicit empty list means "clear the template value"; None
+        means "keep it".  This matches the CLI semantic where the flag
+        defaults to None until the user supplies it.
+        """
+        defn = _minimal_defn(allowed_tools=["Read", "Bash"])
+        body = _run_start(ai, mock_org, defn, allowed_tools=[])
+        assert body["profile"]["allowed_tools"] == []
+
+
+class TestStartSessionEnvironmentOverride:
+    """Environment MERGES template + overrides, override wins on collisions."""
+
+    def test_env_override_adds_new_keys(self, ai, mock_org):
+        defn = _minimal_defn(environment={"BASE": "base-value"})
+        body = _run_start(ai, mock_org, defn,
+                          environment={"EXTRA": "extra-value"})
+        env = body["profile"]["environment"]
+        assert env["BASE"] == "base-value"
+        assert env["EXTRA"] == "extra-value"
+
+    def test_env_override_wins_on_collision(self, ai, mock_org):
+        defn = _minimal_defn(environment={"SHARED": "from-template"})
+        body = _run_start(ai, mock_org, defn,
+                          environment={"SHARED": "from-cli"})
+        assert body["profile"]["environment"]["SHARED"] == "from-cli"
+
+    def test_env_override_secrets_resolve(self, ai, mock_org):
+        defn = _minimal_defn(environment={"TEMPLATE_SECRET": "hive://secret/t-key"})
+        body = _run_start(
+            ai, mock_org, defn,
+            environment={"OVERRIDE_SECRET": "hive://secret/o-key"},
+            extra_records={
+                "t-key": {"secret": "template-resolved"},
+                "o-key": {"secret": "override-resolved"},
+            },
+        )
+        env = body["profile"]["environment"]
+        assert env["TEMPLATE_SECRET"] == "template-resolved"
+        assert env["OVERRIDE_SECRET"] == "override-resolved"
+
+    def test_env_override_without_template_env(self, ai, mock_org):
+        defn = _minimal_defn()
+        body = _run_start(ai, mock_org, defn,
+                          environment={"NEW": "value"})
+        assert body["profile"]["environment"] == {"NEW": "value"}
+
+
+class TestStartSessionCredentialOverrides:
+    """anthropic_key / lc_api_key / lc_uid overrides bypass the hive defaults."""
+
+    def test_anthropic_key_literal_override(self, ai, mock_org):
+        defn = _minimal_defn(anthropic_secret="sk-from-template")
+        body = _run_start(ai, mock_org, defn, anthropic_key="sk-override")
+        assert body["anthropic_key"] == "sk-override"
+
+    def test_anthropic_key_secret_ref_override(self, ai, mock_org):
+        defn = _minimal_defn(anthropic_secret="sk-from-template")
+        body = _run_start(
+            ai, mock_org, defn,
+            anthropic_key="hive://secret/different-key",
+            extra_records={"different-key": {"secret": "sk-resolved-via-override"}},
+        )
+        assert body["anthropic_key"] == "sk-resolved-via-override"
+
+    def test_lc_api_key_override(self, ai, mock_org):
+        defn = _minimal_defn(lc_api_key_secret="template-lc")
+        body = _run_start(ai, mock_org, defn, lc_api_key="override-lc")
+        assert body["lc_api_key"] == "override-lc"
+
+    def test_lc_uid_override(self, ai, mock_org):
+        defn = _minimal_defn()
+        body = _run_start(ai, mock_org, defn, lc_uid="override-uid")
+        assert body["lc_uid"] == "override-uid"
+
+
+# ---------------------------------------------------------------------------
+# CLI surface: parsing helpers and Click registration
+# ---------------------------------------------------------------------------
+
+class TestCliOverrideParsing:
+
+    def test_split_csv_none_passthrough(self):
+        from limacharlie.commands.ai import _split_csv
+        assert _split_csv(None) is None
+
+    def test_split_csv_splits_and_strips(self):
+        from limacharlie.commands.ai import _split_csv
+        assert _split_csv("a, b ,c,") == ["a", "b", "c"]
+
+    def test_split_csv_empty_string_yields_empty_list(self):
+        """Explicit empty value (-t '') clears the template list."""
+        from limacharlie.commands.ai import _split_csv
+        assert _split_csv("") == []
+
+    def test_parse_env_kv_empty_tuple_returns_none(self):
+        from limacharlie.commands.ai import _parse_env_kv
+        assert _parse_env_kv(()) is None
+
+    def test_parse_env_kv_builds_dict(self):
+        from limacharlie.commands.ai import _parse_env_kv
+        assert _parse_env_kv(("FOO=bar", "BAZ=qux")) == {"FOO": "bar", "BAZ": "qux"}
+
+    def test_parse_env_kv_preserves_value_equals(self):
+        """Only the first '=' splits; later ones stay in the value."""
+        from limacharlie.commands.ai import _parse_env_kv
+        assert _parse_env_kv(("URL=https://x?a=1",)) == {"URL": "https://x?a=1"}
+
+    def test_parse_env_kv_rejects_bare_value(self):
+        import click
+        from limacharlie.commands.ai import _parse_env_kv
+        with pytest.raises(click.BadParameter):
+            _parse_env_kv(("no-equals-here",))
+
+    def test_parse_env_kv_rejects_empty_key(self):
+        import click
+        from limacharlie.commands.ai import _parse_env_kv
+        with pytest.raises(click.BadParameter):
+            _parse_env_kv(("=bare",))
+
+
+class TestStartSessionCliHelp:
+    """The Click command exposes every override flag in --help output."""
+
+    def test_help_lists_every_override(self):
+        import click.testing
+        from limacharlie.cli import cli
+
+        runner = click.testing.CliRunner()
+        result = runner.invoke(cli, ["ai", "start-session", "--help"])
+        assert result.exit_code == 0, result.output
+        for flag in (
+            "--model", "--max-turns", "--max-budget-usd",
+            "--task-budget-tokens", "--ttl-seconds", "--one-shot",
+            "--permission-mode", "--allowed-tools", "--denied-tools",
+            "--plugin", "--env", "--anthropic-key", "--lc-api-key", "--lc-uid",
+        ):
+            assert flag in result.output, f"missing flag in help: {flag}"


### PR DESCRIPTION
## Summary

Three related additions to the `ai` CLI, on top of cli-v2.  Together they cover the two distinct session models the ai-sessions backend exposes — org-owned automation and user-owned interactive — plus the WebSocket attach that streams both.

### 1. `limacharlie ai session attach` — live session streaming + interactive chat

- New subcommand that opens a WebSocket to `ai.limacharlie.io` and streams session messages in real time with colour-coded pretty-printing (`--raw` for JSON).
- `--interactive` / `-i` turns the terminal into a chat: stdin lines are sent as `prompt` messages; `tool_approval_request` and `ask_user_question` messages are surfaced as live prompts; `/interrupt` and `/quit` built in.
- `--read-only` connects to the org-scoped `/v1/ws/org/sessions/{id}` endpoint.  When the owner endpoint returns 403 (the caller isn't the session owner), the CLI transparently falls back to read-only with a notice.
- WS URL path uses the `/v1/ws/...` form — the only prefix the GCP load balancer routes to the interaction-proxy.  The legacy `/v1/sessions/{id}/ws` form registered on the proxy service isn't reachable through the LB and returns 404.
- New `limacharlie.sdk.ai_session.SessionAttachment` async helper wrapping the full WebSocket protocol (see `ai-sessions/api/WEBSOCKET_PROTOCOL.md`): prompt, interrupt, tool_approval_response, ask_user_question_response, heartbeat.
- `AI.attach_session(session_id, read_only=...)` factory on the SDK.
- Adds `websockets>=13.0` to runtime dependencies.

**Important:** sessions created by `ai start-session` (below) are org-owned (`OwnerOID` set, `OwnerUID` empty, `SessionType=API`).  The backend exposes those only through the read-only org-scoped WS endpoint, so `ai session attach --interactive` against an org-started session will always auto-fall back to read-only.  Use `ai chat` (below) to get a real interactive session.

### 2. `limacharlie ai start-session` + `ai session {list,get,terminate,history}` — org-owned sessions

`ai start-session` runs an `ai_agent` hive record as a template; every field on the server's `ProfileContent` schema can be overridden for a single run:

- `--model`, `--max-turns`, `--max-budget-usd`, `--task-budget-tokens`, `--ttl-seconds`, `--one-shot/--no-one-shot`, `--permission-mode`, `--allowed-tools`, `--denied-tools`, `--plugin` (repeatable).
- `--env KEY=VALUE` (repeatable) — merged with the template's environment; override wins on key collisions.
- `--anthropic-key`, `--lc-api-key`, `--lc-uid` — credential overrides that accept literal values or `hive://secret/<name>` refs.

Scalars and lists REPLACE the template value when passed.  Environment MERGES.  Omitted flags leave the template untouched.  Override values starting with `hive://secret/` are resolved before sending so secrets never appear in argv.

The `ai session` group manages org-owned sessions through their lifecycle: `list`, `get`, `terminate`, `history`, `attach`.

Examples:
\`\`\`
limacharlie ai start-session --definition my-agent \
  --model claude-sonnet-4-6 --max-budget-usd 2.50
limacharlie ai start-session --definition my-agent \
  --env SLACK_WEBHOOK=hive://secret/slack-webhook
limacharlie ai start-session --definition my-agent \
  --allowed-tools Read,Grep --denied-tools Bash,Write --no-one-shot
\`\`\`

### 3. `limacharlie ai chat` + `ai chats {list,get,terminate,history}` + `ai auth claude` — user-owned interactive sessions

`ai start-session` creates **org-owned** sessions (read-only over the WS by design).  `ai chat` creates **user-owned** sessions billed against the caller's registered Claude credential, opens the owner WS endpoint, and hands the terminal off to the interactive attach loop — the setup the existing `--interactive` flag was always describing.

`ai chats` is the user-scoped counterpart to `ai session`: same subcommand shape (`list`, `get`, `terminate`, `history`), but it routes to `/v1/sessions/*` (user-owned, keyed by the caller's UID) instead of `/v1/org/sessions/*`.  Sessions of one kind are not visible from the other group's commands; they live in distinct ownership models on the backend.

New credential-management surface (one-time setup before `ai chat` works):

- `ai auth claude status` — returns `has_credentials`, `credential_type` (`oauth_token` / `apikey`), `created_at`.
- `ai auth claude login` — full browser OAuth flow: calls `/v1/auth/claude/start`, polls `/v1/auth/claude/url` for the URL, prompts the user for the returned code, posts it to `/v1/auth/claude/code`.
- `ai auth claude set-key --key <VALUE>` (or `--key-from-stdin`) — stores a raw Anthropic API key; `hive://secret/<name>` is resolved before sending.
- `ai auth claude logout` — `DELETE /v1/auth/claude`.

`ai chat` flow:

1. Calls `claude_auth_status`; if `has_credentials=false`, exits non-zero with a pointer to `auth claude login` / `set-key`.  No silent fallback.
2. Calls `POST /v1/register` (idempotent).
3. `POST /v1/sessions` with any supplied overrides (`--model`, `--max-turns`, `--max-budget-usd`, `--task-budget-tokens`, `--permission-mode`, `--allowed-tools`, `--denied-tools`, `--plugin`, `--name`, `--idempotent-key`).
4. Attaches via the owner WS endpoint in interactive mode.  If a `PROMPT` argument is given it's sent as the opening prompt; further turns come from the interactive stdin loop.  Stdin is **not** consumed as the opening prompt — supply that via the argument so multi-line piping doesn't get glued into one message.

Examples:
\`\`\`
limacharlie ai auth claude login
limacharlie ai chat "what sensors pinged in the last hour?"
limacharlie ai chat --model claude-sonnet-4-6 --max-budget-usd 0.50
limacharlie ai chats list --status running
limacharlie ai chats terminate --id <id>
\`\`\`

The existing `ai session attach` still works for either kind of session — use it to rejoin an existing session or view an org-owned one live in read-only mode.

## Cross-linked PRs

- documentation (CLI reference page): https://github.com/refractionPOINT/documentation/pull/189
- lc-ai (READMEs): https://github.com/refractionPOINT/lc-ai/pull/82

## Protocol references
- WebSocket auth / endpoints / message types: `ai-sessions/internal/proxy/handler.go:111-397` and `ai-sessions/api/WEBSOCKET_PROTOCOL.md`.  GCP LB URL map: `ai-sessions/terraform/modules/load-balancer/main.tf:137-190` — `/v1/ws/*` routes to the interaction-proxy.
- Org-session shape: `ai-sessions/pkg/api/types.go` (`SessionRequest` / `ProfileContent`).
- User-session shape: `ai-sessions/internal/sessionmanager/models.go` (`CreateSessionRequest`).  Routes: `handler.go:36-43`.
- Claude credential management handlers: `ai-sessions/internal/claudeauth/handler.go`.
- Auth middleware: `ai-sessions/internal/common/jwt.go` — accepts `Authorization: Bearer <jwt>` and `Sec-WebSocket-Protocol: access_token, <jwt>`; the CLI uses the header form via `Client.get_jwt()`.

## Test plan
- [x] `pytest tests/unit/` — 3075 passed, 5 pre-existing platform/docstring skips.  39 in `tests/unit/test_ai_session_attach.py` plus 73 in the extended `tests/unit/test_sdk_ai_sessions.py` (org SDK + user SDK + auth + chat + chats CLI groups).
- [x] Manual (white-sands, prod): `ai start-session` override propagation verified on-wire (model/max_turns/max_budget_set in session init); `max_budget_usd=0.10` cap triggered precisely at \$0.10530.
- [x] Manual (white-sands, prod): `ai session attach` connects via `/v1/ws/sessions/{id}`; pretty + `--raw | jq` both work; owner endpoint 403 → transparent read-only fallback notice emitted.
- [x] Manual (prod): `ai auth claude status` returns the live credential state.
- [x] Manual (white-sands, prod): `ai chat "What is the capital of France?"` against a registered user — assistant replied "Paris" in interactive mode (no read-only fallback).
- [x] Manual (white-sands, prod): re-attach via `ai session attach --interactive` to the same session and send a follow-up — assistant replied "56" to "What is 7 times 8?".
- [x] Manual (white-sands, prod): `ai chats list` / `ai chats get --id <id>` show user-owned sessions invisible to `ai session list`.
- [ ] Manual: `ai auth claude login` against a fresh user — walk through browser flow, confirm credential stored.
- [ ] Manual: `ai auth claude set-key --key-from-stdin` with a raw Anthropic key.