### PR TITLE
ai: resolve ai-sessions URL from per-org service URLs instead of hardcoding

### DIFF
--- a/limacharlie/sdk/ai.py
+++ b/limacharlie/sdk/ai.py
@@ -9,6 +9,11 @@ if TYPE_CHECKING:
     from .organization import Organization
 
 _HIVE_SECRET_PREFIX = "hive://secret/"
+
+# Fallback only.  The real ai-sessions host is resolved per-org from the
+# ``ai`` entry of ``orgs/{oid}/url`` (see :meth:`AI._get_ai_url`) because
+# it differs by deployment -- e.g. staging orgs return
+# ``ai-staging.limacharlie.io``.
 _AI_SESSIONS_URL = "https://ai.limacharlie.io"
 
 
@@ -17,11 +22,31 @@ class AI:
 
     def __init__(self, org: Organization) -> None:
         self._org = org
+        self._ai_url: str | None = None
 
     @property
     def client(self) -> Any:
         """The underlying API client."""
         return self._org.client
+
+    def _get_ai_url(self) -> str:
+        """Resolve the ai-sessions base URL for this org.
+
+        The per-org service URLs (``orgs/{oid}/url``) carry an ``ai``
+        entry whose value depends on the deployment the org lives in
+        (production orgs resolve to ``ai.limacharlie.io``, staging orgs
+        to ``ai-staging.limacharlie.io``, etc.), so the host must not be
+        hardcoded.  Mirrors the lazy, cached resolution used by
+        :class:`~limacharlie.sdk.search.Search`.  Falls back to
+        :data:`_AI_SESSIONS_URL` only when the org URL set has no ``ai``
+        entry.
+        """
+        if self._ai_url is None:
+            ai_url = self._org.get_urls().get("ai", "")
+            if ai_url and not ai_url.startswith(("http://", "https://")):
+                ai_url = "https://" + ai_url
+            self._ai_url = ai_url or _AI_SESSIONS_URL
+        return self._ai_url
 
     def _resolve_secret(self, value: str) -> str:
         """Resolve a value that may be a hive://secret/ reference."""
@@ -248,7 +273,7 @@ class AI:
                 raw_body=json.dumps(request_body).encode(),
                 content_type="application/json",
                 is_no_auth=True,
-                alt_root=_AI_SESSIONS_URL,
+                alt_root=self._get_ai_url(),
                 extra_headers=extra,
             )
 
@@ -256,7 +281,7 @@ class AI:
             "POST", "v1/api/sessions",
             raw_body=json.dumps(request_body).encode(),
             content_type="application/json",
-            alt_root=_AI_SESSIONS_URL,
+            alt_root=self._get_ai_url(),
             extra_headers=extra,
         )
 
@@ -364,13 +389,13 @@ class AI:
                 verb, path,
                 query_params=query_params,
                 is_no_auth=True,
-                alt_root=_AI_SESSIONS_URL,
+                alt_root=self._get_ai_url(),
                 extra_headers=extra,
             )
         return self.client.request(
             verb, path,
             query_params=query_params,
-            alt_root=_AI_SESSIONS_URL,
+            alt_root=self._get_ai_url(),
             extra_headers=extra,
         )
 
@@ -523,7 +548,7 @@ class AI:
         ``claims.UID()`` alone; sending X-LC-OID is unnecessary here
         and the routes don't accept raw API keys.
         """
-        kwargs: dict[str, Any] = {"alt_root": _AI_SESSIONS_URL}
+        kwargs: dict[str, Any] = {"alt_root": self._get_ai_url()}
         if raw_body is not None:
             kwargs["raw_body"] = raw_body
             kwargs["content_type"] = "application/json"

--- a/limacharlie/sdk/ai_session.py
+++ b/limacharlie/sdk/ai_session.py
@@ -85,12 +85,13 @@ class SessionAttachment:
     def __init__(self, ai: "AI", session_id: str, *,
                  read_only: bool = False,
                  base_url: str | None = None) -> None:
-        from .ai import _AI_SESSIONS_URL
-
         self._ai = ai
         self._session_id = session_id
         self._read_only = read_only
-        self._base_url = base_url or _AI_SESSIONS_URL
+        # When no explicit override is supplied, resolve the per-org
+        # ai-sessions host lazily (in :meth:`url`) so we honour the org's
+        # deployment (prod vs staging) rather than a hardcoded host.
+        self._base_url = base_url
         self._ws: Any = None
         self._heartbeat_task: asyncio.Task | None = None
 
@@ -107,7 +108,8 @@ class SessionAttachment:
         return self._read_only
 
     def url(self) -> str:
-        return _derive_ws_url(self._base_url, self._session_id, self._read_only)
+        base_url = self._base_url or self._ai._get_ai_url()
+        return _derive_ws_url(base_url, self._session_id, self._read_only)
 
     # ------------------------------------------------------------------
     # Connection lifecycle

--- a/tests/unit/test_ai_session_attach.py
+++ b/tests/unit/test_ai_session_attach.py
@@ -238,6 +238,61 @@ class TestSessionAttachmentUrl:
         )
         assert att.url() == "wss://example.test/v1/ws/org/sessions/sid-42"
 
+    def test_url_resolves_from_org_ai_url_when_no_override(self):
+        """With no explicit base_url, the attach URL is derived from the
+        org's resolved ai-sessions host (e.g. the staging deployment)
+        rather than a hardcoded production host.
+        """
+        ai_stub = SimpleNamespace(
+            _get_ai_url=lambda: "https://ai-staging.limacharlie.io",
+        )
+        att = SessionAttachment(ai_stub, "sid-42")
+        assert att.url() == "wss://ai-staging.limacharlie.io/v1/ws/sessions/sid-42"
+
+
+# ---------------------------------------------------------------------------
+# Per-org ai-sessions URL resolution
+# ---------------------------------------------------------------------------
+
+class TestAiUrlResolution:
+    """``AI._get_ai_url`` must read the per-org ``ai`` service URL from
+    ``orgs/{oid}/url`` so staging/region deployments are honoured, and
+    must only fall back to the hardcoded production host when that entry
+    is absent.
+    """
+
+    def _make_ai(self, urls: dict):
+        from limacharlie.sdk.ai import AI
+
+        calls = {"n": 0}
+
+        def get_urls():
+            calls["n"] += 1
+            return urls
+
+        org_stub = SimpleNamespace(get_urls=get_urls)
+        return AI(org_stub), calls
+
+    def test_uses_ai_entry_and_adds_https(self):
+        ai, _ = self._make_ai({"ai": "ai-staging.limacharlie.io"})
+        assert ai._get_ai_url() == "https://ai-staging.limacharlie.io"
+
+    def test_preserves_existing_scheme(self):
+        ai, _ = self._make_ai({"ai": "http://localhost:8080"})
+        assert ai._get_ai_url() == "http://localhost:8080"
+
+    def test_falls_back_when_ai_entry_missing(self):
+        from limacharlie.sdk.ai import _AI_SESSIONS_URL
+
+        ai, _ = self._make_ai({"search": "x.replay-search.limacharlie.io"})
+        assert ai._get_ai_url() == _AI_SESSIONS_URL
+
+    def test_result_is_cached(self):
+        ai, calls = self._make_ai({"ai": "ai.limacharlie.io"})
+        ai._get_ai_url()
+        ai._get_ai_url()
+        assert calls["n"] == 1
+
 
 # ---------------------------------------------------------------------------
 # Pretty-printer

--- a/tests/unit/test_sdk_ai_sessions.py
+++ b/tests/unit/test_sdk_ai_sessions.py
@@ -23,6 +23,9 @@ def mock_org():
     # MagicMock would auto-vivify a truthy _uid and leak an X-LC-UID
     # header into every request.)
     org.client._uid = None
+    # ai-sessions host is resolved per-org from orgs/{oid}/url; return the
+    # production host so the resolved alt_root matches _AI_SESSIONS_URL.
+    org.get_urls.return_value = {"ai": "ai.limacharlie.io"}
     return org
 
 


### PR DESCRIPTION
## Problem

The AI session CLI/SDK commands (`ai start session`, `ai chat`, `ai auth claude`, `ai session list/get/terminate/attach`, usage, etc.) hardcoded `https://ai.limacharlie.io` as the ai-sessions host via `_AI_SESSIONS_URL` in `limacharlie/sdk/ai.py`.

The `orgs/{oid}/url` endpoint already returns a per-org `ai` entry (`lc.SiteURLs.Ai` in `go-essentials/lc/sites.go`) whose value varies by deployment — e.g. the staging site returns `ai-staging.limacharlie.io`. So the hardcode pointed staging orgs at the **production** ai-sessions service.

## Fix

- Add `AI._get_ai_url()` — resolves the host lazily and cached from `Organization.get_urls()["ai"]`, prefixing `https://` when the entry lacks a scheme, and falling back to `_AI_SESSIONS_URL` only when the `ai` entry is absent. This mirrors the existing lazy/cached pattern in `Search._get_search_url()`.
- Replace all four `alt_root=_AI_SESSIONS_URL` uses in `ai.py` (`start_session`, `_org_request`, `_user_request`) with `self._get_ai_url()`.
- `SessionAttachment` (WebSocket attach) now resolves the same per-org host when no explicit `base_url` override is given, instead of defaulting to the hardcoded constant.

`_AI_SESSIONS_URL` is kept as the fallback default.

## Tests

- New `TestAiUrlResolution`: `ai` entry used + `https://` added, existing scheme preserved, fallback when absent, result cached (single `get_urls` call).
- New `SessionAttachment` test: attach URL derives from the org-resolved host when no override is supplied.
- Updated the `mock_org` fixture in `test_sdk_ai_sessions.py` to return `{"ai": "ai.limacharlie.io"}` so the resolved `alt_root` matches `_AI_SESSIONS_URL` (existing assertions unchanged).

All 152 AI-related unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)