### PR TITLE
Migrate billing endpoints from billing-service to lc_api-go

### DIFF
--- a/limacharlie/Billing.py
+++ b/limacharlie/Billing.py
@@ -12,10 +12,10 @@ class Billing( object ):
         self._manager = manager
 
     def getOrgStatus( self ):
-        return self._manager._apiCall( 'orgs/%s/status' % ( self._manager._oid, ), GET, altRoot = 'https://billing.limacharlie.io/' )
+        return self._manager._apiCall( 'orgs/%s/billing/status' % ( self._manager._oid, ), GET )
 
     def getOrgDetails( self ):
-        return self._manager._apiCall( 'orgs/%s/details' % ( self._manager._oid, ), GET, altRoot = 'https://billing.limacharlie.io/' )
+        return self._manager._apiCall( 'orgs/%s/billing/details' % ( self._manager._oid, ), GET )
 
     def getOrgInvoiceURL( self, year, month, format = None ):
         year = str( int( year ) )
@@ -23,13 +23,13 @@ class Billing( object ):
         params = {}
         if format:
             params[ 'format' ] = format
-        return self._manager._apiCall( 'orgs/%s/invoice_url/%s/%s' % ( self._manager._oid, year, month ), GET, altRoot = 'https://billing.limacharlie.io/', queryParams = params )
+        return self._manager._apiCall( 'orgs/%s/billing/invoice/%s/%s' % ( self._manager._oid, year, month ), GET, queryParams = params )
 
     def getAvailablePlans( self ):
-        return self._manager._apiCall( 'user/self/plans', GET, altRoot = 'https://billing.limacharlie.io/' )
-
-    def getUserAuthRequirements( self ):
-        return self._manager._apiCall( 'user/self/auth', GET, altRoot = 'https://billing.limacharlie.io/' )
+        return self._manager._apiCall( 'plans', GET )
 
     def getSkuDefinitions( self ):
-        return self._manager._apiCall( 'orgs/%s/sku-definitions' % ( self._manager._oid, ), GET, altRoot = 'https://billing.limacharlie.io/' )
+        return self._manager._apiCall( 'orgs/%s/billing/sku' % ( self._manager._oid, ), GET )
+
+    def getUserAuthRequirements( self ):
+        return self._manager._apiCall( 'user/self/auth', GET )


### PR DESCRIPTION
## Summary

Billing functionality has been migrated server-side from the legacy `billing.limacharlie.io` service to `lc_api-go` (served at `api.limacharlie.io/v1/`). This PR points the SDK at the new endpoints so consumers don't drift out of sync as the legacy service is retired.

Mirrors [go-limacharlie#237](https://github.com/refractionPOINT/go-limacharlie/pull/237).

### Path changes
| Method | Old path (billing root) | New path (default root) |
|---|---|---|
| `getOrgStatus` | `orgs/{oid}/status` | `orgs/{oid}/billing/status` |
| `getOrgDetails` | `orgs/{oid}/details` | `orgs/{oid}/billing/details` |
| `getOrgInvoiceURL` | `orgs/{oid}/invoice_url/{y}/{m}` | `orgs/{oid}/billing/invoice/{y}/{m}` |
| `getAvailablePlans` | `user/self/plans` | `plans` |
| `getSkuDefinitions` | `orgs/{oid}/sku-definitions` | `orgs/{oid}/billing/sku` |
| `getUserAuthRequirements` | `user/self/auth` (billing root) | `user/self/auth` (default root) |

All `altRoot = 'https://billing.limacharlie.io/'` arguments are dropped; calls now use the default `api.limacharlie.io/v1/` base from `Manager._restCall`.

Side note: `billing-services/billing-service` never actually served `/orgs/{oid}/sku-definitions` — `getSkuDefinitions` had been pointed at a non-existent endpoint. It's now backed by `lc_api-go`'s real `/orgs/{oid}/billing/sku` handler.

## Semantic parity

Compared each migrated endpoint against its legacy counterpart in `billing-services/billing-service`. Caller-visible differences:

- **`/billing/invoice/{y}/{m}`** — lc_api-go returns only the first paid/open invoice for a month. The legacy `urls[]` / `invoices[]` multi-invoice keys are gone. Single-URL consumers (the common case) are unaffected.
- **`/plans`** — response is narrower (`{id, name, region}`) than the legacy shape (`{ID, MetaProduct, Datacenter:{Name, Region}}`). The SDK passes responses through as dicts, so any consumer reading `plan['ID']` / `plan['MetaProduct']` / `plan['Datacenter']` needs to switch to the new keys.
- **`/user/self/auth`** — error message for non-user identities unchanged; lc_api-go additionally returns a top-level `is_unified_billing`.
- `/billing/status`, `/billing/details` — identical response shape.

## Test plan

- [x] `python3 -c 'import ast; ast.parse(open(\"limacharlie/Billing.py\").read())'` passes
- [ ] Manual smoke test of each `Billing` method against a real org
- [ ] Verify no downstream consumers rely on the removed `urls[]` / `invoices[]` response keys from `getOrgInvoiceURL` or on the legacy plan object fields from `getAvailablePlans`

🤖 Generated with [Claude Code](https://claude.com/claude-code)