### PR TITLE
Bump requests to 2.33.0 and drop Python 3.9 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v6
         with:
@@ -37,7 +37,7 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install ".[dev]"
-          # Python 3.9 needs tomli for pyproject.toml parsing in tests
+          # Python 3.10 needs tomli for pyproject.toml parsing in tests (tomllib is stdlib from 3.11)
           if python -c "import sys; sys.exit(0 if sys.version_info < (3, 11) else 1)"; then
             pip install "tomli>=1.0"
           fi

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v6
         with:
@@ -30,7 +30,7 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install ".[dev]"
-          # Python 3.9 needs tomli for pyproject.toml parsing in tests
+          # Python 3.10 needs tomli for pyproject.toml parsing in tests (tomllib is stdlib from 3.11)
           if python -c "import sys; sys.exit(0 if sys.version_info < (3, 11) else 1)"; then
             pip install "tomli>=1.0"
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,17 @@
   request-scoped JWT (multi-org for user credentials when `oid` is omitted)
   without touching the client's own token, cache, or refresh callback.
 
+### Dependencies & Python support
+
+- **`requests` 2.32.3 -> 2.33.0**: picks up the fix for GHSA-gc5v-m9x4-r6x2
+  (insecure temp-file reuse in `extract_zipped_paths()`; vulnerable `<2.33.0`).
+- **Minimum Python is now 3.10** (was 3.9). `requests` 2.33.0 requires Python
+  `>=3.10`, and Python 3.9 reached end-of-life in October 2025. The 3.9 entries
+  in the CI matrices, Cloud Build, and PyPI classifiers are removed, and the
+  orjson/pytest version shims that existed only to keep 3.9 working are
+  simplified (orjson uncapped `>=3.10.0`; pytest pinned to the CVE-fixed 9.0.3
+  for all supported versions).
+
 ## 5.2.0 - March 20, 2026
 
 ### CLI

--- a/NEW_CLI.md
+++ b/NEW_CLI.md
@@ -941,7 +941,7 @@ All integration tests use a real LimaCharlie org (credentials via `--oid` and `-
 - [ ] `typing-extensions` - Type annotation support
 
 ### 9.3 Python Version Support
-- [ ] Python 3.9+
+- [ ] Python 3.10+
 - [ ] Type annotations throughout (for IDE support and documentation)
 
 ---

--- a/cloudbuild_pr.yaml
+++ b/cloudbuild_pr.yaml
@@ -33,68 +33,6 @@ steps:
 # Each step: build wheel from source, install in clean dir, verify package.
 # ---------------------------------------------------------------------------
 
-- id: "Dist (Python 3.9)"
-  name: 'python:3.9'
-  entrypoint: "bash"
-  args:
-    - '-c'
-    - |
-      set -e
-      echo "=========================================="
-      echo "  Dist Check: Python 3.9"
-      echo "=========================================="
-
-      echo "--- Building wheel ---"
-      cp -r /workspace /tmp/build-39 && cd /tmp/build-39
-      pip install --upgrade pip setuptools wheel build -q
-      # Create a local-only tag so setuptools-scm generates a real version
-      # instead of 0.0.0.dev0. This tag is never pushed.
-      git tag 99.0.0.dev39 2>/dev/null || true
-      python -m build -q
-      ls -lh dist/
-
-      echo "--- Installing wheel ---"
-      pip install dist/limacharlie-*-py3-none-any.whl -q
-
-      echo "--- Verifying installation ---"
-      pip show limacharlie
-      limacharlie --version
-
-      echo "--- Verifying version consistency ---"
-      python -c "
-      from importlib.metadata import version as pkg_version
-      import limacharlie
-
-      meta_ver = pkg_version('limacharlie')
-      attr_ver = limacharlie.__version__
-
-      print(f'importlib.metadata: {meta_ver}')
-      print(f'limacharlie.__version__: {attr_ver}')
-
-      assert meta_ver == attr_ver, (
-          f'Version mismatch: importlib.metadata={meta_ver!r} vs '
-          f'__version__={attr_ver!r}'
-      )
-      assert attr_ver != '0.0.0.dev0', (
-          f'__version__ is the fallback 0.0.0.dev0 - _version.py import failed'
-      )
-      print(f'Version consistency: OK ({meta_ver})')
-      "
-
-      echo "--- Verifying orjson (expect 3.10.x on Python 3.9) ---"
-      python -c "
-      import orjson
-      v = tuple(int(x) for x in orjson.__version__.split('.'))
-      assert v[0] == 3 and v[1] == 10, f'Expected orjson 3.10.x, got {orjson.__version__}'
-      print(f'orjson {orjson.__version__} (OK)')
-      from limacharlie.json_compat import backend_name, HAS_ORJSON
-      assert HAS_ORJSON, 'orjson should be available on Python 3.9'
-      print(f'JSON backend: {backend_name()} (OK)')
-      "
-
-      echo "--- Dist check passed ---"
-  waitFor: ["-"]
-
 - id: "Dist (Python 3.10)"
   name: 'python:3.10'
   entrypoint: "bash"
@@ -363,27 +301,6 @@ steps:
 # Unit tests for each supported Python version (all parallel).
 # Install from source (editable-like) to get test dependencies.
 # ---------------------------------------------------------------------------
-
-- id: "Unit Tests (Python 3.9)"
-  name: 'python:3.9'
-  entrypoint: "bash"
-  args:
-    - '-c'
-    - |
-      set -e
-      echo "=========================================="
-      echo "  Unit Tests: Python 3.9"
-      echo "=========================================="
-
-      cp -r /workspace /tmp/test-39 && cd /tmp/test-39
-      pip install --upgrade pip -q
-      pip install ".[dev]" "tomli>=1.0" -q
-
-      echo "--- Running unit tests ---"
-      pytest -s -v --durations=10 --reruns 3 --reruns-delay 5 --benchmark-disable tests/unit/ tests/microbenchmarks/
-
-      echo "--- Unit tests passed ---"
-  waitFor: ["-"]
 
 - id: "Unit Tests (Python 3.10)"
   name: 'python:3.10'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "Python SDK and CLI for the LimaCharlie endpoint detection and res
 readme = "README.md"
 license = "Apache-2.0"
 authors = [{name = "Maxime Lamothe-Brassard", email = "maxime@refractionpoint.com"}]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
@@ -17,7 +17,6 @@ classifiers = [
     "Topic :: Security",
     "Topic :: System :: Monitoring",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -26,7 +25,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "requests==2.32.3",
+    "requests==2.33.0",
     "passlib==1.7.4",
     "pyyaml==6.0.2",
     "tabulate==0.9.0",
@@ -36,20 +35,19 @@ dependencies = [
     "cryptography==48.0.1",
     "click==8.1.8",
     "jmespath==1.1.0",
-    "orjson>=3.10.0,<3.11; python_version < '3.10'",
-    "orjson>=3.10.0; python_version >= '3.10'",
+    "orjson>=3.10.0",
     "websockets>=13.0",
     "toon_format>=0.9.0b1,<1.0",
 ]
 
 [project.optional-dependencies]
 dev = [
-    # pytest 9.x (CVE-2025-71176 fix) requires Python >= 3.10; 3.9 keeps the
-    # last compatible release until 3.9 support is dropped
-    "pytest==9.0.3; python_version >= '3.10'",
-    "pytest==8.3.4; python_version < '3.10'",
+    # pytest 9.x carries the CVE-2025-71176 fix and requires Python >= 3.10,
+    # which matches our minimum supported version.
+    "pytest==9.0.3",
     "pytest-rerunfailures==15.0",
     "pytest-benchmark>=5.0.0",
+    # tomllib is stdlib from 3.11; Python 3.10 still needs the tomli backport.
     "tomli>=1.0; python_version < '3.11'",
 ]
 

--- a/tests/unit/test_packaging.py
+++ b/tests/unit/test_packaging.py
@@ -82,7 +82,8 @@ class TestPyprojectToml:
         with open(PROJECT_ROOT / "pyproject.toml", "rb") as f:
             data = tomllib.load(f)
         requires = data["project"].get("requires-python", "")
-        assert "3.9" in requires, "Minimum Python should be 3.9"
+        assert "3.10" in requires, "Minimum Python should be 3.10"
+        assert "3.9" not in requires, "Python 3.9 is EOL and no longer supported"
 
     def test_classifiers_production_stable(self):
         with open(PROJECT_ROOT / "pyproject.toml", "rb") as f:
@@ -105,24 +106,26 @@ class TestPyprojectToml:
         for name, url in urls.items():
             assert url.startswith("https://"), f"URL for {name} is not HTTPS: {url}"
 
-    def test_orjson_has_environment_markers(self):
-        """orjson dependency should use environment markers for Python compat.
+    def test_orjson_is_uncapped(self):
+        """orjson should be a single uncapped dependency.
 
-        orjson 3.11+ requires Python 3.10+, so we split the dependency:
-        - Python <3.10: orjson >=3.10.0,<3.11 (last series with 3.9 support)
-        - Python >=3.10: orjson >=3.10.0 (latest)
+        orjson 3.11+ requires Python 3.10+. Now that our minimum is 3.10, the
+        old python_version<3.10 split (which capped orjson at <3.11 to keep 3.9
+        working) is gone, and every supported version can take the latest orjson.
         """
         with open(PROJECT_ROOT / "pyproject.toml", "rb") as f:
             data = tomllib.load(f)
         deps = data["project"].get("dependencies", [])
         orjson_deps = [d for d in deps if d.startswith("orjson")]
-        assert len(orjson_deps) == 2, (
-            f"Expected 2 orjson deps (split markers), got {len(orjson_deps)}: {orjson_deps}"
+        assert len(orjson_deps) == 1, (
+            f"Expected a single orjson dep, got {len(orjson_deps)}: {orjson_deps}"
         )
-        # One should cap <3.11 for older Python, one should be uncapped
-        markers = " ".join(orjson_deps)
-        assert "<3.11" in markers, "Missing <3.11 cap for Python <3.10"
-        assert "python_version" in markers, "Missing python_version marker"
+        spec = orjson_deps[0]
+        assert ">=3.10.0" in spec, f"orjson should floor at >=3.10.0, got {spec!r}"
+        assert "<3.11" not in spec, f"orjson should not be capped below 3.11, got {spec!r}"
+        assert "python_version" not in spec, (
+            f"orjson no longer needs a python_version marker, got {spec!r}"
+        )
 
     def test_orjson_available_on_current_python(self):
         """orjson should be importable on any supported Python version."""


### PR DESCRIPTION
## Summary

Upgrades `requests` to **2.33.0**, which patches **[GHSA-gc5v-m9x4-r6x2](https://github.com/advisories/GHSA-gc5v-m9x4-r6x2)** (insecure temp-file reuse in `extract_zipped_paths()`; vulnerable `<2.33.0`).

`requests` 2.33.0 requires **Python >=3.10**, so this raises the SDK's minimum supported Python to 3.10. Python 3.9 reached [end-of-life in October 2025](https://devguide.python.org/versions/), so this is the natural time to drop it. This supersedes Dependabot #316 (which bumped only `requests` and could not merge because it broke the 3.9 CI job).

## Changes

- **`requires-python = ">=3.10"`**; removed the `Programming Language :: Python :: 3.9` classifier.
- **`requests==2.32.3` -> `==2.33.0`** (the security fix).
- Removed `3.9` from both CI matrices (`ci.yml`, `publish-to-pypi.yml`) and the two `python:3.9` Cloud Build steps (`cloudbuild_pr.yaml`).
- Simplified the dependency shims that existed only for 3.9:
  - `orjson` is now a single uncapped `>=3.10.0` (orjson 3.11+ requires 3.10+).
  - `pytest` pinned to `9.0.3` for all supported versions (carries the CVE-2025-71176 fix; previously the `<3.10` shim held it back to 8.3.4).
  - `tomli` backport kept for 3.10 (`tomllib` is stdlib only from 3.11).
- Updated packaging tests for the new 3.10 floor and the single orjson dependency.

## Test plan / validation (local, Python 3.11)

- Fresh venv `pip install ".[dev]"` from source resolves `requests 2.33.0`, `orjson 3.11.9`, `pytest 9.0.3`.
- Full suite `pytest tests/unit/ tests/microbenchmarks/ --benchmark-disable`: **3744 passed, 5 skipped**.
- `test_packaging.py`: **20/20 pass** (incl. updated `test_requires_python_minimum` and `test_orjson_is_uncapped`).
- `python -m build` produces sdist + wheel; built metadata shows `Requires-Python: >=3.10`, classifiers 3.10–3.14, `requests==2.33.0`, `orjson>=3.10.0`.