### PR TITLE
fix(deps): make toon_format an optional extra so uv can install current releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,21 @@
 
 ### Dependencies & Python support
 
+- **`toon_format` moved to an optional `toon` extra** (was a hard dependency).
+  The only `toon_format` release in our supported range is a pre-release
+  (`0.9.0b1`), and resolvers that refuse transitive pre-releases — uv among
+  them — cannot install *any* limacharlie version that requires it. uv
+  backtracks silently to 5.3.0 instead, so `uv tool install limacharlie` and
+  `uvx limacharlie` have been stuck on the last release predating the
+  dependency, with `uv tool upgrade` reporting "Nothing to upgrade". Pinning
+  the exact pre-release would not help: uv honours pre-release specifiers only
+  on direct requirements, never on transitive ones. **Behavior change:** a
+  default install no longer supports `--output toon`.
+  `pip install 'limacharlie[toon]'` restores it; under uv, name the package
+  directly (`uv tool install limacharlie --with 'toon-format>=0.9.0b1'`),
+  because asking uv for the extra hits the same transitive pre-release rule.
+  The other five output formats are unaffected, and requesting TOON without
+  the encoder now points at both install forms.
 - **`requests` 2.32.3 -> 2.33.0**: picks up the fix for GHSA-gc5v-m9x4-r6x2
   (insecure temp-file reuse in `extract_zipped_paths()`; vulnerable `<2.33.0`).
 - **Minimum Python is now 3.10** (was 3.9). `requests` 2.33.0 requires Python

--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ Python SDK and command-line interface for the [LimaCharlie](https://limacharlie.
 
 ```bash
 pip install limacharlie
+
+# Optional: adds the TOON output format (limacharlie --output toon)
+pip install 'limacharlie[toon]'
+uv tool install limacharlie --with 'toon-format>=0.9.0b1'   # uv equivalent
 ```
 
 ```bash

--- a/doc/cli/README.md
+++ b/doc/cli/README.md
@@ -31,6 +31,18 @@ limacharlie sensor list --output table    # Rich table (default for TTY)
 limacharlie sensor list --output jsonl    # Newline-delimited JSON
 ```
 
+`--output toon` needs the optional `toon` extra; the other formats work with a default install.
+
+```bash
+pip install 'limacharlie[toon]'
+```
+
+Under uv, name the package directly instead — `toon_format` only publishes a pre-release, and uv resolves pre-releases for directly named requirements only, so asking it for the extra makes it fall back to an older `limacharlie`:
+
+```bash
+uv tool install limacharlie --with 'toon-format>=0.9.0b1'
+```
+
 ## Filtering with JMESPath
 
 Use `--filter` with a [JMESPath](https://jmespath.org/) expression to extract or transform output. This works with every command and any output format.

--- a/limacharlie/output.py
+++ b/limacharlie/output.py
@@ -181,9 +181,12 @@ def format_toon(data: Any) -> str:
     See https://toonformat.dev for the spec.
     """
     if _toon_format is None:
+        # uv resolves the extra's pre-release only when toon-format is named as
+        # a direct requirement, hence the separate form.
         raise ImportError(
             "toon_format is required for --output toon. "
-            "Install with: pip install toon_format"
+            "Install with: pip install 'limacharlie[toon]'\n"
+            "With uv: uv tool install limacharlie --with 'toon-format>=0.9.0b1'"
         )
     return _toon_format.encode(data)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,10 +37,16 @@ dependencies = [
     "jmespath==1.1.0",
     "orjson>=3.10.0",
     "websockets>=13.0",
-    "toon_format>=0.9.0b1,<1.0",
 ]
 
 [project.optional-dependencies]
+# TOON is one of six opt-in --output formats, and the only toon_format release
+# in our supported range is a pre-release (0.9.0b1). Resolvers that reject
+# transitive pre-releases (uv) cannot install any version of limacharlie that
+# requires it, so it stays optional: pip install 'limacharlie[toon]'.
+toon = [
+    "toon_format>=0.9.0b1,<1.0",
+]
 dev = [
     # pytest 9.x carries the CVE-2025-71176 fix and requires Python >= 3.10,
     # which matches our minimum supported version.
@@ -49,6 +55,8 @@ dev = [
     "pytest-benchmark>=5.0.0",
     # tomllib is stdlib from 3.11; Python 3.10 still needs the tomli backport.
     "tomli>=1.0; python_version < '3.11'",
+    # Keep the optional TOON output path under test even though it is an extra.
+    "toon_format>=0.9.0b1,<1.0",
 ]
 
 [project.scripts]

--- a/tests/unit/test_output.py
+++ b/tests/unit/test_output.py
@@ -1,10 +1,13 @@
 """Tests for limacharlie.output module."""
 
 import json
+import sys
 from unittest.mock import patch
 
+import pytest
 import yaml
 
+import limacharlie.output as output_mod
 from limacharlie.output import (
     format_output,
     format_json,
@@ -21,7 +24,15 @@ from limacharlie.output import (
     _table_value,
 )
 
-import toon_format
+try:
+    import toon_format
+except ImportError:  # toon_format ships in the optional 'toon' extra.
+    toon_format = None
+
+requires_toon = pytest.mark.skipif(
+    toon_format is None,
+    reason="requires the optional 'toon' extra: pip install 'limacharlie[toon]'",
+)
 
 
 class TestFormatJson:
@@ -56,6 +67,7 @@ class TestFormatYaml:
         assert parsed == [1, 2, 3]
 
 
+@requires_toon
 class TestFormatToon:
     def test_dict_roundtrip(self):
         data = {"name": "Alice", "age": 30}
@@ -99,18 +111,61 @@ class TestFormatToon:
     def test_empty_list(self):
         assert toon_format.decode(format_toon([])) == []
 
-    def test_raises_import_error_when_missing(self):
-        """format_toon should raise a descriptive ImportError if the
-        toon_format package is unavailable at call time."""
-        import limacharlie.output as output_mod
-        saved = output_mod._toon_format
-        output_mod._toon_format = None
-        try:
-            import pytest
-            with pytest.raises(ImportError, match="toon_format"):
-                format_toon({"a": 1})
-        finally:
-            output_mod._toon_format = saved
+
+class TestFormatToonMissingExtra:
+    """TOON output is opt-in: toon_format lives in the 'toon' extra, so a
+    default install has no encoder and every path into TOON has to say so."""
+
+    @pytest.fixture(autouse=True)
+    def _toon_unavailable(self, monkeypatch):
+        monkeypatch.setattr(output_mod, "_toon_format", None)
+
+    def test_format_toon_error_points_at_the_extra(self):
+        """The error has to name the extra, not the bare package: installing
+        toon_format by hand next to a pipx/uv-managed CLI does not put it on
+        the CLI's path."""
+        with pytest.raises(ImportError) as excinfo:
+            format_toon({"a": 1})
+        assert "limacharlie[toon]" in str(excinfo.value)
+
+    def test_format_output_toon_error_points_at_the_extra(self):
+        """--output toon routes through format_output, not format_toon."""
+        with pytest.raises(ImportError) as excinfo:
+            format_output({"a": 1}, fmt="toon")
+        assert "limacharlie[toon]" in str(excinfo.value)
+
+    def test_format_toon_error_offers_a_uv_form(self):
+        """`uv pip install 'limacharlie[toon]'` does not work: toon_format's
+        only in-range release is a pre-release, and uv honours pre-release
+        specifiers on direct requirements only. Told to install the extra, uv
+        silently backtracks to a limacharlie old enough not to want it. The
+        error has to give uv users a form that names toon-format directly."""
+        with pytest.raises(ImportError) as excinfo:
+            format_toon({"a": 1})
+        message = str(excinfo.value)
+        assert "uv" in message
+        assert "toon-format>=0.9.0b1" in message
+
+    def test_cli_reports_the_extra_without_a_traceback(self, monkeypatch, tmp_path, capsys):
+        """End users see a one-line hint and exit 1, not a stack trace."""
+        from limacharlie.cli import main
+
+        monkeypatch.setenv("LC_CONFIG_DIR", str(tmp_path))
+        monkeypatch.setattr(
+            sys, "argv", ["limacharlie", "--output", "toon", "config", "show-paths"]
+        )
+        with pytest.raises(SystemExit) as excinfo:
+            main()
+
+        assert excinfo.value.code == 1
+        err = capsys.readouterr().err
+        assert "limacharlie[toon]" in err
+        assert "Traceback" not in err
+
+    def test_other_formats_still_work(self):
+        """Only TOON degrades; the rest of --output is unaffected."""
+        assert json.loads(format_output({"a": 1}, fmt="json")) == {"a": 1}
+        assert yaml.safe_load(format_output({"a": 1}, fmt="yaml")) == {"a": 1}
 
 
 class TestFormatCsv:
@@ -220,21 +275,25 @@ class TestFormatOutput:
         result = format_output({"key": "val"}, fmt="yaml")
         assert yaml.safe_load(result) == {"key": "val"}
 
+    @requires_toon
     def test_toon_format(self):
         result = format_output({"key": "val"}, fmt="toon")
         assert toon_format.decode(result) == {"key": "val"}
 
+    @requires_toon
     def test_toon_respects_field_selection(self):
         data = [{"name": "a", "value": 1, "extra": "x"}]
         result = format_output(data, fmt="toon", fields=["name", "value"])
         decoded = toon_format.decode(result)
         assert decoded == [{"name": "a", "value": 1}]
 
+    @requires_toon
     def test_toon_respects_jmespath_filter(self):
         data = {"items": [1, 2, 3]}
         result = format_output(data, fmt="toon", filter_expr="items[0]")
         assert toon_format.decode(result) == 1
 
+    @requires_toon
     def test_toon_respects_sort(self):
         data = [{"n": "b"}, {"n": "a"}, {"n": "c"}]
         result = format_output(data, fmt="toon", sort_by="n")

--- a/tests/unit/test_packaging.py
+++ b/tests/unit/test_packaging.py
@@ -1,6 +1,7 @@
 """Tests for pyproject.toml packaging and distribution."""
 
 import pathlib
+import re
 import sys
 
 import pytest
@@ -12,6 +13,12 @@ else:
 
 
 PROJECT_ROOT = pathlib.Path(__file__).parent.parent.parent
+
+
+def _dep_name(requirement: str) -> str:
+    """Normalized distribution name from a PEP 508 requirement string."""
+    name = re.split(r"[<>=!~;\[\s]", requirement, maxsplit=1)[0]
+    return name.strip().lower().replace("_", "-")
 
 
 class TestPyprojectToml:
@@ -54,6 +61,42 @@ class TestPyprojectToml:
         dev_deps = data["project"].get("optional-dependencies", {}).get("dev", [])
         dep_names = [d.split("==")[0].split(">=")[0] for d in dev_deps]
         assert "pytest" in dep_names
+
+    def test_toon_format_is_not_a_hard_dependency(self):
+        """toon_format must stay out of [project.dependencies].
+
+        The only release satisfying our range is a pre-release (0.9.0b1), and
+        resolvers that reject transitive pre-releases (uv) refuse to install
+        any limacharlie version that requires it -- they silently backtrack to
+        an older release instead. TOON is one of six opt-in --output formats,
+        so it belongs in an extra rather than stranding every uv user.
+        """
+        with open(PROJECT_ROOT / "pyproject.toml", "rb") as f:
+            data = tomllib.load(f)
+        deps = data["project"].get("dependencies", [])
+        toon_deps = [d for d in deps if _dep_name(d) == "toon-format"]
+        assert not toon_deps, (
+            f"toon_format must be an optional extra, not a hard dependency: {toon_deps}"
+        )
+
+    def test_toon_extra_defined(self):
+        """The 'toon' extra restores TOON output for anyone who wants it."""
+        with open(PROJECT_ROOT / "pyproject.toml", "rb") as f:
+            data = tomllib.load(f)
+        extras = data["project"].get("optional-dependencies", {})
+        assert "toon" in extras, "Missing 'toon' optional-dependencies group"
+        assert [d for d in extras["toon"] if _dep_name(d) == "toon-format"], (
+            f"The 'toon' extra should require toon_format, got {extras['toon']}"
+        )
+
+    def test_dev_extra_includes_toon(self):
+        """CI installs [dev]; it must keep exercising the TOON output path."""
+        with open(PROJECT_ROOT / "pyproject.toml", "rb") as f:
+            data = tomllib.load(f)
+        dev_deps = data["project"].get("optional-dependencies", {}).get("dev", [])
+        assert [d for d in dev_deps if _dep_name(d) == "toon-format"], (
+            f"The 'dev' extra should install toon_format, got {dev_deps}"
+        )
 
     def test_classifiers_present(self):
         with open(PROJECT_ROOT / "pyproject.toml", "rb") as f:

--- a/tests/unit/test_search_output.py
+++ b/tests/unit/test_search_output.py
@@ -9,6 +9,7 @@ should pass through unchanged.
 
 from __future__ import annotations
 
+import importlib.util
 import json
 import sys
 import time
@@ -503,6 +504,10 @@ class TestOutputSearchResults:
         captured = capsys.readouterr()
         assert "type: events" in captured.out
 
+    @pytest.mark.skipif(
+        importlib.util.find_spec("toon_format") is None,
+        reason="requires the optional 'toon' extra: pip install 'limacharlie[toon]'",
+    )
     def test_toon_format_passes_raw(self, capsys):
         """TOON output should pass raw results unchanged."""
         results = [_make_search_result("events", rows=[_make_event_row()])]


### PR DESCRIPTION
Closes #324.

## Problem

`limacharlie` 5.3.1+ declare a hard dependency on `toon_format>=0.9.0b1,<1.0`. On PyPI, `toon-format` has published exactly two versions — `0.1.0` and `0.9.0b1` — so no *stable* release satisfies that range.

pip honours the pre-release specifier and installs 5.5.4 without complaint. uv does not: it accepts pre-releases only for requirements named directly, never for transitive ones. Faced with a `limacharlie` that needs a pre-release it will not take, uv backtracks to the newest release that does not — 5.3.0.

The failure is silent. No error, no warning:

```console
$ uv pip install --no-cache limacharlie
Resolved 21 packages in 424ms
 + limacharlie==5.3.0
```

`uv tool install limacharlie` and `uvx limacharlie` land on the same 5.3.0, and `uv tool upgrade limacharlie` reports "Nothing to upgrade" — so uv users have been pinned to a release predating the dependency, with no signal that anything is wrong. (The docs list `uv tool install limacharlie` as a supported installation method, so this is a documented path: https://docs.limacharlie.io/6-developer-guide/mcp-server/#installation.) Asking for the version explicitly is the only way to surface the real error:

```console
$ uv pip install --no-cache limacharlie==5.5.4
  × No solution found when resolving dependencies:
  ╰─▶ Because only toon-format<0.9.0b1 is available and limacharlie>=5.5.4
      depends on toon-format>=0.9.0b1, we can conclude that limacharlie>=5.5.4
      cannot be used.
```

Pinning the requirement to the exact pre-release (`toon_format==0.9.0b1`) would **not** fix this — uv's rule is about direct vs. transitive requirements, not about the shape of the specifier.

## Fix

Move `toon_format` out of `[project.dependencies]` into a `toon` extra. The code already treats it as optional at runtime — `limacharlie/output.py` imports it in a `try/except ImportError` with a `_toon_format = None` fallback, the same pattern used for `jmespath` and `tabulate` — and TOON is one of six opt-in `--output` formats, not a default. Nothing but `--output toon` touches it.

With the dependency optional, uv installs the current release normally, no flags (shown here resolving a wheel built from this branch):

```console
$ uv pip install --no-cache limacharlie
Resolved 21 packages in 305ms
 + limacharlie==5.5.5
```

## Behavior change

**A default install loses `--output toon`.** The other five formats (`json`, `yaml`, `csv`, `table`, `jsonl`) are unaffected, and `toon` stays in the `--output` choice list so it still validates and tab-completes.

Requesting TOON without the encoder exits 1 with a message naming both install forms — no traceback, matching how `--filter` reports a missing `jmespath`:

```console
$ limacharlie --output toon sensor list
Error: toon_format is required for --output toon. Install with: pip install 'limacharlie[toon]'
With uv: uv tool install limacharlie --with 'toon-format>=0.9.0b1'
```

The uv-specific form is deliberate. `uv pip install 'limacharlie[toon]'` does not work either — the extra's requirement is still transitive, so uv applies the same rule and quietly falls back to 5.3.0, which does not even have a `toon` extra (it warns, then installs the old version anyway). Naming `toon-format` directly makes it a direct requirement, and uv then honours the pre-release specifier. If `toon_format` ever ships a stable release in range, both forms collapse into the obvious one and the extra keeps working unchanged.

## Tests

CI installs `[dev]`, and `[dev]` now pulls in `toon_format`, so all existing TOON coverage runs unchanged. Added:

- `tests/unit/test_packaging.py` — `toon_format` absent from `[project.dependencies]`, present in the `toon` extra, and present in `dev` so CI keeps exercising the path.
- `tests/unit/test_output.py::TestFormatToonMissingExtra` — with `_toon_format` patched to `None`: `format_toon()` and `format_output(fmt="toon")` both name the extra, the message carries the uv form, the CLI exits 1 without a traceback, and the other formats keep working.
- TOON tests needing a real encoder are marked `skipif`, so `pip install -e .` + `pytest` no longer fails at collection without the extra.

Full suite, both ways:

```
# pip install ".[dev]" (CI's install)
3772 passed, 4 skipped

# without the toon extra
3759 passed, 17 skipped
```

Also verified against a built wheel: fresh venv, `uv pip install <wheel>` with no pre-release flags succeeds and does not pull `toon-format`; `limacharlie --version` works; `--output toon` gives the friendly error; adding the encoder restores TOON output.

## Related

refractionPOINT/lc-ai#112 works around this same resolution failure in the lc-essentials plugin's CLI auto-installer (`--prerelease=allow` + a 5.4.0 floor). With `toon_format` optional, that workaround becomes unnecessary for future releases — and its noted trade-off (that `--prerelease=allow` could also admit a pre-release of `limacharlie` itself) goes away.
