### PR TITLE
Add CLI support for the new app and ai_cost_model hives

### DIFF
--- a/limacharlie/cli.py
+++ b/limacharlie/cli.py
@@ -98,6 +98,7 @@ def _config_no_warnings() -> bool:
 # The regression test TestModuleMapping verifies this stays in sync.
 _COMMAND_MODULE_MAP: dict[str, tuple[str, str]] = {
     "ai": ("ai", "group"),
+    "ai-cost-model": ("ai_cost_model", "group"),
     "ai-memory": ("ai_memory", "group"),
     "ai-skill": ("ai_skill", "group"),
     "api": ("api_cmd", "cmd"),

--- a/limacharlie/commands/ai_cost_model.py
+++ b/limacharlie/commands/ai_cost_model.py
@@ -34,7 +34,7 @@ The data payload describes one costing profile:
     rate_source_note: "FY26 loaded SOC cost / 1,600 hrs"  # optional provenance
 
 loaded_hourly_rate and minutes_per_investigation are required and must
-be non-negative; the backend rejects values outside the allowed range.
+be non-negative; the backend rejects either value above 100000.
 
 Profiles can be tagged and organized with usr_mtd:
 

--- a/limacharlie/commands/ai_cost_model.py
+++ b/limacharlie/commands/ai_cost_model.py
@@ -1,0 +1,57 @@
+"""AI cost model commands for LimaCharlie CLI v2."""
+
+from __future__ import annotations
+
+from ._hive_shortcut import make_hive_group
+from ..discovery import register_explain
+
+group = make_hive_group("ai-cost-model", "ai_cost_model", "AI cost model")
+
+# Override the generic hive explains with cost-model-specific documentation.
+
+register_explain("ai-cost-model.list", """\
+List all AI cost-model profiles stored in the organization.  Each
+profile turns AI-agent activity into an auditable cost/savings figure
+by pairing a fully-burdened analyst rate with the standard manual
+handling time for one investigation of that kind of work.  Because
+this hive is per-org (OID-partitioned), the profiles are per-tenant.
+""")
+
+register_explain("ai-cost-model.get", """\
+Get a specific AI cost-model profile by key.  Returns the full record
+including the economic inputs and metadata.
+""")
+
+register_explain("ai-cost-model.set", """\
+Create or update an AI cost-model profile.
+
+The data payload describes one costing profile:
+
+  data:
+    label: "SOC L1 Triage"           # optional display name
+    loaded_hourly_rate: 95.0         # required: fully-burdened USD/hour
+    minutes_per_investigation: 30.0  # required: standard manual minutes
+    rate_source_note: "FY26 loaded SOC cost / 1,600 hrs"  # optional provenance
+
+loaded_hourly_rate and minutes_per_investigation are required and must
+be non-negative; the backend rejects values outside the allowed range.
+
+Profiles can be tagged and organized with usr_mtd:
+
+  data:
+    label: "SOC L1 Triage"
+    loaded_hourly_rate: 95.0
+    minutes_per_investigation: 30.0
+  usr_mtd:
+    tags: [soc, triage]
+    comment: "FY26 baseline"
+
+Provide data via --input-file (YAML/JSON) or pipe through stdin.
+
+Examples:
+  limacharlie ai-cost-model set --key soc-l1 --input-file model.yaml
+""")
+
+register_explain("ai-cost-model.delete", """\
+Delete an AI cost-model profile.  Requires --confirm.
+""")

--- a/limacharlie/commands/hive.py
+++ b/limacharlie/commands/hive.py
@@ -100,6 +100,8 @@ _KNOWN_HIVE_TYPES = [
     "external_adapter",
     "sop",
     "org_notes",
+    "app",
+    "ai_cost_model",
 ]
 
 
@@ -141,6 +143,8 @@ hold configuration data.  Common hive names include:
   ai_agent         - AI agent configurations
   ai_skill         - Claude Code skill definitions
   ai_memory        - AI agent memories (partial-merge updates)
+  ai_cost_model    - Per-org AI cost/savings economic model
+  app              - AI-generated iframe web apps
 
 Each record returned contains:
   data     - The record payload (structure varies by hive type)

--- a/limacharlie/help_topics.py
+++ b/limacharlie/help_topics.py
@@ -85,8 +85,10 @@ Shortcut commands:
     limacharlie cloud-sensor list/get/set/delete
     limacharlie sop list/get/set/delete
     limacharlie note list/get/set/delete
+    limacharlie app list/get/set/delete
+    limacharlie ai-cost-model list/get/set/delete
 
-Related commands: hive, secret, lookup, playbook, adapter, cloud-sensor, sop, note
+Related commands: hive, secret, lookup, playbook, adapter, cloud-sensor, sop, note, app, ai-cost-model
 """
 
 HELP_TOPICS["lcql"] = """\

--- a/tests/unit/test_cli_lazy_loading_regression.py
+++ b/tests/unit/test_cli_lazy_loading_regression.py
@@ -45,7 +45,7 @@ del _ctx, _name
 
 # Every top-level command/group that must be registered on cli.
 EXPECTED_TOP_LEVEL_COMMANDS = frozenset({
-    "ai", "ai-memory", "ai-skill", "api", "api-key", "app", "arl", "artifact",
+    "ai", "ai-cost-model", "ai-memory", "ai-skill", "api", "api-key", "app", "arl", "artifact",
     "audit", "auth", "billing", "case", "cloud-adapter", "completion", "config",
     "detection", "download", "dr", "endpoint-policy", "event", "exfil",
     "extension", "external-adapter", "feedback", "fp", "group", "help", "hive",
@@ -60,6 +60,7 @@ EXPECTED_TOP_LEVEL_COMMANDS = frozenset({
 EXPECTED_MODULE_MAP = {
     "adapter": ("group", "external-adapter"),
     "ai": ("group", "ai"),
+    "ai_cost_model": ("group", "ai-cost-model"),
     "ai_memory": ("group", "ai-memory"),
     "ai_skill": ("group", "ai-skill"),
     "api_cmd": ("cmd", "api"),
@@ -123,6 +124,7 @@ EXPECTED_SUBCOMMANDS: dict[str, frozenset[str]] = {
         "generate-response", "generate-rule", "generate-selector",
         "session", "start-session", "summarize-detection", "usage",
     }),
+    "ai-cost-model": frozenset({"delete", "disable", "enable", "get", "list", "set", "tag"}),
     "ai-memory": frozenset({
         "delete", "delete-record", "get", "list", "list-records", "set",
     }),
@@ -915,7 +917,7 @@ class TestLazyLoadingBehavior:
         """Hive shortcut commands (secret, fp, lookup, etc.) must load
         correctly via lazy loading since they use a factory pattern."""
         ctx = click.Context(cli)
-        for name in ("secret", "fp", "lookup", "playbook", "sop", "note", "app"):
+        for name in ("secret", "fp", "lookup", "playbook", "sop", "note", "app", "ai-cost-model"):
             cmd = cli.get_command(ctx, name)
             assert cmd is not None, f"Hive shortcut {name!r} not loaded"
             assert isinstance(cmd, click.Group), (


### PR DESCRIPTION
## What was asked

Review the last couple of weeks of changes to the backend hive config schema and determine whether the CLI tool in this repo needs corresponding changes.

## What was done

Two hives were recently added on the backend:

- **`app`** — AI-generated iframe web apps.
- **`ai_cost_model`** — per-org AI cost/savings economic model (cost profiles).

The CLI was only partially caught up:

- `app` already had a shortcut command (added during the cli-v2 sync) but was **missing from the hive discoverability lists**.
- `ai_cost_model` had **no CLI presence at all**.

Changes:

- **`limacharlie/commands/hive.py`** — add `app` and `ai_cost_model` to `_KNOWN_HIVE_TYPES` and to the `hive list` explain text, so both are discoverable via the generic `hive` command.
- **`limacharlie/commands/ai_cost_model.py`** (new) — `ai-cost-model` shortcut command built on the `make_hive_group` factory, bringing it to parity with the other config-like hive shortcuts (`sop`, `note`, `app`, …). The `set` help is field-accurate to the backend record (`label`, `loaded_hourly_rate`, `minutes_per_investigation`, `rate_source_note`).
- **`limacharlie/cli.py`** — register `ai-cost-model` in the lazy-loading command map.
- **`limacharlie/help_topics.py`** — list `app` and `ai-cost-model` wrappers in the `hive` help topic.
- **`tests/unit/test_cli_lazy_loading_regression.py`** — update the CLI-surface snapshot (top-level commands, module map, subcommands, shortcut-load loop).

### Intentionally out of scope

The IaC sync set (`Configs.ALL_HIVES` and the sync `_HIVE_FLAG_MAP`) is left unchanged. It is a curated subset tied to backend `ext-infrastructure` support and already excludes several existing hives (`app`, `sop`, `org_notes`, …), so adding these there would require confirming backend sync support first.

## Testing

Run with the repo `.venv`:

- `pytest tests/unit/test_cli_lazy_loading_regression.py tests/unit/test_discovery.py` → **1003 passed, 2 skipped** (skips are pre-existing, environment-conditional).
- Functional smoke test via `CliRunner`: `ai-cost-model --help`, `ai-cost-model set --help`, and `help topic hive` all render correctly.
- The full `tests/unit` run shows ~111 pre-existing failures unrelated to this change — all in `test_search_*`, caused by the `toon_format` package shipping a `NotImplementedError` stub in this environment. None touch the code changed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)