### PR TITLE
schema: add 'schema reset' command to rebuild org schemas

### DIFF
--- a/limacharlie/commands/schema.py
+++ b/limacharlie/commands/schema.py
@@ -103,3 +103,46 @@ def get(ctx, name) -> None:
     org = _get_org(ctx)
     data = org.get_schema(name)
     _output(ctx, data)
+
+
+# ---------------------------------------------------------------------------
+# reset
+# ---------------------------------------------------------------------------
+
+_EXPLAIN_RESET = """\
+Reset (rebuild) all event schemas for the organization.  This clears
+the cached schema/ontology so it is rebuilt from newly observed
+events.
+
+This is useful when the recorded schema has gone stale -- for example
+after telemetry shape changes -- and event fields are missing from
+'schema list' or 'schema get'.  The schema repopulates as new events
+flow in; there may be a short window where schemas are incomplete.
+
+This is a destructive, organization-wide operation and requires the
+--confirm flag.
+
+Examples:
+  limacharlie schema reset --confirm
+"""
+register_explain("schema.reset", _EXPLAIN_RESET)
+
+
+@group.command()
+@click.option("--confirm", is_flag=True, default=False, help="Confirm the reset (required).")
+@pass_context
+def reset(ctx, confirm) -> None:
+    """Reset (rebuild) all event schemas for the organization."""
+    if not confirm:
+        click.echo(
+            "Error: Destructive operation requires --confirm flag.\n"
+            "Suggestion: Re-run with --confirm to reset all org schemas.",
+            err=True,
+        )
+        ctx.exit(4)
+        return
+    org = _get_org(ctx)
+    data = org.reset_schemas()
+    if not ctx.obj.quiet:
+        click.echo("Org schemas reset; they will rebuild as new events are observed.")
+    _output(ctx, data)

--- a/limacharlie/sdk/organization.py
+++ b/limacharlie/sdk/organization.py
@@ -146,6 +146,18 @@ class Organization:
         """
         return self._client.request("GET", f"orgs/{self.oid}/schema/{urlescape(name, safe='')}")
 
+    def reset_schemas(self) -> dict[str, Any]:
+        """Reset (rebuild) all event schemas for the organization.
+
+        Clears the cached schema/ontology so it is rebuilt from newly
+        observed events.  This is useful after telemetry shape changes
+        when the recorded schema has gone stale.
+
+        Returns:
+            dict: API response (typically ``{"success": true}``).
+        """
+        return self._client.request("DELETE", f"orgs/{self.oid}/schema")
+
     def get_runtime_metadata(self, entity_type: str | None = None, entity_name: str | None = None) -> dict[str, Any]:
         """Get runtime metadata.
 

--- a/tests/unit/test_cli_commands.py
+++ b/tests/unit/test_cli_commands.py
@@ -509,3 +509,41 @@ class TestHiveEnableDisable:
         assert record.tags == ["keep-me"]
 
 
+class TestSchemaCommands:
+    @patch("limacharlie.commands.schema.Client")
+    @patch("limacharlie.commands.schema.Organization")
+    def test_schema_list(self, mock_org_cls, mock_client_cls):
+        mock_org = MagicMock()
+        mock_org.get_schemas.return_value = {"event_types": ["NEW_PROCESS"]}
+        mock_org_cls.return_value = mock_org
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--output", "json", "schema", "list"])
+        assert result.exit_code == 0
+        mock_org.get_schemas.assert_called_once_with()
+
+    @patch("limacharlie.commands.schema.Client")
+    @patch("limacharlie.commands.schema.Organization")
+    def test_schema_reset_without_confirm(self, mock_org_cls, mock_client_cls):
+        mock_org = MagicMock()
+        mock_org_cls.return_value = mock_org
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["schema", "reset"])
+        assert result.exit_code == 4
+        assert "--confirm" in result.output
+        mock_org.reset_schemas.assert_not_called()
+
+    @patch("limacharlie.commands.schema.Client")
+    @patch("limacharlie.commands.schema.Organization")
+    def test_schema_reset_with_confirm(self, mock_org_cls, mock_client_cls):
+        mock_org = MagicMock()
+        mock_org.reset_schemas.return_value = {"success": True}
+        mock_org_cls.return_value = mock_org
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--output", "json", "schema", "reset", "--confirm"])
+        assert result.exit_code == 0
+        mock_org.reset_schemas.assert_called_once_with()
+
+

--- a/tests/unit/test_cli_lazy_loading_regression.py
+++ b/tests/unit/test_cli_lazy_loading_regression.py
@@ -189,7 +189,7 @@ EXPECTED_SUBCOMMANDS: dict[str, frozenset[str]] = {
     "payload": frozenset({"delete", "download", "list", "upload"}),
     "playbook": frozenset({"delete", "disable", "enable", "get", "list", "set"}),
     "replay": frozenset({"run"}),
-    "schema": frozenset({"get", "list"}),
+    "schema": frozenset({"get", "list", "reset"}),
     "search": frozenset({
         "checkpoint-show", "checkpoints", "estimate", "run",
         "saved-create", "saved-delete", "saved-get", "saved-list",

--- a/tests/unit/test_sdk_organization.py
+++ b/tests/unit/test_sdk_organization.py
@@ -91,6 +91,10 @@ class TestOrganizationSchemas:
         org.get_schema("NEW_PROCESS")
         mock_client.request.assert_called_once_with("GET", "orgs/test-oid-123/schema/NEW_PROCESS")
 
+    def test_reset_schemas(self, org, mock_client):
+        org.reset_schemas()
+        mock_client.request.assert_called_once_with("DELETE", "orgs/test-oid-123/schema")
+
 
 class TestOrganizationOutputs:
     def test_get_outputs(self, org, mock_client):


### PR DESCRIPTION
## Summary

Exposes the existing backend endpoint `DELETE /orgs/{oid}/schema` (`resetOrgSchemas`) through the Python CLI/SDK. This was previously only reachable via the Go SDK (`Organization.ResetSchemas()`) or a raw API call — there was no Python CLI/SDK surface for it.

Resetting schemas clears the cached schema/ontology so it rebuilds from newly observed events — useful when the recorded schema has gone stale (e.g. after telemetry shape changes) and fields are missing from `schema list` / `schema get`.

## Changes

- **SDK** (`limacharlie/sdk/organization.py`): `Organization.reset_schemas()` → `DELETE orgs/{oid}/schema`. Returns the raw response dict, consistent with sibling methods (`delete_org`, `dismiss_error`).
- **CLI** (`limacharlie/commands/schema.py`): `limacharlie schema reset`, guarded by `--confirm` (exits 4 without it, mirroring the `ai-memory delete` convention), with `register_explain` text surfaced via `--ai-help`.
- **Tests**: SDK request assertion; CLI tests for the `--confirm` guard and happy path; a `schema list` regression guard; updated the lazy-loading regression's expected subcommand set.

## Usage

```
limacharlie schema reset --confirm
```

## Validation

- Targeted suite (SDK org / CLI commands / lazy-loading / command-map lint / discovery): **1134 passed**.
- New tests pass individually.
- The pre-existing `test_search_*` failures on `cli-v2` are unrelated (confirmed by stashing this change and re-running on the clean base branch).
- Smoke-tested: `schema --help` lists `reset`, `schema reset --help` shows `--confirm`, `--ai-help` renders the explain text.

## Note for reviewers

The backend authorizes this destructive, org-wide endpoint with the `org.get` permission (`lc_api-go/.../endpoint_org_info.go`). Not changed here (backend concern), but worth being aware of.

🤖 Generated with [Claude Code](https://claude.com/claude-code)