### PR TITLE
cloudsec(sdk): keep resolver_ready through the chunked resolve merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@
 
 ### Cloud Security (CNAPP)
 
+- **Sensor↔cloud resolution keeps the resolver-readiness signal**:
+  `CloudSec.resolve_sensors()` / `resolve_assets()` chunk large batches and
+  merge the responses; the merge dropped `resolver_ready`, so a caller could
+  not tell "no sensor runs on a cloud asset" from "the resolver is not
+  provisioned in this datacenter". It is now carried through, pessimistically
+  (one not-ready chunk makes the whole batch not-ready), and stays absent when
+  the backend never sent it.
+
 - **Multi-org fleet overview**: `limacharlie cloudsec fleet overview` /
   `CloudSec.get_fleet_overview()` — one posture row per authorized org plus
   cross-tenant rollups, narrowable with `--oid` (repeatable) and org

--- a/limacharlie/sdk/cloudsec.py
+++ b/limacharlie/sdk/cloudsec.py
@@ -763,16 +763,36 @@ class CloudSec:
         The ids ride as repeated query params, so an unbounded batch would
         blow the ~8KB load-balancer URL limit long before the gateway's
         500-per-request cap — chunking makes any batch size work.
+
+        The server's honesty signals are merged, not dropped: ``resolver_ready``
+        (redis-cloudsec provisioned) is pessimistic — one not-ready chunk makes
+        the whole answer not-ready — and ``verdicts_available`` (a posture
+        verdict was actually computed) is true if any chunk carried one. They
+        are the only way a caller can tell a real negative from an unevaluated
+        one: a resolved asset with no ``exposed`` field means UNKNOWN, not safe.
+        A signal no chunk reported (an older backend) stays absent rather than
+        being invented.
         """
         resolved: list[Any] = []
         unresolved: list[Any] = []
+        ready: list[Any] = []
+        verdicts: list[Any] = []
         values = list(values)
         for i in range(0, len(values), _RESOLVE_CHUNK_SIZE):
             chunk = values[i:i + _RESOLVE_CHUNK_SIZE]
             resp = self._get(path, _query_pairs(**{key: chunk}))
             resolved.extend(resp.get("resolved") or [])
             unresolved.extend(resp.get("unresolved") or [])
-        return {"resolved": resolved, "unresolved": unresolved}
+            if "resolver_ready" in resp:
+                ready.append(resp["resolver_ready"])
+            if "verdicts_available" in resp:
+                verdicts.append(resp["verdicts_available"])
+        out: dict[str, Any] = {"resolved": resolved, "unresolved": unresolved}
+        if ready:
+            out["resolver_ready"] = all(bool(v) for v in ready)
+        if verdicts:
+            out["verdicts_available"] = any(bool(v) for v in verdicts)
+        return out
 
     def resolve_sensors(self, sids: list[str]) -> dict[str, Any]:
         """Resolve sensor ids to the cloud asset each runs on.

--- a/limacharlie/sdk/cloudsec.py
+++ b/limacharlie/sdk/cloudsec.py
@@ -764,19 +764,16 @@ class CloudSec:
         blow the ~8KB load-balancer URL limit long before the gateway's
         500-per-request cap — chunking makes any batch size work.
 
-        The server's honesty signals are merged, not dropped: ``resolver_ready``
-        (redis-cloudsec provisioned) is pessimistic — one not-ready chunk makes
-        the whole answer not-ready — and ``verdicts_available`` (a posture
-        verdict was actually computed) is true if any chunk carried one. They
-        are the only way a caller can tell a real negative from an unevaluated
-        one: a resolved asset with no ``exposed`` field means UNKNOWN, not safe.
-        A signal no chunk reported (an older backend) stays absent rather than
-        being invented.
+        ``resolver_ready`` (is redis-cloudsec provisioned at all) is merged,
+        not dropped: it is pessimistic — one not-ready chunk makes the whole
+        merged answer not-ready. Without it a caller cannot tell "no sensor
+        runs on a cloud asset" from "the resolver is not running here". It
+        stays ABSENT when no chunk reported it (an older backend) rather than
+        being invented as False.
         """
         resolved: list[Any] = []
         unresolved: list[Any] = []
         ready: list[Any] = []
-        verdicts: list[Any] = []
         values = list(values)
         for i in range(0, len(values), _RESOLVE_CHUNK_SIZE):
             chunk = values[i:i + _RESOLVE_CHUNK_SIZE]
@@ -785,13 +782,9 @@ class CloudSec:
             unresolved.extend(resp.get("unresolved") or [])
             if "resolver_ready" in resp:
                 ready.append(resp["resolver_ready"])
-            if "verdicts_available" in resp:
-                verdicts.append(resp["verdicts_available"])
         out: dict[str, Any] = {"resolved": resolved, "unresolved": unresolved}
         if ready:
             out["resolver_ready"] = all(bool(v) for v in ready)
-        if verdicts:
-            out["verdicts_available"] = any(bool(v) for v in verdicts)
         return out
 
     def resolve_sensors(self, sids: list[str]) -> dict[str, Any]:

--- a/tests/unit/test_sdk_cloudsec.py
+++ b/tests/unit/test_sdk_cloudsec.py
@@ -348,37 +348,29 @@ class TestResolution:
             "unresolved": ["x", "y"],
         }
 
-    def test_resolve_sensors_keeps_readiness_signals(self, cs, mock_org):
-        # resolver_ready ("redis-cloudsec is provisioned") and verdicts_available
-        # ("a posture verdict was actually computed") are the only way a caller can
-        # tell a real negative from an unevaluated one — an absent `exposed` means
-        # UNKNOWN, not safe. Dropping them in the merge hands the caller silence.
+    def test_resolve_sensors_keeps_readiness_signal(self, cs, mock_org):
+        # resolver_ready ("redis-cloudsec is provisioned") is how a caller tells
+        # "no sensor runs on a cloud asset" from "the resolver is not running
+        # here". Dropping it in the merge hands the caller silence instead.
         mock_org.client.request.side_effect = [
-            {"resolved": [{"sid": "a"}], "unresolved": [], "resolver_ready": True,
-             "verdicts_available": False},
-            {"resolved": [{"sid": "b"}], "unresolved": [], "resolver_ready": True,
-             "verdicts_available": True},
+            {"resolved": [{"sid": "a"}], "unresolved": [], "resolver_ready": True},
+            {"resolved": [{"sid": "b"}], "unresolved": [], "resolver_ready": True},
         ]
         out = cs.resolve_sensors([f"sid-{i}" for i in range(150)])
         assert out["resolver_ready"] is True
-        # any chunk carrying a verdict means verdicts came back for this batch.
-        assert out["verdicts_available"] is True
 
     def test_resolve_sensors_readiness_is_pessimistic_across_chunks(self, cs, mock_org):
         # One chunk served by a datacenter without the resolver makes the whole
         # merged answer unreliable: report not-ready rather than averaging it away.
         mock_org.client.request.side_effect = [
-            {"resolved": [{"sid": "a"}], "unresolved": [], "resolver_ready": True,
-             "verdicts_available": False},
-            {"resolved": [], "unresolved": ["x"], "resolver_ready": False,
-             "verdicts_available": False},
+            {"resolved": [{"sid": "a"}], "unresolved": [], "resolver_ready": True},
+            {"resolved": [], "unresolved": ["x"], "resolver_ready": False},
         ]
         out = cs.resolve_sensors([f"sid-{i}" for i in range(150)])
         assert out["resolver_ready"] is False
-        assert out["verdicts_available"] is False
 
-    def test_resolve_sensors_omits_signals_an_older_backend_never_sent(self, cs, mock_org):
-        # A gateway/DC that predates the flags must not gain a fabricated one.
+    def test_resolve_sensors_omits_a_signal_an_older_backend_never_sent(self, cs, mock_org):
+        # A gateway/DC that predates the flag must not gain a fabricated one.
         mock_org.client.request.return_value = {"resolved": [], "unresolved": ["x"]}
         out = cs.resolve_sensors(["sid-1"])
         assert out == {"resolved": [], "unresolved": ["x"]}

--- a/tests/unit/test_sdk_cloudsec.py
+++ b/tests/unit/test_sdk_cloudsec.py
@@ -348,6 +348,41 @@ class TestResolution:
             "unresolved": ["x", "y"],
         }
 
+    def test_resolve_sensors_keeps_readiness_signals(self, cs, mock_org):
+        # resolver_ready ("redis-cloudsec is provisioned") and verdicts_available
+        # ("a posture verdict was actually computed") are the only way a caller can
+        # tell a real negative from an unevaluated one — an absent `exposed` means
+        # UNKNOWN, not safe. Dropping them in the merge hands the caller silence.
+        mock_org.client.request.side_effect = [
+            {"resolved": [{"sid": "a"}], "unresolved": [], "resolver_ready": True,
+             "verdicts_available": False},
+            {"resolved": [{"sid": "b"}], "unresolved": [], "resolver_ready": True,
+             "verdicts_available": True},
+        ]
+        out = cs.resolve_sensors([f"sid-{i}" for i in range(150)])
+        assert out["resolver_ready"] is True
+        # any chunk carrying a verdict means verdicts came back for this batch.
+        assert out["verdicts_available"] is True
+
+    def test_resolve_sensors_readiness_is_pessimistic_across_chunks(self, cs, mock_org):
+        # One chunk served by a datacenter without the resolver makes the whole
+        # merged answer unreliable: report not-ready rather than averaging it away.
+        mock_org.client.request.side_effect = [
+            {"resolved": [{"sid": "a"}], "unresolved": [], "resolver_ready": True,
+             "verdicts_available": False},
+            {"resolved": [], "unresolved": ["x"], "resolver_ready": False,
+             "verdicts_available": False},
+        ]
+        out = cs.resolve_sensors([f"sid-{i}" for i in range(150)])
+        assert out["resolver_ready"] is False
+        assert out["verdicts_available"] is False
+
+    def test_resolve_sensors_omits_signals_an_older_backend_never_sent(self, cs, mock_org):
+        # A gateway/DC that predates the flags must not gain a fabricated one.
+        mock_org.client.request.return_value = {"resolved": [], "unresolved": ["x"]}
+        out = cs.resolve_sensors(["sid-1"])
+        assert out == {"resolved": [], "unresolved": ["x"]}
+
     def test_resolve_assets_empty_batch_makes_no_request(self, cs, mock_org):
         out = cs.resolve_assets([])
         mock_org.client.request.assert_not_called()


### PR DESCRIPTION
## The bug

`CloudSec._resolve_chunked` (`limacharlie/sdk/cloudsec.py`) rebuilds the merged response from scratch:

```python
return {"resolved": resolved, "unresolved": unresolved}
```

dropping `resolver_ready` — the flag that says whether the sensor↔cloud resolver (redis-cloudsec) is provisioned in that datacenter at all. Without it an SDK caller cannot tell **"no sensor runs on a cloud asset"** from **"nothing resolved because the resolver isn't running here"**. The server added that flag precisely so the two are distinguishable; the SDK threw it away.

This matters more now that refractionPOINT/legion_graph#94 makes the same endpoint report posture verdicts only where they were actually computed — the whole surface is being made to say "unknown" out loud rather than imply a negative.

## The fix

Merge it rather than drop it, pessimistically: one not-ready chunk makes the whole merged answer not-ready (a batch split across chunks is only as trustworthy as its weakest chunk). A backend that never sent the flag still gets no flag — **absent, not a fabricated `False`**.

## Tests

Three new cases in `tests/unit/test_sdk_cloudsec.py::TestResolution`, verified failing-first on master with `KeyError: 'resolver_ready'`:
- the signal survives a multi-chunk merge;
- one not-ready chunk ⇒ merged `resolver_ready is False`;
- a backend that sends no flag ⇒ output unchanged, no invented key.

## Verified

- `python3 -m pytest tests/unit` — **3676 passed, 6 skipped**.
- The CLI (`limacharlie/commands/cloudsec.py`) `_output`s whatever this returns, so the flag now reaches CLI users too; no CLI change needed.

## Not verified

- Integration tests need live credentials; not run. Not exercised against a live gateway.

Related: refractionPOINT/legion_graph#94.