### PR TITLE
cli: add `org quota-usage` command (getOrgQuotaUsage API)

### DIFF
--- a/doc/cli/platform-admin.md
+++ b/doc/cli/platform-admin.md
@@ -9,6 +9,7 @@ Commands for organization management, users, groups, API keys, ingestion keys, b
 ```bash
 limacharlie org info                     # Name, sensor count, version, quotas
 limacharlie org stats                    # Usage statistics
+limacharlie org quota-usage              # Enforced sensor quota usage + breakdown
 limacharlie org urls                     # Service URLs (for firewall rules)
 limacharlie org errors                   # Platform errors
 limacharlie org dismiss-error --component <name>

--- a/limacharlie/commands/org.py
+++ b/limacharlie/commands/org.py
@@ -391,6 +391,32 @@ def quota(ctx: click.Context, quota: int) -> None:
 
 
 # ---------------------------------------------------------------------------
+# quota-usage
+# ---------------------------------------------------------------------------
+
+_EXPLAIN_QUOTA_USAGE = """\
+Display the enforced sensor quota usage for the organization.  This is the
+weighted virtual-sensor count the platform actually uses to decide whether a
+sensor may come online, so it is the value to size the sensor quota against.
+
+The reported usage can read higher than the online sensor count, which
+weights EPP/response-mode sensors at 0.  The response includes the configured
+quota and a per-category breakdown (raw count and weighted contribution),
+making it useful for capacity planning and understanding headroom before
+licensing additional sensors.
+"""
+register_explain("org.quota-usage", _EXPLAIN_QUOTA_USAGE)
+
+
+@group.command("quota-usage")
+@pass_context
+def quota_usage(ctx: click.Context) -> None:
+    org = _get_org(ctx)
+    data = org.get_quota_usage()
+    _output(ctx, data)
+
+
+# ---------------------------------------------------------------------------
 # schema
 # ---------------------------------------------------------------------------
 

--- a/limacharlie/sdk/organization.py
+++ b/limacharlie/sdk/organization.py
@@ -186,6 +186,20 @@ class Organization:
         """
         return self._client.request("POST", f"orgs/{self.oid}/quota", params={"quota": quota})
 
+    def get_quota_usage(self) -> dict[str, Any]:
+        """Get the enforced sensor quota usage for the organization.
+
+        This is the weighted virtual-sensor count the platform actually uses
+        to decide whether a sensor may come online, so it is the value to size
+        the sensor quota against.  It can read higher than the online sensor
+        count, which weights EPP/response-mode sensors at 0.
+
+        Returns:
+            dict: ``{"usage": int, "quota": int, "breakdown": {category:
+                {"n": int, "quota": float}}}``.
+        """
+        return self._client.request("GET", f"quota_usage/{self.oid}")
+
     def rename(self, new_name: str) -> dict[str, Any]:
         """Rename the organization.
 

--- a/tests/unit/test_cli_commands.py
+++ b/tests/unit/test_cli_commands.py
@@ -315,6 +315,25 @@ class TestOrgCommands:
 
     @patch("limacharlie.commands.org.Client")
     @patch("limacharlie.commands.org.Organization")
+    def test_org_quota_usage(self, mock_org_cls, mock_client_cls):
+        mock_org = MagicMock()
+        mock_org.get_quota_usage.return_value = {
+            "usage": 42,
+            "quota": 100,
+            "breakdown": {"edr": {"n": 40, "quota": 40.0}},
+        }
+        mock_org_cls.return_value = mock_org
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--output", "json", "org", "quota-usage"])
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert parsed["usage"] == 42
+        assert parsed["quota"] == 100
+        mock_org.get_quota_usage.assert_called_once()
+
+    @patch("limacharlie.commands.org.Client")
+    @patch("limacharlie.commands.org.Organization")
     def test_org_urls(self, mock_org_cls, mock_client_cls):
         mock_org = MagicMock()
         mock_org.get_urls.return_value = {"main": "https://app.limacharlie.io"}

--- a/tests/unit/test_cli_lazy_loading_regression.py
+++ b/tests/unit/test_cli_lazy_loading_regression.py
@@ -183,7 +183,7 @@ EXPECTED_SUBCOMMANDS: dict[str, frozenset[str]] = {
     "org": frozenset({
         "check-name", "config-get", "config-set", "create", "delete",
         "dismiss-error", "errors", "info", "list", "mitre", "quota",
-        "rename", "runtime-metadata", "schema", "stats", "urls",
+        "quota-usage", "rename", "runtime-metadata", "schema", "stats", "urls",
     }),
     "output": frozenset({"create", "delete", "list"}),
     "payload": frozenset({"delete", "download", "list", "upload"}),

--- a/tests/unit/test_sdk_organization.py
+++ b/tests/unit/test_sdk_organization.py
@@ -47,6 +47,17 @@ class TestOrganizationInfo:
         org.get_stats()
         mock_client.request.assert_called_once_with("GET", "usage/test-oid-123")
 
+    def test_get_quota_usage(self, org, mock_client):
+        mock_client.request.return_value = {
+            "usage": 42,
+            "quota": 100,
+            "breakdown": {"edr": {"n": 40, "quota": 40.0}},
+        }
+        result = org.get_quota_usage()
+        mock_client.request.assert_called_once_with("GET", "quota_usage/test-oid-123")
+        assert result["usage"] == 42
+        assert result["quota"] == 100
+
     def test_get_errors(self, org, mock_client):
         mock_client.request.return_value = {"errors": []}
         org.get_errors()


### PR DESCRIPTION
## Summary

Adds CLI + SDK support for the new [`getOrgQuotaUsage`](https://api.limacharlie.io/static/swagger/#/Sensors/getOrgQuotaUsage) API (`GET /quota_usage/{oid}`).

This endpoint returns the **enforced** sensor quota usage — the weighted virtual-sensor count the platform actually uses to decide whether a sensor may come online. Unlike the `/online` count (which weights EPP/response-mode sensors at 0), this is the value to size `sensor_quota` against, and it can read higher than the online count.

Response shape: `{ "usage": int, "quota": int, "breakdown": { <category>: { "n": int, "quota": float } } }`.

## Changes

- **SDK** — `Organization.get_quota_usage()` (`limacharlie/sdk/organization.py`)
- **CLI** — `limacharlie org quota-usage`, with `--ai-help` explain text (`limacharlie/commands/org.py`)
- **Docs** — added to `doc/cli/platform-admin.md`
- **Tests** — SDK + CLI unit tests, plus updates to the command-map lint and subcommand-structure regression lists

## Testing

`pytest` passes for all org/quota/lint tests. The pre-existing failures in `test_search_checkpoint_cli.py` / `test_search_output.py` are date-dependent and present on the base `cli-v2` branch, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)