### PR TITLE
cloudsec(sdk): document the third finding status, "accepted"

### DIFF
--- a/limacharlie/commands/cloudsec.py
+++ b/limacharlie/commands/cloudsec.py
@@ -856,7 +856,9 @@ def _finding_filter_options(f):
     )(f)
     f = click.option(
         "--status", "statuses", multiple=True,
-        help="Filter by status (open/resolved); repeatable (OR).",
+        help="Filter by status (open/resolved/accepted); repeatable (OR). "
+             "'accepted' is a live risk acceptance (the risk remains, on purpose); "
+             "'resolved' means mitigated or false-positive.",
     )(f)
     f = click.option(
         "--class", "finding_classes", multiple=True,
@@ -1160,7 +1162,8 @@ def finding_get(ctx, finding_id) -> None:
               help="Resolution kind; 'open' reopens the finding.")
 @click.option("--reason", default=None, help="Optional operator note.")
 @click.option("--expires-at", default=None, type=int,
-              help="Unix seconds; only meaningful with --kind accepted.")
+              help="Unix seconds; only meaningful with --kind accepted. Omit for a "
+                   "permanent acceptance — an expiry is optional, not required.")
 @pass_context
 def finding_resolve(ctx, finding_id, kind, reason, expires_at) -> None:
     """Disposition (or reopen, with --kind open) FINDING_ID.
@@ -1183,7 +1186,8 @@ def finding_resolve(ctx, finding_id, kind, reason, expires_at) -> None:
               help="Resolution kind (reopen is single-finding only: use 'finding resolve --kind open').")
 @click.option("--reason", default=None, help="Optional operator note.")
 @click.option("--expires-at", default=None, type=int,
-              help="Unix seconds; only meaningful with --kind accepted.")
+              help="Unix seconds; only meaningful with --kind accepted. Omit for a "
+                   "permanent acceptance — an expiry is optional, not required.")
 @pass_context
 def finding_bulk_resolve(ctx, finding_ids, kind, reason, expires_at) -> None:
     """Apply one resolution to many findings.

--- a/limacharlie/sdk/cloudsec.py
+++ b/limacharlie/sdk/cloudsec.py
@@ -204,7 +204,15 @@ class CloudSec:
             finding_class: Filter values (toxic_combination, public_exposure,
                 ciem_risk, privilege_escalation, vulnerability, misconfig,
                 coverage_gap), OR'd.
-            status: Filter values (open/resolved), OR'd.
+            status: Filter values (open/resolved/accepted), OR'd.
+                ``resolved`` means the risk is gone (mitigated or a false
+                positive); ``accepted`` is a LIVE risk acceptance — the risk
+                is still there and an owner signed off on carrying it, so it
+                is deliberately NOT rolled into ``resolved``. An acceptance
+                that passes its expiry, or that dispositioned an earlier
+                occurrence of a finding that closed and recurred, reads
+                ``open`` again. The same three values are the keys of the
+                ``status`` map returned by :meth:`get_finding_facets`.
             account: Cloud account filter values, OR'd.
             reachable: Only findings on (non-)reachable resources.
             kev: Only findings with (without) a KEV vulnerability.
@@ -286,9 +294,14 @@ class CloudSec:
             finding_id: The finding to disposition.
             kind: ``mitigated``, ``accepted``, ``false_positive``, or
                 ``open`` to clear the disposition and reopen the finding
-                (owner/ticket are kept).
+                (owner/ticket are kept). ``accepted`` puts the finding in
+                the ``accepted`` status — a live risk acceptance, not a
+                resolution.
             reason: Optional operator note.
-            expires_at: Unix seconds; only meaningful for ``accepted``.
+            expires_at: Unix seconds; only meaningful for ``accepted``, and
+                OPTIONAL — omitting it accepts the risk permanently, which
+                is a supported disposition. When set, the finding reopens
+                at that instant.
 
         Returns:
             ``{"ok": bool}``.


### PR DESCRIPTION
Docs only — companion to **go-cloudsec#114** / **legion_graph#97** (B3).

The findings API returns `status ∈ {open, resolved, accepted}`, not just `open|resolved`. `accepted` is a **live risk acceptance** — the risk is still there and an owner signed off on carrying it — so it is deliberately not rolled into `resolved` (mitigated / false positive, where the risk is gone). Two places enumerated only the old pair, which reads as "accepted findings are fixed":

- `limacharlie/sdk/cloudsec.py:207` — `list_findings`' `status:` arg (also notes the same three values are the `get_finding_facets` `status` map keys, and that a lapsed or stale-epoch acceptance reads `open` again).
- `limacharlie/commands/cloudsec.py:859` — the `--status` filter help.

Also states that `--expires-at` / `expires_at` is **optional** for an acceptance: omitting it accepts the risk permanently, which is a supported disposition rather than an unfinished one (`set_finding_status` docstring + both `--expires-at` help strings).

No behaviour change — `status` was already a passthrough filter, so `--status accepted` worked before this; it just wasn't documented.

`python3 -m pytest tests/unit` → **3676 passed, 6 skipped** (all 6 skips pre-existing and environmental: Windows/macOS-only, orjson unavailable, two `pre-existing` docstring markers).