### PR TITLE
cli: add app hive shortcut command

### DIFF
--- a/doc/cli/hive-data.md
+++ b/doc/cli/hive-data.md
@@ -64,6 +64,18 @@ limacharlie external-adapter list
 limacharlie cloud-adapter list
 ```
 
+### app
+
+User-authored, AI-generated mini web apps (a self-contained HTML document
+rendered in a sandboxed iframe by the web UI).
+
+```bash
+limacharlie app list
+limacharlie app get --key my-app
+limacharlie app set --key my-app --input-file app.yaml
+limacharlie app delete --key my-app --confirm
+```
+
 ## extension
 
 ```bash

--- a/limacharlie/cli.py
+++ b/limacharlie/cli.py
@@ -102,6 +102,7 @@ _COMMAND_MODULE_MAP: dict[str, tuple[str, str]] = {
     "ai-skill": ("ai_skill", "group"),
     "api": ("api_cmd", "cmd"),
     "api-key": ("api_key", "group"),
+    "app": ("app", "group"),
     "arl": ("arl", "group"),
     "artifact": ("artifact", "group"),
     "audit": ("audit", "group"),

--- a/limacharlie/commands/app.py
+++ b/limacharlie/commands/app.py
@@ -1,0 +1,62 @@
+"""App commands for LimaCharlie CLI v2."""
+
+from __future__ import annotations
+
+from ._hive_shortcut import make_hive_group
+from ..discovery import register_explain
+
+group = make_hive_group("app", "app", "app")
+
+# Override the generic hive explains with app-specific documentation.
+
+register_explain("app.list", """\
+List all apps stored in the 'app' hive.  An app is a user-authored,
+AI-generated mini web application: a single self-contained HTML
+document that the LimaCharlie web UI renders inside a sandboxed
+<iframe>.
+""")
+
+register_explain("app.get", """\
+Get a specific app by key.  Returns the full record including the
+HTML document, required permissions, and metadata.
+""")
+
+register_explain("app.set", """\
+Create or update an app.  An app record holds a single self-contained
+HTML document (HTML + inline JS + inline CSS) rendered in a sandboxed
+iframe.
+
+The data payload looks like:
+
+  data:
+    display_name: "My App"          # required, human label
+    html: "<html>...</html>"        # required, the self-contained document
+    description: "What it does"      # optional blurb
+    icon: "🛠"                       # optional emoji / icon id / data-URI
+    required_permissions:            # perms minted into the iframe JWT,
+      - sensor.get                   #   intersected with the viewing user's
+      - sensor.task                  #   own permissions at view time
+    allowed_origins:                 # optional third-party https origins
+      - https://example.com          #   the iframe JS may contact (CSP)
+    required_services:               # optional first-party LC services to
+      - search                       #   broker: search, replay, cases, ai
+    locations:                       # optional UI surfaces: standalone,
+      - standalone                   #   within_a_sensor, within_a_case, etc.
+    expected_context:                # optional context keys passed in when
+      - sid                          #   embedded (sid, atom, detection_id…)
+
+Records can be tagged and organized with usr_mtd:
+
+  usr_mtd:
+    tags: [internal, dashboard]
+    comment: "Sensor triage dashboard"
+
+Provide data via --input-file (YAML/JSON) or pipe through stdin.
+
+Examples:
+  limacharlie app set --key triage-dashboard --input-file app.yaml
+""")
+
+register_explain("app.delete", """\
+Delete an app from the 'app' hive.  Requires --confirm.
+""")

--- a/tests/unit/test_cli_lazy_loading_regression.py
+++ b/tests/unit/test_cli_lazy_loading_regression.py
@@ -45,7 +45,7 @@ del _ctx, _name
 
 # Every top-level command/group that must be registered on cli.
 EXPECTED_TOP_LEVEL_COMMANDS = frozenset({
-    "ai", "ai-memory", "ai-skill", "api", "api-key", "arl", "artifact",
+    "ai", "ai-memory", "ai-skill", "api", "api-key", "app", "arl", "artifact",
     "audit", "auth", "billing", "case", "cloud-adapter", "completion", "config",
     "detection", "download", "dr", "endpoint-policy", "event", "exfil",
     "extension", "external-adapter", "feedback", "fp", "group", "help", "hive",
@@ -64,6 +64,7 @@ EXPECTED_MODULE_MAP = {
     "ai_skill": ("group", "ai-skill"),
     "api_cmd": ("cmd", "api"),
     "api_key": ("group", "api-key"),
+    "app": ("group", "app"),
     "arl": ("group", "arl"),
     "artifact": ("group", "artifact"),
     "audit": ("group", "audit"),
@@ -127,6 +128,7 @@ EXPECTED_SUBCOMMANDS: dict[str, frozenset[str]] = {
     }),
     "ai-skill": frozenset({"delete", "disable", "enable", "get", "list", "set", "tag"}),
     "api-key": frozenset({"create", "delete", "list"}),
+    "app": frozenset({"delete", "disable", "enable", "get", "list", "set", "tag"}),
     "arl": frozenset({"get"}),
     "artifact": frozenset({"download", "list", "upload"}),
     "audit": frozenset({"list"}),
@@ -913,7 +915,7 @@ class TestLazyLoadingBehavior:
         """Hive shortcut commands (secret, fp, lookup, etc.) must load
         correctly via lazy loading since they use a factory pattern."""
         ctx = click.Context(cli)
-        for name in ("secret", "fp", "lookup", "playbook", "sop", "note"):
+        for name in ("secret", "fp", "lookup", "playbook", "sop", "note", "app"):
             cmd = cli.get_command(ctx, name)
             assert cmd is not None, f"Hive shortcut {name!r} not loaded"
             assert isinstance(cmd, click.Group), (


### PR DESCRIPTION
## Summary

Adds an `app` hive-shortcut command group to the CLI, mirroring the existing hive shortcuts (`secret`, `lookup`, `playbook`, `note`, `sop`, `external-adapter`, `cloud-adapter`, …). This wires up CLI support for the new `app` hive added in `legion_config_hive` (`hives/def_app.go`).

The `app` hive holds user-authored, AI-generated mini web apps — each record is a single self-contained HTML document that the LimaCharlie web UI renders inside a sandboxed `<iframe>`.

## Changes

- **`limacharlie/commands/app.py`** — new module built via `make_hive_group("app", "app", "app")`, giving `list`/`get`/`set`/`delete`/`enable`/`disable`/`tag` subcommands for free. Adds app-specific `--ai-help`/explain text documenting the record shape (`display_name`, `html`, `required_permissions`, `allowed_origins`, `required_services`, `locations`, `expected_context`).
- **`limacharlie/cli.py`** — register `"app"` in `_COMMAND_MODULE_MAP` for lazy loading.
- **`tests/unit/test_cli_lazy_loading_regression.py`** — add `app` to the expected top-level commands, module map, subcommands map, and the hive-shortcut load test.
- **`doc/cli/hive-data.md`** — document the new shortcut.

## Testing

- `pytest tests/unit/test_cli_lazy_loading_regression.py` — 974 passed.
- `limacharlie app --help` and `limacharlie app set --ai-help` render as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)