### PR TITLE
Add org description (org_info) support to SDK and CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### Organization
+
+- **Set org description (org info)**: `Organization.set_description()` /
+  `limacharlie org set-description --description ...` update an organization's
+  description without renaming it (the helper re-submits the current name so
+  only the description changes). `Organization.rename()` and `limacharlie org
+  rename` also take an optional `description` to set both at once. The
+  backend only exposes the description through the rename endpoint, so these
+  are thin wrappers over `POST /v1/orgs/{oid}/name`.
+
 ### Cloud Security (CNAPP)
 
 - **Multi-org fleet overview**: `limacharlie cloudsec fleet overview` /

--- a/limacharlie/commands/org.py
+++ b/limacharlie/commands/org.py
@@ -356,16 +356,41 @@ def delete(ctx: click.Context, confirm_token: str | None) -> None:
 _EXPLAIN_RENAME = """\
 Rename an organization.  The new name must be unique across LimaCharlie.
 Use 'limacharlie org check-name' to verify availability before renaming.
+Optionally pass --description to update the organization description (org
+info) at the same time.
 """
 register_explain("org.rename", _EXPLAIN_RENAME)
 
 
 @group.command()
 @click.option("--name", required=True, help="New organization name.")
+@click.option("--description", default=None, help="New description (org info) for the organization.")
 @pass_context
-def rename(ctx: click.Context, name: str) -> None:
+def rename(ctx: click.Context, name: str, description: str | None) -> None:
     org = _get_org(ctx)
-    data = org.rename(name)
+    data = org.rename(name, description=description)
+    _output(ctx, data)
+
+
+# ---------------------------------------------------------------------------
+# set-description
+# ---------------------------------------------------------------------------
+
+_EXPLAIN_SET_DESCRIPTION = """\
+Set the organization's description (org info) without changing its name.
+The backend only exposes the description through the rename endpoint, so
+this command reads the organization's current name and re-submits it
+unchanged so only the description is updated.
+"""
+register_explain("org.set-description", _EXPLAIN_SET_DESCRIPTION)
+
+
+@group.command("set-description")
+@click.option("--description", required=True, help="New description (org info) for the organization.")
+@pass_context
+def set_description(ctx: click.Context, description: str) -> None:
+    org = _get_org(ctx)
+    data = org.set_description(description)
     _output(ctx, data)
 
 

--- a/limacharlie/sdk/organization.py
+++ b/limacharlie/sdk/organization.py
@@ -200,16 +200,42 @@ class Organization:
         """
         return self._client.request("GET", f"quota_usage/{self.oid}")
 
-    def rename(self, new_name: str) -> dict[str, Any]:
+    def rename(self, new_name: str, description: str | None = None) -> dict[str, Any]:
         """Rename the organization.
 
         Args:
             new_name: New organization name.
+            description: Optional new description (org info) for the
+                organization. When provided, it is set as a side-effect of
+                the rename. Pass None to leave the description unchanged.
 
         Returns:
             dict: API response.
         """
-        return self._client.request("POST", f"orgs/{self.oid}/name", query_params={"name": new_name})
+        query_params: dict[str, Any] = {"name": new_name}
+        if description is not None:
+            query_params["description"] = description
+        return self._client.request("POST", f"orgs/{self.oid}/name", query_params=query_params)
+
+    def set_description(self, description: str) -> dict[str, Any]:
+        """Set the organization's description (org info).
+
+        The backend only exposes the description as a side-effect of the org
+        rename endpoint, which requires a (non-empty) name. This helper reads
+        the organization's current name and re-submits it unchanged so only
+        the description is updated.
+
+        Args:
+            description: New description for the organization.
+
+        Returns:
+            dict: API response.
+        """
+        current_name = self.get_info().get("name")
+        if not current_name:
+            from ..errors import ApiError
+            raise ApiError("could not resolve current organization name to set description")
+        return self.rename(current_name, description=description)
 
     def get_ontology(self) -> dict[str, Any]:
         """Get the LimaCharlie ontology (event type definitions).

--- a/tests/unit/test_cli_lazy_loading_regression.py
+++ b/tests/unit/test_cli_lazy_loading_regression.py
@@ -195,7 +195,8 @@ EXPECTED_SUBCOMMANDS: dict[str, frozenset[str]] = {
     "org": frozenset({
         "check-name", "config-get", "config-set", "create", "delete",
         "dismiss-error", "errors", "info", "list", "mitre", "quota",
-        "quota-usage", "rename", "runtime-metadata", "schema", "stats", "urls",
+        "quota-usage", "rename", "runtime-metadata", "schema", "set-description",
+        "stats", "urls",
     }),
     "output": frozenset({"create", "delete", "list"}),
     "payload": frozenset({"delete", "download", "list", "upload"}),

--- a/tests/unit/test_sdk_organization.py
+++ b/tests/unit/test_sdk_organization.py
@@ -175,6 +175,48 @@ class TestOrganizationRename:
             query_params={"name": "new-org-name"},
         )
 
+    def test_rename_with_description(self, org, mock_client):
+        org.rename("new-org-name", description="my new description")
+        mock_client.request.assert_called_once_with(
+            "POST", "orgs/test-oid-123/name",
+            query_params={"name": "new-org-name", "description": "my new description"},
+        )
+
+    def test_rename_none_description_omitted(self, org, mock_client):
+        org.rename("new-org-name", description=None)
+        mock_client.request.assert_called_once_with(
+            "POST", "orgs/test-oid-123/name",
+            query_params={"name": "new-org-name"},
+        )
+
+    def test_set_description_reuses_current_name(self, org, mock_client):
+        mock_client.request.return_value = {"name": "existing-org-name", "oid": "test-oid-123"}
+        org.set_description("brand new description")
+        assert mock_client.request.call_args_list == [
+            call("GET", "orgs/test-oid-123"),
+            call(
+                "POST", "orgs/test-oid-123/name",
+                query_params={"name": "existing-org-name", "description": "brand new description"},
+            ),
+        ]
+
+    def test_set_description_empty_allowed(self, org, mock_client):
+        mock_client.request.return_value = {"name": "existing-org-name"}
+        org.set_description("")
+        assert mock_client.request.call_args_list == [
+            call("GET", "orgs/test-oid-123"),
+            call(
+                "POST", "orgs/test-oid-123/name",
+                query_params={"name": "existing-org-name", "description": ""},
+            ),
+        ]
+
+    def test_set_description_missing_name_raises(self, org, mock_client):
+        from limacharlie.errors import ApiError
+        mock_client.request.return_value = {"oid": "test-oid-123"}
+        with pytest.raises(ApiError):
+            org.set_description("anything")
+
 
 class TestOrganizationSubscriptions:
     def test_get_subscriptions_unwraps(self, org, mock_client):


### PR DESCRIPTION
## Summary

Answers a support question: how to set an organization's **description (org info)** via the Python SDK.

The description is only exposed by the backend as an optional side-effect of the org **rename** endpoint (`POST /v1/orgs/{oid}/name`), which requires a non-empty `name`. Previously there was no way to set it from the SDK/CLI — `Organization.rename()` dropped the `description` param and there was no dedicated helper.

## Changes

- **`Organization.rename(new_name, description=None)`** — optionally forwards a `description` to the rename endpoint.
- **`Organization.set_description(description)`** — reads the org's current name via `get_info()` and re-submits it unchanged, so only the description is updated. This is the ergonomic "just set the description on an existing org" call.
- **CLI**:
  - `limacharlie org rename --name ... --description ...`
  - new `limacharlie org set-description --description ...`
- Unit tests (rename with/without description, `set_description` reuse-name + missing-name error) and CHANGELOG entry.

## Notes

- These are thin, honest wrappers over `POST /v1/orgs/{oid}/name` (perm `billing.ctrl`, rate-limited 3/hour server-side).
- The backend skips an empty description and treats the description write as best-effort, so this does not add clear-description semantics the server doesn't support.
- Read the value back via `Organization.get_info()["desc"]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)