### PR TITLE
cloudsec: enable-gate extension renamed to ext-cloud-security

### DIFF
--- a/limacharlie/commands/cloudsec.py
+++ b/limacharlie/commands/cloudsec.py
@@ -8,9 +8,9 @@ surface), sensor<->cloud-asset resolution, and finding triage.
 
 Reads require the ``cloudsec.get`` permission and writes require
 ``cloudsec.set``. Every command requires the org to be subscribed to
-the ``ext-cloud-inventory`` extension:
+the ``ext-cloud-security`` extension:
 
-  limacharlie extension subscribe --name ext-cloud-inventory
+  limacharlie extension subscribe --name ext-cloud-security
 
 Provider credentials and the cloudsec policies are hive records —
 manage them with the hive commands (``limacharlie hive list
@@ -620,7 +620,7 @@ def _sort_options(f):
 def group() -> None:
     """Cloud Security (CNAPP): findings, inventory, graph, compliance.
 
-    Requires the org to be subscribed to the ext-cloud-inventory
+    Requires the org to be subscribed to the ext-cloud-security
     extension. Reads need the 'cloudsec.get' permission; triage and
     other writes need 'cloudsec.set'. Provider configs and policies
     are hive records (cloudsec_provider / cloudsec_policy hives).

--- a/limacharlie/sdk/cloudsec.py
+++ b/limacharlie/sdk/cloudsec.py
@@ -9,7 +9,7 @@ writes.
 
 Reads require the ``cloudsec.get`` permission and writes require
 ``cloudsec.set``; every route additionally requires the org to be
-subscribed to the ``ext-cloud-inventory`` extension (403 otherwise).
+subscribed to the ``ext-cloud-security`` extension (403 otherwise).
 
 Provider credentials/config and the cloudsec policies are hive
 records (``cloudsec_provider``, ``cloudsec_policy``, ``cloudsec_query``


### PR DESCRIPTION
The ext-cloud-inventory extension (the /cloudsec enable/billing gate) was renamed to ext-cloud-security. Help-text/docstring references in the cloudsec CLI + SDK follow. No functional change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015kiVFM7wDDFeLHjbd477AW