### PR TITLE
ioc search: add --info locations, --limit, --case-sensitive, --wildcards flags

### DIFF
--- a/limacharlie/commands/ioc.py
+++ b/limacharlie/commands/ioc.py
@@ -94,13 +94,20 @@ Supported --type values:
   service_name - Service/daemon name
   package_name - Installed package name
 
-The result includes prevalence data showing which sensors observed
-the IOC, how many times, and when (first/last seen).
+--info controls the response shape:
+  summary    prevalence counts per time bucket (default).
+  locations  the list of sensor IDs that observed the IOC, with
+             first/last seen times and hostnames. Use --limit to cap
+             the number of entries returned.
+
+--wildcards treats the value as a pattern where '%' matches anything
+(e.g. '10.10.%'). --case-insensitive disables case-sensitive matching.
 
 Examples:
   limacharlie ioc search --type domain --value evil.com
-  limacharlie ioc search --type ip --value 1.2.3.4
+  limacharlie ioc search --type ip --value 1.2.3.4 --info locations
   limacharlie ioc search --type file_hash --value abc123...
+  limacharlie ioc search --type ip --value '10.10.%' --info locations --wildcards
 """
 register_explain("ioc.search", _EXPLAIN_SEARCH)
 
@@ -108,11 +115,15 @@ register_explain("ioc.search", _EXPLAIN_SEARCH)
 @group.command()
 @click.option("--type", "ioc_type", required=True, help="IOC type (domain, ip, file_hash, file_path, etc.).")
 @click.option("--value", required=True, help="IOC value to search for.")
+@click.option("--info", "info", type=click.Choice(["summary", "locations"]), default="summary", show_default=True, help="Response shape: 'summary' counts only, or 'locations' to return the sensor IDs that observed the IOC.")
+@click.option("--limit", type=int, default=None, help="Max number of results returned.")
+@click.option("--case-sensitive/--case-insensitive", default=True, show_default=True, help="Case-sensitive matching of the IOC value.")
+@click.option("--wildcards", is_flag=True, default=False, help="Treat the value as a pattern where '%' matches anything.")
 @pass_context
-def search(ctx: click.Context, ioc_type: str, value: str) -> None:
+def search(ctx: click.Context, ioc_type: str, value: str, info: str, limit: int | None, case_sensitive: bool, wildcards: bool) -> None:
     org = _get_org(ctx)
     insight = Insight(org)
-    data = insight.search_ioc(ioc_type, value)
+    data = insight.search_ioc(ioc_type, value, info=info, case_sensitive=case_sensitive, wildcards=wildcards, limit=limit)
     _output(ctx, data)
 
 

--- a/tests/integration/test_cli_comprehensive.py
+++ b/tests/integration/test_cli_comprehensive.py
@@ -631,6 +631,13 @@ class TestCliIOC:
         ])
         assert result.exit_code == 0
 
+    def test_search_locations(self, oid, key):
+        result, _ = _invoke(oid, key, [
+            "ioc", "search", "--type", "domain", "--value", "example.com",
+            "--info", "locations", "--limit", "10",
+        ])
+        assert result.exit_code == 0
+
     def test_hosts(self, oid, key):
         result, _ = _invoke(oid, key, [
             "ioc", "hosts", "--hostname", "nonexistent-test-host-12345",


### PR DESCRIPTION
## Problem

`limacharlie ioc search --type ip --value <IP>` only ever returns prevalence counts — there is no way to see *which* sensors observed the IOC. A user reported this in support.

The whole stack below the CLI already supports it: the SDK's `search_ioc()` accepts `info="locations"` (plus `limit`, `case_sensitive`, `wildcards`), the API gateway routes `info=locations` to the `get_obj_locations` RPC, and the backend returns per-SID entries with first/last seen and hostnames. The CLI `search` command just never exposed the flags (`batch-search` in the same file already has `--info`/`--limit`).

## Change

- `ioc search` gains `--info summary|locations` (default `summary`, unchanged behavior), `--limit`, `--case-sensitive/--case-insensitive` and `--wildcards`, passed straight through to `Insight.search_ioc()`.
- Updated the `--ai-help` explain text with the new flags and examples.
- Added an integration test covering `--info locations --limit`.

## Verification

- `tests/unit/test_sdk_insight.py` (18 tests) passes; the full unit suite shows the same 111 pre-existing failures as master (unrelated `test_search_*` files).
- `ioc search --help` renders the new options correctly.
- Integration tests require org creds and will run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F2QkWSTn8PEgyKvs7epe7f