### PR TITLE
cli: fix org quota help text + add dr enable/disable aliases

### DIFF
--- a/limacharlie/commands/dr.py
+++ b/limacharlie/commands/dr.py
@@ -362,6 +362,79 @@ def delete(ctx, key, namespace, confirm) -> None:
 
 
 # ---------------------------------------------------------------------------
+# enable / disable
+# ---------------------------------------------------------------------------
+
+_EXPLAIN_ENABLE = """\
+Enable a D&R rule by setting its usr_mtd.enabled flag to true.  Only the
+enabled flag is changed; all other metadata (tags, expiry, comment) and
+the rule data (detect/respond) are preserved.
+
+If the rule is in the 'managed' or 'service' namespace, pass --namespace
+accordingly.
+
+Examples:
+  limacharlie dr enable --key my-rule
+  limacharlie dr enable --key some-managed-rule --namespace managed
+"""
+register_explain("dr.enable", _EXPLAIN_ENABLE)
+
+_EXPLAIN_DISABLE = """\
+Disable a D&R rule by setting its usr_mtd.enabled flag to false.  Only
+the enabled flag is changed; all other metadata (tags, expiry, comment)
+and the rule data (detect/respond) are preserved.
+
+If the rule is in the 'managed' or 'service' namespace, pass --namespace
+accordingly.
+
+Examples:
+  limacharlie dr disable --key my-rule
+  limacharlie dr disable --key some-managed-rule --namespace managed
+"""
+register_explain("dr.disable", _EXPLAIN_DISABLE)
+
+
+def _set_enabled(ctx: click.Context, namespace: str | None, key: str, enabled: bool) -> None:
+    """Toggle the enabled flag on a D&R rule.
+
+    Reads the current metadata first so that tags, expiry, and comment
+    are preserved (the API replaces usr_mtd wholesale).
+    """
+    hive_name = _hive_name(namespace)
+    org = _get_org(ctx)
+    hive = Hive(org, hive_name)
+    record = hive.get_metadata(key)
+    record.enabled = enabled
+    result = hive.set(record)
+    state = "enabled" if enabled else "disabled"
+    if not ctx.obj.quiet:
+        click.echo(f"Rule '{key}' {state} in namespace '{namespace or 'general'}'.")
+    _output(ctx, result)
+
+
+@group.command()
+@click.option("--key", required=True, help="Rule key name.")
+@click.option(
+    "--namespace", default=None, type=_NS_CHOICES,
+    help="Namespace (default: general).",
+)
+@pass_context
+def enable(ctx, key, namespace) -> None:
+    _set_enabled(ctx, namespace, key, True)
+
+
+@group.command()
+@click.option("--key", required=True, help="Rule key name.")
+@click.option(
+    "--namespace", default=None, type=_NS_CHOICES,
+    help="Namespace (default: general).",
+)
+@pass_context
+def disable(ctx, key, namespace) -> None:
+    _set_enabled(ctx, namespace, key, False)
+
+
+# ---------------------------------------------------------------------------
 # Helpers for loading events
 # ---------------------------------------------------------------------------
 

--- a/limacharlie/commands/org.py
+++ b/limacharlie/commands/org.py
@@ -374,15 +374,15 @@ def rename(ctx: click.Context, name: str) -> None:
 # ---------------------------------------------------------------------------
 
 _EXPLAIN_QUOTA = """\
-Set the sensor quota for the organization.  The quota limits how many
-sensors can be enrolled simultaneously.  Set to 0 to remove the quota
-limit (billing still applies).
+Set the sensor quota for the organization.  The quota is the number of
+sensors the organization is licensed (billed) for.  Set to 0 to put the
+organization on the free tier (no paid sensor quota).
 """
 register_explain("org.quota", _EXPLAIN_QUOTA)
 
 
 @group.command()
-@click.option("--quota", required=True, type=int, help="Sensor quota (0 to remove limit).")
+@click.option("--quota", required=True, type=int, help="Sensor quota: number of licensed sensors (0 = free tier).")
 @pass_context
 def quota(ctx: click.Context, quota: int) -> None:
     org = _get_org(ctx)

--- a/tests/unit/test_cli_commands.py
+++ b/tests/unit/test_cli_commands.py
@@ -428,6 +428,70 @@ class TestDRCommands:
         assert "my-rule" in parsed
         mock_hive.list.assert_called_once()
 
+    @staticmethod
+    def _existing_record(name="my-rule", enabled=True):
+        from limacharlie.sdk.hive import HiveRecord
+        return HiveRecord(
+            name=name, enabled=enabled,
+            tags=["keep-me"], expiry=1234, comment="preserve this",
+            etag="old-etag",
+        )
+
+    @patch("limacharlie.commands.dr.Client")
+    @patch("limacharlie.commands.dr.Organization")
+    @patch("limacharlie.commands.dr.Hive")
+    def test_dr_enable(self, mock_hive_cls, mock_org_cls, mock_client_cls):
+        mock_hive = MagicMock()
+        mock_hive.get_metadata.return_value = self._existing_record(enabled=False)
+        mock_hive.set.return_value = {"etag": "new"}
+        mock_hive_cls.return_value = mock_hive
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["dr", "enable", "--key", "my-rule"])
+        assert result.exit_code == 0
+        # Defaults to the dr-general hive.
+        assert mock_hive_cls.call_args[0][1] == "dr-general"
+        record = mock_hive.set.call_args[0][0]
+        assert record.enabled is True
+        assert record.data is None  # only metadata update
+        assert record.tags == ["keep-me"]
+        assert record.expiry == 1234
+        assert record.comment == "preserve this"
+
+    @patch("limacharlie.commands.dr.Client")
+    @patch("limacharlie.commands.dr.Organization")
+    @patch("limacharlie.commands.dr.Hive")
+    def test_dr_disable(self, mock_hive_cls, mock_org_cls, mock_client_cls):
+        mock_hive = MagicMock()
+        mock_hive.get_metadata.return_value = self._existing_record(enabled=True)
+        mock_hive.set.return_value = {"etag": "new"}
+        mock_hive_cls.return_value = mock_hive
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["dr", "disable", "--key", "my-rule"])
+        assert result.exit_code == 0
+        record = mock_hive.set.call_args[0][0]
+        assert record.enabled is False
+        assert record.data is None
+        assert record.tags == ["keep-me"]
+
+    @patch("limacharlie.commands.dr.Client")
+    @patch("limacharlie.commands.dr.Organization")
+    @patch("limacharlie.commands.dr.Hive")
+    def test_dr_disable_namespace(self, mock_hive_cls, mock_org_cls, mock_client_cls):
+        mock_hive = MagicMock()
+        mock_hive.get_metadata.return_value = self._existing_record(enabled=True)
+        mock_hive.set.return_value = {"etag": "new"}
+        mock_hive_cls.return_value = mock_hive
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["dr", "disable", "--key", "my-rule", "--namespace", "managed"])
+        assert result.exit_code == 0
+        # Namespace maps to the dr-managed hive.
+        assert mock_hive_cls.call_args[0][1] == "dr-managed"
+        record = mock_hive.set.call_args[0][0]
+        assert record.enabled is False
+
 
 class TestHiveEnableDisable:
     @staticmethod

--- a/tests/unit/test_cli_lazy_loading_regression.py
+++ b/tests/unit/test_cli_lazy_loading_regression.py
@@ -146,8 +146,8 @@ EXPECTED_SUBCOMMANDS: dict[str, frozenset[str]] = {
     "detection": frozenset({"get", "list"}),
     "download": frozenset({"adapter", "list", "sensor"}),
     "dr": frozenset({
-        "convert-rules", "delete", "export", "get", "import",
-        "list", "replay", "set", "test", "validate",
+        "convert-rules", "delete", "disable", "enable", "export", "get",
+        "import", "list", "replay", "set", "test", "validate",
     }),
     "endpoint-policy": frozenset({"isolate", "rejoin", "seal", "status", "unseal"}),
     "event": frozenset({


### PR DESCRIPTION
Two small CLI fixes (bundled).

## 1. Fix misleading `org quota --quota` help text

From a user question on [Slack](https://refractionpoint.slack.com/archives/C02G3J27URZ/p1780005116396659): the help said `Sensor quota (0 to remove limit)`, which reads as if `0` makes the quota unlimited.

Verified against the backend `doQuotaChange` (`lc_api-go/service/endpoint_billing.go`): `--quota` sets the org's **licensed sensor count** (the Stripe subscription quantity). Setting `0` does **not** remove the limit — it puts the org on the **free tier** (no paid quota; values 1–2 also collapse to 0). The wording was exactly backwards.

- `--quota` help → `Sensor quota: number of licensed sensors (0 = free tier).`
- `_EXPLAIN_QUOTA` (AI help) updated to match.

## 2. Add `dr enable` / `dr disable` aliases

D&R rules are hive-backed, but the `dr` group lacked the enable/disable convenience aliases that `hive` (and the per-hive shortcuts) provide. Added them mirroring the hive pattern:

- Reads record metadata first (preserves tags/expiry/comment), toggles only `usr_mtd.enabled`, routes to the `/mtd` endpoint.
- Honors `--namespace` (general/managed/service).
- Includes `--ai-help` explain text and unit tests.

## Tests

Full unit suite green (`3311 passed`). Updated the lazy-loading regression test's expected `dr` subcommand set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)