### PR TITLE
auth login: allow user-scoped API key without --oid

### DIFF
--- a/limacharlie/commands/auth.py
+++ b/limacharlie/commands/auth.py
@@ -129,18 +129,34 @@ def login(ctx: click.Context, oid: str | None, api_key: str | None, environment:
 
     if oauth:
         _login_oauth(ctx, oid, env_name, provider, no_browser)
-    else:
-        if not oid or not api_key:
-            click.echo(
-                "Error: --oid and --api-key are required for API key login.\n"
-                "Suggestion: Use --oauth for browser-based OAuth login, or provide both --oid and --api-key.",
-                err=True,
-            )
-            ctx.exit(4)
-            return
-        write_credentials(env_name, oid=oid, api_key=api_key, uid=uid or "")
-        if not ctx.obj.quiet:
-            click.echo(f"Credentials saved for environment '{env_name}'.")
+        return
+
+    # API key login. Two valid shapes:
+    #   1. --oid + --api-key                — org-scoped key (and optional --uid for service accounts).
+    #   2. --uid + --api-key (oid optional) — user-scoped key on a brand-new account with no orgs yet.
+    if not api_key:
+        click.echo(
+            "Error: --api-key is required for API key login.\n"
+            "Suggestion: Use --oauth for browser-based OAuth login, or provide --api-key with "
+            "either --oid (org-scoped key) or --uid (user-scoped key).",
+            err=True,
+        )
+        ctx.exit(4)
+        return
+
+    if not oid and not uid:
+        click.echo(
+            "Error: provide either --oid (org-scoped key) or --uid (user-scoped key) along with --api-key.\n"
+            "Suggestion: --uid is correct for User API Keys generated under your account profile; "
+            "--oid is correct for Organization API Keys generated under an org's settings.",
+            err=True,
+        )
+        ctx.exit(4)
+        return
+
+    write_credentials(env_name, oid=oid, api_key=api_key, uid=uid or "")
+    if not ctx.obj.quiet:
+        click.echo(f"Credentials saved for environment '{env_name}'.")
 
 
 def _login_oauth(ctx: click.Context, oid: str | None, env_name: str, provider: str, no_browser: bool) -> None:


### PR DESCRIPTION
## Problem

`limacharlie auth login --uid X --api-key Y` (a user-scoped API key, no org context) is rejected with:

```
Error: --oid and --api-key are required for API key login.
Suggestion: Use --oauth for browser-based OAuth login, or provide both --oid and --api-key.
```

…even though `--uid` is documented as the flag for "user-scoped API keys" and the `--ai-help` text says *"If you are using a user-scoped API key, also pass --uid."*

This breaks the bootstrap flow for any brand-new LimaCharlie account that hasn't created an org yet — chicken-and-egg, since the user can't list/create their first org without working CLI auth, can't auth without an OID, and doesn't have an OID until they create an org.

The User API Key itself is fully capable of user-scoped operations — `LC_UID + LC_API_KEY` env vars already work for `auth list-orgs` (the only call needed to bootstrap from "I have a User API Key" to "I know my OIDs"). The bug was purely in the `auth login` validator forcing an `--oid` constraint that the rest of the CLI doesn't actually need.

## Discovered

Live during a workshop where one student chose the email/password signup path (which yields a User API Key). The OAuth-via-Google/Microsoft paths worked fine; the email/password path failed at this validator.

## Fix

Rework the validator to accept either of two valid shapes:

- `--oid + --api-key` — org-scoped key (existing behavior, plus optional `--uid` for service accounts)
- `--uid + --api-key` — user-scoped key, `--oid` optional

When neither `--oid` nor `--uid` is provided, emit a clear error distinguishing the two key types so users picking the wrong key from the LC web UI get pointed to the right one.

The `write_credentials` call already handles `oid=None` correctly (skips writing the field), so no downstream changes are needed.

## Tests run locally against a real account

| Case | Result |
|---|---|
| `auth login --uid X --api-key Y` (no `--oid`) | ✓ "Credentials saved" |
| `auth list-orgs` against those credentials | ✓ Returns the user's orgs |
| `auth login --api-key Y` (neither `--oid` nor `--uid`) | ✓ New clear error, exit 4 |
| `auth login --oid X --api-key Y` (existing org-scoped path) | ✓ Unchanged |
| `auth login --oauth --provider google` | ✓ Unchanged (verified end-to-end via browser) |

## Downstream impact

A workshop's `setup.sh` currently uses a placeholder-OID workaround (`--oid 00000000-0000-0000-0000-000000000000 --uid X --api-key Y`) to bootstrap users with brand-new accounts. After this lands and ships, that workaround becomes unnecessary — but it'll keep working since the `--oid + --api-key + --uid` shape stays valid.