### PR TITLE
Remove workload-scanning finding classes from cloudsec CLI/SDK help

### DIFF
--- a/doc/cli/cloud-security.md
+++ b/doc/cli/cloud-security.md
@@ -38,7 +38,7 @@ limacharlie cloudsec fleet overview --oid <OID1> --oid <OID2>
 
 ## Findings
 
-Repeatable filters are OR within a key and AND across keys. Finding classes: `toxic_combination`, `public_exposure`, `ciem_risk`, `privilege_escalation`, `vulnerability`, `misconfig`, `malware`, `secret`, `scan_finding`, `coverage_gap`. Sort keys: `lc_risk` (default), `severity`, `first_seen`.
+Repeatable filters are OR within a key and AND across keys. Finding classes: `toxic_combination`, `public_exposure`, `ciem_risk`, `privilege_escalation`, `vulnerability`, `misconfig`, `coverage_gap`. Sort keys: `lc_risk` (default), `severity`, `first_seen`.
 
 ```bash
 limacharlie cloudsec finding list --severity CRITICAL --severity HIGH

--- a/limacharlie/commands/cloudsec.py
+++ b/limacharlie/commands/cloudsec.py
@@ -87,9 +87,9 @@ Repeatable filters are OR within a key and AND across keys:
   --severity CRITICAL --severity HIGH --class toxic_combination
 
 Finding classes: toxic_combination, public_exposure, ciem_risk,
-privilege_escalation, vulnerability, misconfig, malware, secret,
-scan_finding, coverage_gap, device_posture. The canonical, always
-current list is served by 'cloudsec finding classes'.
+privilege_escalation, vulnerability, misconfig, coverage_gap,
+device_posture. The canonical, always current list is served by
+'cloudsec finding classes'.
 
 Pagination is keyset-based: pass the previous page's next_cursor
 via --cursor.
@@ -152,7 +152,7 @@ use 'finding resolve <id> --kind open' per finding.
 
 Example:
   limacharlie cloudsec finding bulk-resolve --finding-id fnd_a... --finding-id fnd_b... \\
-      --kind false_positive --reason "scanner artifact"
+      --kind false_positive --reason "expected configuration"
 """
 
 _EXPLAIN_FINDING_SET_OWNER = """\

--- a/limacharlie/sdk/cloudsec.py
+++ b/limacharlie/sdk/cloudsec.py
@@ -203,7 +203,7 @@ class CloudSec:
             severity: Filter values (CRITICAL/HIGH/MEDIUM/LOW/INFO), OR'd.
             finding_class: Filter values (toxic_combination, public_exposure,
                 ciem_risk, privilege_escalation, vulnerability, misconfig,
-                malware, secret, scan_finding, coverage_gap), OR'd.
+                coverage_gap), OR'd.
             status: Filter values (open/resolved), OR'd.
             account: Cloud account filter values, OR'd.
             reachable: Only findings on (non-)reachable resources.


### PR DESCRIPTION
Companion to the web-app and documentation PRs removing the Workload Scanning (CWPP) surface, since the feature is not enabled in any production deployment.

The cloudsec CLI has **no scanner-specific commands** — `limacharlie cloudsec scan-status` reports the collection-sweep status (inventory runs), not the workload scanner, so it stays. What this PR removes is the scanner-only vocabulary baked into help text and docstrings:

- `malware`, `secret`, `scan_finding` dropped from the finding-class lists in `_EXPLAIN_FINDING_LIST` (commands/cloudsec.py), the `get_findings` docstring (sdk/cloudsec.py), and `doc/cli/cloud-security.md`.
- The `bulk-resolve` example reason "scanner artifact" replaced with a neutral example.

Kept: `scan-status` (collection status), `coverage_gap` (CAASM), CAASM `scanner` source wording (third-party vuln-scanner integrations), and the dynamic `cloudsec finding classes` command, which always serves the server's canonical list.

Tests: full unit suite green (3653 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KT6t7WyXfsEfyCGahubzqa