### PR TITLE
feat: add --event-type and --sid filters to `audit list`

### DIFF
--- a/limacharlie/commands/audit.py
+++ b/limacharlie/commands/audit.py
@@ -69,10 +69,15 @@ in seconds.  If not provided, defaults to the last 24 hours.
 
 Use --limit to cap the number of results returned.
 
+Filter results server-side with --event-type (e.g. hive_set, send_task,
+remove_sensor) or --sid (limit to events relating to a specific sensor).
+
 Examples:
   limacharlie audit list
   limacharlie audit list --start 1700000000 --end 1700100000
   limacharlie audit list --limit 50
+  limacharlie audit list --event-type hive_set
+  limacharlie audit list --sid 37270c5f-53b5-4215-b1ed-d4f60e818a7f
 """
 register_explain("audit.list", _EXPLAIN_LIST)
 
@@ -87,8 +92,16 @@ register_explain("audit.list", _EXPLAIN_LIST)
     help="End time (Unix seconds).  Defaults to now.",
 )
 @click.option("--limit", default=None, type=int, help="Maximum number of results.")
+@click.option(
+    "--event-type", "event_type", default=None,
+    help="Server-side filter: only return events of this type (e.g. hive_set, send_task).",
+)
+@click.option(
+    "--sid", default=None,
+    help="Server-side filter: only return events relating to this sensor ID.",
+)
 @pass_context
-def list_audit(ctx, start, end, limit) -> None:
+def list_audit(ctx, start, end, limit, event_type, sid) -> None:
     validate_epoch_seconds(start, "start")
     validate_epoch_seconds(end, "end")
 
@@ -99,5 +112,8 @@ def list_audit(ctx, start, end, limit) -> None:
         start = now - 86400  # 24 hours ago
 
     org = _get_org(ctx)
-    data = list(org.get_audit_logs(start=start, end=end, limit=limit))
+    data = list(org.get_audit_logs(
+        start=start, end=end, limit=limit,
+        event_type=event_type, sid=sid,
+    ))
     _output(ctx, data)


### PR DESCRIPTION
## Summary
- Expose the `event_type` and `sid` server-side filters on `audit list`. The SDK and API both already accept them, but the CLI didn't pass them through.
- New flags: `--event-type` (e.g. `hive_set`, `send_task`) and `--sid` (limit to a specific sensor).

## Why
Without server-side filtering, callers have to pull the full audit stream and grep client-side. On a busy org a 7-day window can contain ~5,000 entries dominated by a single extension's traffic — wasteful and noisy for AI agents and humans alike.

## Test plan
- [x] `python -m pytest tests/unit -k audit` (9 passed)
- [x] Manual smoke test against the white-sands org

🤖 Generated with [Claude Code](https://claude.com/claude-code)