### PR TITLE
Fix stray empty output on payload upload/delete CLI

### DIFF
--- a/limacharlie/commands/payload.py
+++ b/limacharlie/commands/payload.py
@@ -110,7 +110,11 @@ def delete(ctx, name, confirm) -> None:
     data = payloads.delete(name)
     if not ctx.obj.quiet:
         click.echo(f"Payload '{name}' deleted.")
-    _output(ctx, data)
+    # The delete API returns an empty body on success; only render it if the
+    # backend actually returned something meaningful, otherwise we'd print an
+    # empty "Field / Value" table on top of the confirmation line above.
+    if data:
+        _output(ctx, data)
 
 
 # ---------------------------------------------------------------------------
@@ -142,7 +146,11 @@ def upload(ctx, name, file_path) -> None:
     data = payloads.upload(name, file_path=file_path)
     if not ctx.obj.quiet:
         click.echo(f"Payload '{name}' uploaded.")
-    _output(ctx, data)
+    # upload() returns the raw HTTP body from the storage backend's PUT, which
+    # is empty (b'') on success. Don't echo it on top of the confirmation line
+    # above; only render if the backend returned meaningful content.
+    if data:
+        _output(ctx, data)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_cli_commands.py
+++ b/tests/unit/test_cli_commands.py
@@ -727,3 +727,66 @@ class TestSchemaCommands:
         mock_org.reset_schemas.assert_called_once_with()
 
 
+
+
+class TestPayloadCommands:
+    """Regression tests for the payload command output.
+
+    Reported by a customer: `payload upload` printed a stray `b''` and
+    `payload delete` printed an empty "Field / Value" table on top of the
+    human-readable confirmation line. Both stem from the command echoing an
+    empty SDK return value (the storage backend's empty PUT body for upload,
+    and the empty DELETE response for delete).
+    """
+
+    @patch("limacharlie.commands.payload.Client")
+    @patch("limacharlie.commands.payload.Organization")
+    @patch("limacharlie.commands.payload.Payloads")
+    def test_upload_does_not_echo_empty_body(self, mock_payloads_cls, mock_org_cls, mock_client_cls):
+        mock_payloads = MagicMock()
+        # The upload() SDK call returns the storage backend's PUT body, which
+        # is empty bytes on success.
+        mock_payloads.upload.return_value = b""
+        mock_payloads_cls.return_value = mock_payloads
+
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            with open("kape.exe", "wb") as f:
+                f.write(b"MZ")
+            result = runner.invoke(cli, ["payload", "upload", "--name", "KAPE", "--file", "kape.exe"])
+        assert result.exit_code == 0
+        assert "Payload 'KAPE' uploaded." in result.output
+        assert "b''" not in result.output
+        mock_payloads.upload.assert_called_once()
+
+    @patch("limacharlie.commands.payload.Client")
+    @patch("limacharlie.commands.payload.Organization")
+    @patch("limacharlie.commands.payload.Payloads")
+    def test_delete_does_not_echo_empty_table(self, mock_payloads_cls, mock_org_cls, mock_client_cls):
+        mock_payloads = MagicMock()
+        # The delete() SDK call returns an empty response body on success.
+        mock_payloads.delete.return_value = {}
+        mock_payloads_cls.return_value = mock_payloads
+
+        runner = CliRunner()
+        # Force table output to reproduce the customer's TTY scenario, where an
+        # empty dict would otherwise render as a bare "Field / Value" header.
+        result = runner.invoke(cli, ["--output", "table", "payload", "delete", "--name", "kape", "--confirm"])
+        assert result.exit_code == 0
+        assert "Payload 'kape' deleted." in result.output
+        assert "Field" not in result.output
+        assert "Value" not in result.output
+        mock_payloads.delete.assert_called_once_with("kape")
+
+    @patch("limacharlie.commands.payload.Client")
+    @patch("limacharlie.commands.payload.Organization")
+    @patch("limacharlie.commands.payload.Payloads")
+    def test_delete_without_confirm_is_blocked(self, mock_payloads_cls, mock_org_cls, mock_client_cls):
+        mock_payloads = MagicMock()
+        mock_payloads_cls.return_value = mock_payloads
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["payload", "delete", "--name", "kape"])
+        assert result.exit_code == 4
+        assert "--confirm" in result.output
+        mock_payloads.delete.assert_not_called()

--- a/tests/unit/test_cli_commands.py
+++ b/tests/unit/test_cli_commands.py
@@ -727,8 +727,6 @@ class TestSchemaCommands:
         mock_org.reset_schemas.assert_called_once_with()
 
 
-
-
 class TestPayloadCommands:
     """Regression tests for the payload command output.
 


### PR DESCRIPTION
## Summary

A customer reported two cosmetic output glitches in the v2 CLI payload commands (both operations actually succeeded):

1. **`payload upload`** printed a stray `b''` after the confirmation line.
2. **`payload delete`** printed an empty `Field / Value` table after the confirmation line.

## Root cause

Both commands print a friendly confirmation and *then* pass the raw SDK return value to `_output()`, but for these two verbs that value is empty/meaningless:

- `Payloads.upload()` returns the storage backend's `PUT` response body, which is empty bytes (`b''`) on a successful upload. In a TTY this echoed `b''`; in non-TTY (JSON) mode it actually raised `TypeError: Type is not JSON serializable: bytes`.
- `Payloads.delete()` returns the API's empty `DELETE` response body (`{}`), which the table formatter renders as a bare `Field / Value` header.

## Fix

Only render the SDK return value when it actually carries content (`if data:`), so the confirmation line stands alone. No functional change to upload/delete behavior.

## Tests

Added `TestPayloadCommands` regression tests reproducing both reported cases (the delete test forces `--output table` to match the customer's TTY scenario). Both new tests fail on `master` and pass with this change; full `test_cli_commands.py` + `test_sdk_payloads.py` suite (60 tests) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C6ug17pCvjJYLveQv6iz81