### PR TITLE
test: cover list_sensors is_online_only and sensor list --online

### DIFF
--- a/tests/integration/test_sensors.py
+++ b/tests/integration/test_sensors.py
@@ -19,6 +19,37 @@ def test_v2_sensor_list(oid, key):
     assert isinstance(sensors, list)
 
 
+def test_v2_sensor_list_online_only(oid, key):
+    # is_online_only must (a) never WIDEN the result and (b) actually FILTER:
+    # every sensor it returns must currently be online. (a) is a race-free
+    # invariant. (b) is the meaningful check - a subset assertion alone would
+    # also pass if the server silently ignored the parameter and returned the
+    # full list, so we confirm the returned sensors are genuinely online.
+    #
+    # The exact query-parameter wiring is pinned deterministically by the unit
+    # tests. Online state is inherently volatile, so (b) reads the online set
+    # (a single bulk get_online_sensors call, scoped to just the returned SIDs)
+    # immediately after the listing to keep the race window minimal.
+    org = _make_org(oid, key)
+    all_sensors = list(org.list_sensors())
+    online_only = list(org.list_sensors(is_online_only=True))
+
+    # (a) never widens, and every returned sensor is a real org sensor.
+    assert len(online_only) <= len(all_sensors)
+    all_sids = {s.get("sid") for s in all_sensors}
+    online_only_sids = [s.get("sid") for s in online_only if s.get("sid")]
+    for sid in online_only_sids:
+        assert sid in all_sids
+
+    # (b) every sensor is_online_only returned is actually online right now.
+    if online_only_sids:
+        actually_online = set(org.get_online_sensors(sids=online_only_sids))
+        for sid in online_only_sids:
+            assert sid in actually_online, (
+                f"is_online_only returned {sid}, but it is not currently online"
+            )
+
+
 def test_v2_sensor_tags(oid, key):
     org = _make_org(oid, key)
     tags = org.get_all_tags()

--- a/tests/unit/test_cli_commands.py
+++ b/tests/unit/test_cli_commands.py
@@ -407,6 +407,21 @@ class TestSensorCommands:
         parsed = json.loads(result.output)
         assert len(parsed) == 2
         assert parsed[0]["sid"] == "sid-1"
+        # Default: online-only is off (all sensors).
+        assert mock_org.list_sensors.call_args.kwargs["is_online_only"] is False
+
+    @patch("limacharlie.commands.sensor.Client")
+    @patch("limacharlie.commands.sensor.Organization")
+    def test_sensor_list_online_only(self, mock_org_cls, mock_client_cls):
+        mock_org = MagicMock()
+        mock_org.list_sensors.return_value = iter([{"sid": "sid-1", "hostname": "host1"}])
+        mock_org_cls.return_value = mock_org
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--output", "json", "sensor", "list", "--online"])
+        assert result.exit_code == 0
+        # The --online flag maps to is_online_only=True on the SDK call.
+        assert mock_org.list_sensors.call_args.kwargs["is_online_only"] is True
 
     @patch("limacharlie.commands.sensor.Client")
     @patch("limacharlie.commands.sensor.Sensor")

--- a/tests/unit/test_sdk_organization.py
+++ b/tests/unit/test_sdk_organization.py
@@ -638,6 +638,32 @@ class TestListSensors:
             },
         )
 
+    def test_list_sensors_online_only(self, org, mock_client):
+        mock_client.request.return_value = {"sensors": []}
+        list(org.list_sensors(is_online_only=True))
+        mock_client.request.assert_called_once_with(
+            "GET", "sensors/test-oid-123",
+            query_params={"is_online_only": "true"},
+        )
+
+    def test_list_sensors_online_only_false_omits_param(self, org, mock_client):
+        # Backward compatible: the default / explicit-False case must NOT send
+        # is_online_only, so the request is byte-identical to before the option
+        # existed (query_params collapses to None when nothing else is set).
+        mock_client.request.return_value = {"sensors": []}
+        list(org.list_sensors(is_online_only=False))
+        mock_client.request.assert_called_once_with(
+            "GET", "sensors/test-oid-123", query_params=None,
+        )
+
+    def test_list_sensors_online_only_with_selector(self, org, mock_client):
+        mock_client.request.return_value = {"sensors": []}
+        list(org.list_sensors(selector="plat == windows", is_online_only=True))
+        mock_client.request.assert_called_once_with(
+            "GET", "sensors/test-oid-123",
+            query_params={"selector": "plat == windows", "is_online_only": "true"},
+        )
+
 
 class TestExportSensors:
     def test_export_sensors(self, org, mock_client):


### PR DESCRIPTION
## Details

Adds test coverage for the `is_online_only` option on `Organization.list_sensors` and the `sensor list --online` CLI flag, which shipped without tests. No production code change.

## Testing
- Unit (SDK): `is_online_only=True` sends `is_online_only="true"` in the query params; the default / explicit `False` omits the parameter entirely (backward compatible - the request is unchanged from before the option existed); and it composes with a `selector`.
- Unit (CLI): `sensor list` defaults to `is_online_only=False`; `sensor list --online` maps to `is_online_only=True`.
- Integration: `is_online_only` may only narrow the result - the online-only listing is a subset of, and no larger than, the full listing (runs against a live org in CI).

## Blast radius / isolation
- Tests only; no runtime or behavior change. Only the sensor-listing test files are touched.

## Related PRs
- go SDK counterpart (adds the same online-only option to the iterative selector resolution): [go-limacharlie#257](https://github.com/refractionPOINT/go-limacharlie/pull/257)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
