### PR TITLE
fix: correct audit list field documentation in --ai-help

### DIFF
--- a/limacharlie/commands/audit.py
+++ b/limacharlie/commands/audit.py
@@ -58,15 +58,21 @@ administrative actions including rule changes, user management,
 sensor operations, and API key usage.
 
 Each audit entry contains:
-  ts         - Timestamp of the action (string, UTC)
-  time       - Timestamp of the action (Unix milliseconds)
-  etype      - Event type (e.g. hive_set, send_task, remove_sensor)
-  ident      - Actor identity (email, API key hash, or extension ID)
-  msg        - Human-readable description of the action
   oid        - Organization ID
-  origin     - Origin of the action (e.g. DR rule, extension)
-  entity     - Affected entity (object, often containing sid)
-  mtd        - Action-specific metadata
+  ts         - Timestamp of the action (UTC string, "YYYY-MM-DD HH:MM:SS")
+  etype      - Event type (e.g. hive_set, send_task, remove_sensor)
+  msg        - Human-readable description of the action
+
+V2 fields (preferred for new callers):
+  time       - Timestamp (Unix milliseconds)
+  ident      - Identity performing the action (email, API key hash,
+               extension ID, or DR rule)
+  entity     - Object the action is performed on (e.g. {sid: ...})
+  mtd        - Characteristics of the action (action-specific metadata)
+
+Legacy field (V1, retained for backward compatibility):
+  origin     - Pre-V2 actor identity; superseded by ident.  When ident
+               is empty, origin holds the actor.
 
 Time range is specified with --start and --end as Unix timestamps
 in seconds.  If not provided, defaults to the last 24 hours.

--- a/limacharlie/commands/audit.py
+++ b/limacharlie/commands/audit.py
@@ -58,11 +58,15 @@ administrative actions including rule changes, user management,
 sensor operations, and API key usage.
 
 Each audit entry contains:
-  ts         - Timestamp of the action
-  who        - Email or API key hash of the actor
-  action     - Action performed (e.g. dr.set, sensor.del)
-  target     - Resource affected
-  details    - Action-specific context
+  ts         - Timestamp of the action (string, UTC)
+  time       - Timestamp of the action (Unix milliseconds)
+  etype      - Event type (e.g. hive_set, send_task, remove_sensor)
+  ident      - Actor identity (email, API key hash, or extension ID)
+  msg        - Human-readable description of the action
+  oid        - Organization ID
+  origin     - Origin of the action (e.g. DR rule, extension)
+  entity     - Affected entity (object, often containing sid)
+  mtd        - Action-specific metadata
 
 Time range is specified with --start and --end as Unix timestamps
 in seconds.  If not provided, defaults to the last 24 hours.


### PR DESCRIPTION
## Summary
- The `--ai-help` text for `audit list` documented fields (`who`, `action`, `target`, `details`) that **do not exist** in the actual API response.
- This caused LLM-driven callers (and humans) to construct filters like `--filter \"[].action\"` that silently return empty arrays.
- Replaced with the real response fields: `ts`, `time`, `etype`, `ident`, `msg`, `oid`, `origin`, `entity`, `mtd`.

## Context
Spotted while reviewing an AI agent session that ran a weekly activity report. The model trusted the documented field names, got back `[]`, then had to dump raw output to discover the field is actually `etype`. Two wasted round-trips per ambiguous query.

## Test plan
- [x] `python -m pytest tests/unit/test_debug_flag_integration.py -k audit` (5 passed)
- [x] Verified `get_explain(\"audit.list\")` renders the corrected field list

🤖 Generated with [Claude Code](https://claude.com/claude-code)