### PR TITLE
feat(cases): attribute notes to the originating AI session

### DIFF
--- a/limacharlie/sdk/cases.py
+++ b/limacharlie/sdk/cases.py
@@ -194,6 +194,7 @@ class Cases:
         content: str,
         note_type: str | None = None,
         is_public: bool | None = None,
+        ai_session_id: str | None = None,
     ) -> dict[str, Any]:
         """Add a note to a case.
 
@@ -204,12 +205,19 @@ class Cases:
                 escalation, handoff, to_stakeholder, from_stakeholder).
             is_public: Whether the note is visible to stakeholders
                 (default false).
+            ai_session_id: Originating AI session id, for cost attribution.
+                When omitted, it is read from the ``LC_AI_SESSION_ID``
+                environment variable (set by the ai-sessions runner), so notes
+                written by an AI agent are attributed automatically.
         """
         body: dict[str, Any] = {"content": content}
         if note_type:
             body["note_type"] = note_type
         if is_public is not None:
             body["is_public"] = is_public
+        session_id = ai_session_id or os.environ.get("LC_AI_SESSION_ID")
+        if session_id:
+            body["ai_session_id"] = session_id
         return self._request(
             "POST",
             f"cases/{case_number}/notes",

--- a/tests/unit/test_sdk_cases.py
+++ b/tests/unit/test_sdk_cases.py
@@ -320,6 +320,33 @@ class TestAddNote:
         body = _extract_body(mock_org)
         assert "is_public" not in body
 
+    def test_ai_session_id_explicit(self, cases, mock_org):
+        mock_org.client.request.return_value = {}
+        cases.add_note(42, "AI findings", ai_session_id="sess-1")
+        body = _extract_body(mock_org)
+        assert body["ai_session_id"] == "sess-1"
+
+    def test_ai_session_id_from_env(self, cases, mock_org, monkeypatch):
+        monkeypatch.setenv("LC_AI_SESSION_ID", "sess-env")
+        mock_org.client.request.return_value = {}
+        cases.add_note(42, "AI findings")
+        body = _extract_body(mock_org)
+        assert body["ai_session_id"] == "sess-env"
+
+    def test_explicit_ai_session_id_overrides_env(self, cases, mock_org, monkeypatch):
+        monkeypatch.setenv("LC_AI_SESSION_ID", "sess-env")
+        mock_org.client.request.return_value = {}
+        cases.add_note(42, "AI findings", ai_session_id="sess-explicit")
+        body = _extract_body(mock_org)
+        assert body["ai_session_id"] == "sess-explicit"
+
+    def test_no_ai_session_id_when_unset(self, cases, mock_org, monkeypatch):
+        monkeypatch.delenv("LC_AI_SESSION_ID", raising=False)
+        mock_org.client.request.return_value = {}
+        cases.add_note(42, "Note text")
+        body = _extract_body(mock_org)
+        assert "ai_session_id" not in body
+
 
 class TestUpdateNoteVisibility:
     def test_set_public(self, cases, mock_org):


### PR DESCRIPTION
## Why

Part of the AI cost-tracking initiative. To attribute a case's AI cost to the session that produced the work, a note written by an AI agent must carry its `ai_session_id`.

## What

`cases.add_note()` gains an optional `ai_session_id`, defaulting to the `LC_AI_SESSION_ID` environment variable (set by the ai-sessions runner). So notes an agent writes are attributed automatically — no caller change needed. Explicit arg overrides the env; with neither set, behavior is unchanged.

Unit tests cover explicit / from-env / override / unset.

## Linked PRs
- web-app-frontend#3894 — consumer (case-anchored savings)
- ext-cases#58 — persists `ai_session_id` on the note event metadata
- ai-sessions — sets `LC_AI_SESSION_ID` on the agent process

🤖 Generated with [Claude Code](https://claude.com/claude-code)