### PR TITLE
feat: add `--brief` listings for the document hives (sop, note, ai-skill)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,13 +52,15 @@
 
 ### CLI
 
-- **`sop list --brief`**: reduce each SOP in the listing to its
-  `description`, dropping the procedure body. The hive listing endpoint
-  returns whole records, so listing an org's SOPs otherwise pulls back every
-  procedure in full — costly when the caller is an agent deciding which
-  procedures apply and paying for the output in context. `--brief` gives it
-  the index; `sop get --key <name>` fetches the ones that matter. Default
-  output is unchanged.
+- **`--brief` listings for document hives**: `sop list --brief`, `note list
+  --brief` and `ai-skill list --brief` reduce each record's `data` to the
+  fields that say what it is (`description`, and for skills also `name` /
+  `when_to_use`), dropping the body. The hive listing endpoint returns whole
+  records, so listing these otherwise pulls back every procedure, note, and
+  SKILL.md — including skills' bundled supporting files. That is costly when
+  the caller is an agent deciding what applies and paying for the output in
+  context: `--brief` gives it the index, and `get --key <name>` fetches the
+  ones that matter. Default output is unchanged.
 
 - **Lazy command loading**: CLI startup is significantly faster. Commands are
   now loaded on-demand via a static map instead of eagerly importing all 49

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,14 @@
 
 ### CLI
 
+- **`sop list --brief`**: reduce each SOP in the listing to its
+  `description`, dropping the procedure body. The hive listing endpoint
+  returns whole records, so listing an org's SOPs otherwise pulls back every
+  procedure in full — costly when the caller is an agent deciding which
+  procedures apply and paying for the output in context. `--brief` gives it
+  the index; `sop get --key <name>` fetches the ones that matter. Default
+  output is unchanged.
+
 - **Lazy command loading**: CLI startup is significantly faster. Commands are
   now loaded on-demand via a static map instead of eagerly importing all 49
   modules. `limacharlie.output` import is deferred to the CLI callback.

--- a/doc/cli/hive-data.md
+++ b/doc/cli/hive-data.md
@@ -44,13 +44,29 @@ limacharlie playbook list
 
 ```bash
 limacharlie note list
+limacharlie note list --brief          # descriptions only, without the note bodies
 ```
 
 ### sop
 
 ```bash
 limacharlie sop list
+limacharlie sop list --brief           # descriptions only, without the procedure bodies
+limacharlie sop get --key ransomware-response
 ```
+
+### ai-skill
+
+```bash
+limacharlie ai-skill list
+limacharlie ai-skill list --brief      # name/description/when_to_use, without SKILL.md bodies or bundled files
+limacharlie ai-skill get --key triage
+```
+
+`list` returns whole records, so for these three hives it includes every
+document body. `--brief` reduces each record's `data` to the fields that say
+what it is, leaving metadata intact — list to find what you want, then `get`
+the ones you need.
 
 ### adapter (external-adapter)
 

--- a/limacharlie/commands/_hive_shortcut.py
+++ b/limacharlie/commands/_hive_shortcut.py
@@ -48,10 +48,17 @@ def make_hive_group(group_name: str, hive_name: str, noun_singular: str, noun_pl
             for the sop hive). When set, 'list' gains a ``--brief`` flag that
             keeps only these fields in each record's ``data``. The listing
             endpoint returns whole records, so for hives whose payload is a
-            large document this is the difference between an index and every
-            body — it matters most when the consumer is an LLM paying for the
-            output in context. Leave None for hives whose records are small
-            enough that the full listing is already the useful answer.
+            document this is the difference between an index and every body —
+            it matters most when the consumer is an LLM paying for the output
+            in context. Set it for hives that carry a body plus a field
+            describing it (sop, org_notes, ai_skill); leave None for hives
+            whose ``data`` is structured config with no such split, where
+            there is no honest subset to call a summary.
+
+            Note that a hive setting this should also mention ``--brief`` in
+            its own ``<group>.list`` explain text if it registers one:
+            ``register_explain`` is last-write-wins, so a module-level
+            override replaces whatever the factory registered.
 
     Returns:
         click.Group: The configured group with list, get, set, delete commands.
@@ -62,14 +69,6 @@ def make_hive_group(group_name: str, hive_name: str, noun_singular: str, noun_pl
     article = "an" if noun_singular[0].lower() in "aeiou" else "a"
 
     explain_list = f"List all {noun_plural} stored in the '{hive_name}' hive."
-    if index_keys:
-        _keys_hint = ", ".join(index_keys)
-        explain_list += (
-            f" Records are returned in full, including their payload. Pass --brief to keep "
-            f"only {_keys_hint} in each record's data, which is enough to tell what each "
-            f"{noun_singular} is without pulling every body; fetch the full record with "
-            f"'{group_name} get --key <name>'."
-        )
     explain_get = f"Get a specific {noun_singular} by its key name from the '{hive_name}' hive."
     value_hint = (
         f"Or use --value to set the {noun_singular} value directly "
@@ -116,8 +115,17 @@ def make_hive_group(group_name: str, hive_name: str, noun_singular: str, noun_pl
         if brief:
             for record in data.values():
                 payload = record.get("data")
-                if isinstance(payload, dict):
-                    record["data"] = {k: payload[k] for k in index_keys if k in payload}
+                if payload is None:
+                    # No payload to summarize; "absent" is not the same as
+                    # "filtered", so leave it alone.
+                    continue
+                if not isinstance(payload, dict):
+                    # A record whose data is not an object has none of the
+                    # index fields. Emitting it whole would quietly hand back
+                    # the payload the caller asked us to drop, so fail closed.
+                    record["data"] = {}
+                    continue
+                record["data"] = {k: payload[k] for k in index_keys if k in payload}
         _output(ctx, data)
 
     @grp.command("get", help=f"Get {article} {noun_singular} by key.")

--- a/limacharlie/commands/_hive_shortcut.py
+++ b/limacharlie/commands/_hive_shortcut.py
@@ -28,7 +28,7 @@ def _output(ctx: click.Context, data: Any) -> None:
         click.echo(format_output(data, fmt))
 
 
-def make_hive_group(group_name: str, hive_name: str, noun_singular: str, noun_plural: str | None = None, value_key: str | None = None) -> click.Group:
+def make_hive_group(group_name: str, hive_name: str, noun_singular: str, noun_plural: str | None = None, value_key: str | None = None, index_keys: tuple[str, ...] | None = None) -> click.Group:
     """Create a Click group for a specific hive type.
 
     Args:
@@ -43,6 +43,15 @@ def make_hive_group(group_name: str, hive_name: str, noun_singular: str, noun_pl
             value as ``{data: {<value_key>: <value>}}``. Leave None for hives
             whose data is structured (lookup, fp, playbook, …) — they have no
             single value field and do not get ``--value``.
+        index_keys: ``data`` fields that summarize a record well enough to
+            decide whether it is worth fetching in full (e.g. ``("description",)``
+            for the sop hive). When set, 'list' gains a ``--brief`` flag that
+            keeps only these fields in each record's ``data``. The listing
+            endpoint returns whole records, so for hives whose payload is a
+            large document this is the difference between an index and every
+            body — it matters most when the consumer is an LLM paying for the
+            output in context. Leave None for hives whose records are small
+            enough that the full listing is already the useful answer.
 
     Returns:
         click.Group: The configured group with list, get, set, delete commands.
@@ -53,6 +62,14 @@ def make_hive_group(group_name: str, hive_name: str, noun_singular: str, noun_pl
     article = "an" if noun_singular[0].lower() in "aeiou" else "a"
 
     explain_list = f"List all {noun_plural} stored in the '{hive_name}' hive."
+    if index_keys:
+        _keys_hint = ", ".join(index_keys)
+        explain_list += (
+            f" Records are returned in full, including their payload. Pass --brief to keep "
+            f"only {_keys_hint} in each record's data, which is enough to tell what each "
+            f"{noun_singular} is without pulling every body; fetch the full record with "
+            f"'{group_name} get --key <name>'."
+        )
     explain_get = f"Get a specific {noun_singular} by its key name from the '{hive_name}' hive."
     value_hint = (
         f"Or use --value to set the {noun_singular} value directly "
@@ -77,13 +94,30 @@ def make_hive_group(group_name: str, hive_name: str, noun_singular: str, noun_pl
 
     grp.help = f"Manage {noun_plural}."
 
+    def _brief_option(fn):
+        # Only hives that named their index fields expose --brief; for the rest
+        # there is no meaningful subset of `data` to keep, so no flag is offered.
+        if not index_keys:
+            return fn
+        return click.option(
+            "--brief", is_flag=True, default=False,
+            help=f"Keep only {', '.join(index_keys)} in each record's data, dropping the "
+                 f"rest of the payload. Metadata is unaffected.",
+        )(fn)
+
     @grp.command("list", help=f"List all {noun_plural}.")
+    @_brief_option
     @pass_context
-    def list_cmd(ctx) -> None:
+    def list_cmd(ctx, brief: bool = False) -> None:
         org = _get_org(ctx)
         hive = Hive(org, hive_name)
         records = hive.list()
         data = {name: rec.to_dict() for name, rec in records.items()}
+        if brief:
+            for record in data.values():
+                payload = record.get("data")
+                if isinstance(payload, dict):
+                    record["data"] = {k: payload[k] for k in index_keys if k in payload}
         _output(ctx, data)
 
     @grp.command("get", help=f"Get {article} {noun_singular} by key.")

--- a/limacharlie/commands/ai_skill.py
+++ b/limacharlie/commands/ai_skill.py
@@ -16,7 +16,10 @@ from __future__ import annotations
 from ._hive_shortcut import make_hive_group
 from ..discovery import register_explain
 
-group = make_hive_group("ai-skill", "ai_skill", "AI skill", "AI skills")
+group = make_hive_group(
+    "ai-skill", "ai_skill", "AI skill", "AI skills",
+    index_keys=("name", "description", "when_to_use"),
+)
 
 # Override the generic hive explains with ai_skill-specific documentation.
 
@@ -24,6 +27,14 @@ register_explain("ai-skill.list", """\
 List all Claude Code skill definitions stored in the 'ai_skill' hive.
 Each record is a self-contained skill (SKILL.md body + frontmatter +
 optional supporting files), keyed by skill name.
+
+The listing returns whole records, so it pulls back every SKILL.md body
+and every bundled supporting file.  Use --brief to get just the index --
+name, description and when_to_use, which are the fields that say what a
+skill is for -- then fetch the ones that apply:
+
+  limacharlie ai-skill list --brief
+  limacharlie ai-skill get --key <name>
 """)
 
 register_explain("ai-skill.get", """\

--- a/limacharlie/commands/note.py
+++ b/limacharlie/commands/note.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from ._hive_shortcut import make_hive_group
 from ..discovery import register_explain
 
-group = make_hive_group("note", "org_notes", "note")
+group = make_hive_group("note", "org_notes", "note", index_keys=("description",))
 
 # Override the generic hive explains with note-specific documentation.
 
@@ -14,6 +14,14 @@ List all organization-level notes.  Notes store free-form text for
 documentation, runbooks, and operational context at the org level.
 These are distinct from investigation notes which are scoped to a
 specific incident.
+
+The listing returns whole records, so an org with many long notes
+returns every note body in full.  Use --brief to get just the index --
+each record's data reduced to its description, with metadata intact --
+then pull the ones you need:
+
+  limacharlie note list --brief
+  limacharlie note get --key <name>
 """)
 
 register_explain("note.get", """\

--- a/limacharlie/commands/sop.py
+++ b/limacharlie/commands/sop.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from ._hive_shortcut import make_hive_group
 from ..discovery import register_explain
 
-group = make_hive_group("sop", "sop", "SOP", "SOPs")
+group = make_hive_group("sop", "sop", "SOP", "SOPs", index_keys=("description",))
 
 # Override the generic hive explains with SOP-specific documentation.
 
@@ -13,6 +13,17 @@ register_explain("sop.list", """\
 List all Standard Operating Procedures stored in the organization.
 SOPs document processes and procedures for incident response,
 security operations, and compliance workflows.
+
+The listing returns whole records, so an org with many long SOPs
+returns every procedure body in full.  Use --brief to get just the
+index -- each record's data reduced to its description, with metadata
+intact -- then pull the ones that apply:
+
+  limacharlie sop list --brief
+  limacharlie sop get --key <name>
+
+This is the intended flow for an agent deciding which procedures are
+relevant to the task in front of it.
 """)
 
 register_explain("sop.get", """\

--- a/tests/unit/test_cli_sop.py
+++ b/tests/unit/test_cli_sop.py
@@ -82,6 +82,96 @@ class TestSopList:
         # rather than KeyError-ing or leaking the body back in.
         assert json.loads(result.output)["bare"]["data"] == {}
 
+    @patch("limacharlie.commands._hive_shortcut.Client")
+    @patch("limacharlie.commands._hive_shortcut.Organization")
+    @patch("limacharlie.commands._hive_shortcut.Hive")
+    def test_brief_fails_closed_on_a_non_object_payload(self, mock_hive_cls, _org, _client):
+        mock_hive = MagicMock()
+        mock_hive.list.return_value = {
+            "listy": _record(["body", "parts"]),
+            "stringy": _record("raw body"),
+            "empty": _record(None),
+        }
+        mock_hive_cls.return_value = mock_hive
+
+        result = CliRunner().invoke(cli, ["--output", "json", "sop", "list", "--brief"])
+        assert result.exit_code == 0, result.output
+        parsed = json.loads(result.output)
+        # A payload that is not an object has none of the index fields. Passing
+        # it through would hand back the very content --brief exists to drop.
+        assert parsed["listy"]["data"] == {}
+        assert parsed["stringy"]["data"] == {}
+        # No payload at all is a different thing from a filtered one.
+        assert parsed["empty"]["data"] is None
+
+    @patch("limacharlie.commands._hive_shortcut.Client")
+    @patch("limacharlie.commands._hive_shortcut.Organization")
+    @patch("limacharlie.commands._hive_shortcut.Hive")
+    def test_brief_applies_to_yaml_output(self, mock_hive_cls, _org, _client):
+        mock_hive = MagicMock()
+        mock_hive.list.return_value = {
+            "ransomware": _record({"text": "SECRET BODY", "description": "Ransomware"}),
+        }
+        mock_hive_cls.return_value = mock_hive
+
+        result = CliRunner().invoke(cli, ["--output", "yaml", "sop", "list", "--brief"])
+        assert result.exit_code == 0, result.output
+        # Filtering happens before rendering, so it must hold for every format.
+        assert "SECRET BODY" not in result.output
+        assert "Ransomware" in result.output
+
+
+class TestBriefOnOtherDocumentHives:
+    """org_notes and ai_skill have the same body-plus-description shape as sop.
+
+    ai_skill is the worst case: a listing carries every SKILL.md body *and*
+    every bundled supporting file.
+    """
+
+    @patch("limacharlie.commands._hive_shortcut.Client")
+    @patch("limacharlie.commands._hive_shortcut.Organization")
+    @patch("limacharlie.commands._hive_shortcut.Hive")
+    def test_note_brief_keeps_description(self, mock_hive_cls, _org, _client):
+        mock_hive = MagicMock()
+        mock_hive.list.return_value = {
+            "baseline": _record({"text": "long note body", "description": "Prod baseline"}),
+        }
+        mock_hive_cls.return_value = mock_hive
+
+        result = CliRunner().invoke(cli, ["--output", "json", "note", "list", "--brief"])
+        assert result.exit_code == 0, result.output
+        assert mock_hive_cls.call_args[0][1] == "org_notes"
+        assert json.loads(result.output)["baseline"]["data"] == {"description": "Prod baseline"}
+
+    @patch("limacharlie.commands._hive_shortcut.Client")
+    @patch("limacharlie.commands._hive_shortcut.Organization")
+    @patch("limacharlie.commands._hive_shortcut.Hive")
+    def test_ai_skill_brief_drops_content_and_bundled_files(self, mock_hive_cls, _org, _client):
+        mock_hive = MagicMock()
+        mock_hive.list.return_value = {
+            "triage": _record({
+                "name": "triage",
+                "description": "Triage a detection",
+                "when_to_use": "When a detection needs first-pass review",
+                "content": "SKILL.md body",
+                "effort": "high",
+                "files": {"scripts/helper.sh": "#!/bin/sh\necho hi"},
+            }),
+        }
+        mock_hive_cls.return_value = mock_hive
+
+        result = CliRunner().invoke(cli, ["--output", "json", "ai-skill", "list", "--brief"])
+        assert result.exit_code == 0, result.output
+        assert mock_hive_cls.call_args[0][1] == "ai_skill"
+        assert json.loads(result.output)["triage"]["data"] == {
+            "name": "triage",
+            "description": "Triage a detection",
+            "when_to_use": "When a detection needs first-pass review",
+        }
+        # The bodies are the whole point of the flag.
+        assert "SKILL.md body" not in result.output
+        assert "helper.sh" not in result.output
+
 
 class TestBriefIsOptIn:
     def test_hives_without_index_keys_have_no_brief_flag(self):
@@ -96,3 +186,16 @@ class TestBriefIsOptIn:
         result = CliRunner().invoke(cli, ["sop", "list", "--help"])
         assert result.exit_code == 0, result.output
         assert "--brief" in result.output
+
+    def test_every_brief_capable_hive_documents_it_in_ai_help(self):
+        # register_explain is last-write-wins, so a module that registers its
+        # own '<group>.list' text silently replaces anything the factory set.
+        # --ai-help is the surface agents read, so a hive that offers --brief
+        # and never mentions it there ships a flag nobody will find.
+        from limacharlie.discovery import get_explain
+
+        for group_name in ("sop", "note", "ai-skill"):
+            result = CliRunner().invoke(cli, [group_name, "list", "--help"])
+            assert "--brief" in result.output, f"{group_name} list lost the flag"
+            explain = get_explain(f"{group_name}.list") or ""
+            assert "--brief" in explain, f"{group_name}.list explain omits --brief"

--- a/tests/unit/test_cli_sop.py
+++ b/tests/unit/test_cli_sop.py
@@ -1,0 +1,98 @@
+"""CLI tests for the sop shortcut group.
+
+The point of these is ``sop list --brief``. The hive listing endpoint
+returns whole records, so listing an org's SOPs pulls back every
+procedure body in full. ``--brief`` reduces each record's data to the
+fields that identify it, so a caller can decide what to fetch without
+paying for all of it -- the flow every SOP-reading agent follows.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch, MagicMock
+
+from click.testing import CliRunner
+
+from limacharlie.cli import cli
+
+
+def _record(data):
+    rec = MagicMock()
+    rec.to_dict.return_value = {
+        "data": data,
+        "usr_mtd": {"enabled": True, "tags": ["ir"]},
+        "sys_mtd": {"etag": "e1"},
+    }
+    return rec
+
+
+class TestSopList:
+    @patch("limacharlie.commands._hive_shortcut.Client")
+    @patch("limacharlie.commands._hive_shortcut.Organization")
+    @patch("limacharlie.commands._hive_shortcut.Hive")
+    def test_list_returns_full_records_by_default(self, mock_hive_cls, _org, _client):
+        mock_hive = MagicMock()
+        mock_hive.list.return_value = {
+            "ransomware": _record({"text": "1. Isolate.", "description": "Ransomware"}),
+        }
+        mock_hive_cls.return_value = mock_hive
+
+        result = CliRunner().invoke(cli, ["--output", "json", "sop", "list"])
+        assert result.exit_code == 0, result.output
+        assert mock_hive_cls.call_args[0][1] == "sop"
+        data = json.loads(result.output)["ransomware"]["data"]
+        # Unchanged default: the body is still there for existing callers.
+        assert data == {"text": "1. Isolate.", "description": "Ransomware"}
+
+    @patch("limacharlie.commands._hive_shortcut.Client")
+    @patch("limacharlie.commands._hive_shortcut.Organization")
+    @patch("limacharlie.commands._hive_shortcut.Hive")
+    def test_brief_drops_body_and_keeps_metadata(self, mock_hive_cls, _org, _client):
+        mock_hive = MagicMock()
+        mock_hive.list.return_value = {
+            "ransomware": _record({"text": "1. Isolate." * 500, "description": "Ransomware"}),
+            "after-hours": _record({"text": "Page on-call.", "description": "Escalation"}),
+        }
+        mock_hive_cls.return_value = mock_hive
+
+        result = CliRunner().invoke(cli, ["--output", "json", "sop", "list", "--brief"])
+        assert result.exit_code == 0, result.output
+        parsed = json.loads(result.output)
+
+        # Every SOP still listed, each reduced to its description.
+        assert set(parsed) == {"ransomware", "after-hours"}
+        assert parsed["ransomware"]["data"] == {"description": "Ransomware"}
+        assert parsed["after-hours"]["data"] == {"description": "Escalation"}
+        # Metadata is what tells you whether an SOP is active, so it stays.
+        assert parsed["ransomware"]["usr_mtd"] == {"enabled": True, "tags": ["ir"]}
+        assert parsed["ransomware"]["sys_mtd"] == {"etag": "e1"}
+
+    @patch("limacharlie.commands._hive_shortcut.Client")
+    @patch("limacharlie.commands._hive_shortcut.Organization")
+    @patch("limacharlie.commands._hive_shortcut.Hive")
+    def test_brief_tolerates_records_without_a_description(self, mock_hive_cls, _org, _client):
+        mock_hive = MagicMock()
+        mock_hive.list.return_value = {"bare": _record({"text": "body only"})}
+        mock_hive_cls.return_value = mock_hive
+
+        result = CliRunner().invoke(cli, ["--output", "json", "sop", "list", "--brief"])
+        assert result.exit_code == 0, result.output
+        # description is optional on an SOP; the record must survive without one
+        # rather than KeyError-ing or leaking the body back in.
+        assert json.loads(result.output)["bare"]["data"] == {}
+
+
+class TestBriefIsOptIn:
+    def test_hives_without_index_keys_have_no_brief_flag(self):
+        # --brief only makes sense where some subset of data identifies the
+        # record. secret/lookup/etc. named no index fields, so offering the
+        # flag there would imply a summary the factory cannot produce.
+        result = CliRunner().invoke(cli, ["secret", "list", "--brief"])
+        assert result.exit_code != 0
+        assert "no such option" in result.output.lower()
+
+    def test_sop_list_help_documents_brief(self):
+        result = CliRunner().invoke(cli, ["sop", "list", "--help"])
+        assert result.exit_code == 0, result.output
+        assert "--brief" in result.output


### PR DESCRIPTION
## Problem

SOP-reading agents follow a two-step flow, and the CLI's own explain text describes it: list the org's SOPs, read the names and descriptions, fetch the one or two that apply.

Step one doesn't do what that flow assumes. `GET /v1/hive/{name}/{oid}` returns whole records, so `limacharlie sop list` already hands back every procedure body in full — the subsequent `sop get` re-fetches something the caller was made to pay for.

That cost lands in an LLM's context window, which is where it hurts. And it scales the wrong way: the guidance is to keep many narrowly-scoped SOPs rather than one giant policy document, so the listing grows with the thing we want people to do more of.

The same shape appears in two sibling hives, for the same reason:

- **`org_notes`** is byte-identical to `sop` — `text` + `description`, same 1 MB cap.
- **`ai_skill`** is the worst case — a listing carries every SKILL.md body *and* every bundled supporting file.

## Fix

An opt-in `--brief` flag on `list` for those three hives, reducing each record's `data` to the fields that identify it and leaving `usr_mtd` / `sys_mtd` intact:

```bash
limacharlie sop list --brief          # the index
limacharlie sop get --key <name>      # the ones that apply
```

Index fields are `description` for sop and note, and `name` / `description` / `when_to_use` for ai-skill.

Default output is deliberately unchanged — the doc-exporter reads `data.text` straight off the SOP listing, and that keeps working.

### Why not the metadata endpoint

The hive service does expose a metadata-only listing, but it returns no `data`, and `description` is the field agents match on. It would drop exactly the thing that makes the index useful, so this filters client-side instead. Making the server return a description-bearing index would be the more thorough fix; it needs a platform change and isn't required for the flow to work.

### Why not `--fields` / `--filter`

Both already exist globally, so I checked. `--fields description` returns `{}` — it doesn't descend into `data`. `--filter 'values(@)[].data.description'` does work but drops the record names, and isn't something an agent would reliably produce.

### Shape

`make_hive_group` gained an `index_keys` argument naming the fields that summarize a record. Hives whose `data` is structured config with no body/description split don't get the flag at all, so there's no misleading option promising a summary the factory can't produce.

`--brief` fails closed: a payload that isn't an object has none of the index fields and is emitted as `{}` rather than passed through whole. A null payload stays null — absent isn't the same as filtered.

## Verification

- `tests/unit/test_cli_sop.py` — 10 tests: default listing unchanged; `--brief` drops bodies while keeping metadata; missing `description` yields `{}` rather than KeyError or a leaked body; non-object payloads fail closed; filtering holds for yaml as well as json; note and ai-skill each covered, with ai-skill asserting both the SKILL.md body and the bundled files are gone; `secret list --brief` is rejected; and every `--brief`-capable hive is asserted to document the flag in `--ai-help`.
- Full unit suite: **3761 passed, 5 skipped** (all five skips pre-existing — Windows/macOS-only and two docstring checks).
- Smoke-tested `list --help` across sop / note / ai-skill / secret against an installed build, and confirmed option ordering works in all three positions (`--output json sop list --brief`, `sop list --brief --output json`, `sop --output json list --brief`).
- The existing regression test pinning each group's subcommand set still holds; this adds an option, not a command.

## Note on the second commit

The first commit covered sop only. Reviewing it turned up that the factory's `--brief` explain text was dead code — `register_explain` is last-write-wins and every relevant hive overrides its own `list` explain — and that the docstring justified excluding note and ai-skill on grounds that don't hold. The second commit removes the dead text, opts both hives in, adds the `--ai-help` regression guard, and makes the filter fail closed.

## Follow-up

The agent prompts that run `sop list` live in another repo and should move to `--brief` once this is released — deliberately not done here, since they'd break against any CLI that predates this flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JwVp8Ug988F8G7G6tjkMaz