### PR TITLE
feat(search): list an organization's open searches and report its search limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 ## Unreleased
 
+### Search
+
+- **List open searches**: `limacharlie search queries [--state all|executing|idle]` /
+  `Search.list_open_queries()` and `Search.iter_open_queries()` report the searches
+  an organization currently has open and which of them consume its concurrency
+  limit. Those are different numbers - a paginated search between pages is open
+  and resumable but holds no slot - so the response reports `slotsHeld` separately
+  from `count`. Each entry carries the query text and time range as submitted, who
+  submitted it and from which client, how long the current page has been running,
+  progress, how much it has scanned and been billed for, and when its slot and its
+  resumability expire. This is what to reach for after a "maximum concurrent
+  queries reached" rejection: it names what is holding the slots so the query worth
+  cancelling is identifiable.
+
+- **Report search limits**: `limacharlie search limits` / `Search.get_limits()` report the
+  resolved per-organization search limits: how many searches may run at once, the shape of a
+  page, how long results stay resumable, how long page results are kept, and any enforced
+  execution deadlines. Every one of these was previously discoverable only by hitting it - a
+  refusal for concurrency does not say what the cap was, and a paginated search stops being
+  resumable with no way to have known the window. A limit that is not enforced is reported as
+  `None` rather than `0`, since in a set of limits a zero would read as "nothing allowed".
+  `capabilities.openQueryListing` says whether `search queries` can report searches that are
+  open but idle on this deployment.
+
 ### Organization
 
 - **Set org description (org info)**: `Organization.set_description()` /

--- a/doc/cli/data-query.md
+++ b/doc/cli/data-query.md
@@ -13,6 +13,9 @@ limacharlie search estimate --query '* | NEW_PROCESS | event/COMMAND_LINE contai
 limacharlie search saved-list                        # Saved queries
 limacharlie search saved-create --name my-query --query '* | NEW_PROCESS | event/COMMAND_LINE contains "powershell"'
 limacharlie search saved-run --name my-query
+limacharlie search queries                           # What this org has open right now
+limacharlie search queries --state executing         # Only what is using a concurrency slot
+limacharlie search limits                            # This org's resolved search limits
 ```
 
 ## ioc

--- a/doc/sdk/search-insight.md
+++ b/doc/sdk/search-insight.md
@@ -13,6 +13,45 @@ search = Search(org)
 results = search.execute("event NEW_PROCESS", start=1704067200, end=1704153600)
 ```
 
+### Open queries
+
+`list_open_queries()` reports the searches the organization currently has open, and which of them are consuming its concurrency limit. Those are different numbers: a paginated search sitting between pages is open and resumable but holds no slot, so `slotsHeld` (not `count`) is what the limit applies to.
+
+```python
+listing = search.list_open_queries()
+print(f"{listing['slotsHeld']} of {listing['limit']} slots in use, {listing['count']} searches open")
+
+# Only what is consuming the limit, which is what to look at after a
+# "maximum concurrent queries reached" rejection.
+for q in search.iter_open_queries(state="executing"):
+    print(q["queryId"], q["submittedBy"], q.get("progressPercent"), q["eventsScanned"])
+```
+
+Each entry carries the query text and time range as submitted, who submitted it and from which client, how long the current page has been running, how far along it is, how much it has scanned, and when its slot and its resumability expire. `progressPercent` is absent when the scope estimate was unavailable, which means progress cannot be computed rather than that nothing has been done; it advances at page boundaries, so a search that returns everything in one page reports 0 for its whole life.
+
+### Search limits
+
+`get_limits()` reports the organization's resolved search limits. Every one of these is otherwise discoverable only by hitting it: a refusal for concurrency does not say what the cap was, and a paginated search stops being resumable with no way to have known the window. Read it once and size the client to it.
+
+```python
+limits = search.get_limits()
+
+print(limits["concurrency"]["maxConcurrentQueries"])   # how many may run at once
+print(limits["retention"]["resumableForSeconds"])      # how long a search may be left paused
+print(limits["pagination"]["resultsPerPage"])          # events per page
+
+# A limit that is not enforced is None, never 0 - in a set of limits a zero
+# would read as "nothing allowed".
+deadline = limits["execution"]["maxQueryDurationSeconds"]
+print(f"{deadline}s" if deadline is not None else "no query deadline enforced")
+
+# Whether this deployment can report searches that are open but idle.
+if limits["capabilities"]["openQueryListing"]:
+    print(search.list_open_queries()["count"], "searches open")
+```
+
+`retention.pageResultsForSeconds` can be shorter than `resumableForSeconds`. That is not a shorter deadline: re-reading a page whose results have aged out recomputes it rather than failing, so it is a latency characteristic. Fields are additive - ignore ones you do not recognise, and treat an absent one as "not applicable to this deployment" rather than as zero.
+
 ## Insight (IOC Search & Enrichment)
 
 ```python

--- a/limacharlie/commands/search.py
+++ b/limacharlie/commands/search.py
@@ -1775,6 +1775,173 @@ def validate(ctx: click.Context, query: str) -> None:
 
 
 # ---------------------------------------------------------------------------
+# queries
+# ---------------------------------------------------------------------------
+
+_EXPLAIN_QUERIES = """\
+List the searches this organization currently has open, and which of
+them are consuming its concurrency limit.
+
+These are two different numbers.  A paginated search sitting between
+pages is open and resumable but holds no slot, so an organization can
+have many searches open while none of them counts against the limit.
+The output reports 'slots' (what the limit applies to) separately from
+'open' (everything the organization has not finished).
+
+Reach for this when a search is refused with "maximum concurrent
+queries reached": it names what is holding the slots, who submitted
+each one, how long it has been running and how much it has scanned, so
+the query worth cancelling is identifiable.  Cancel one with
+'limacharlie search cancel --query-id <id>'.
+
+  --state executing   only searches consuming a slot
+  --state idle        only searches that are open but consuming nothing
+  --state all         both (default)
+
+Progress advances at page boundaries, so a search that returns
+everything in one page - any aggregation, which does not paginate -
+shows 0% for its whole life.  A blank progress column means the scope
+estimate was unavailable, not that nothing has been done.
+"""
+register_explain("search.queries", _EXPLAIN_QUERIES)
+
+
+def _format_open_query_row(entry: dict[str, Any]) -> dict[str, Any]:
+    """Flatten one open-search entry into the columns the table shows."""
+    progress = entry.get("progressPercent")
+    running_ms = entry.get("runningForMs")
+    query_text = entry.get("query") or ""
+    if len(query_text) > 60:
+        query_text = query_text[:57] + "..."
+    return {
+        "queryId": entry.get("queryId", ""),
+        "state": entry.get("state", ""),
+        "slot": "yes" if entry.get("holdsSlot") else ("" if entry.get("holdsSlot") is None else "no"),
+        "progress": f"{progress:.0f}%" if isinstance(progress, (int, float)) else "",
+        "pages": entry.get("pagesCompleted", 0),
+        "scanned": f"{entry.get('eventsScanned', 0):,}",
+        "running": f"{running_ms / 1000:.0f}s" if isinstance(running_ms, (int, float)) else "",
+        "submittedBy": entry.get("submittedBy", ""),
+        "query": query_text,
+    }
+
+
+@group.command("queries")
+@click.option("--state", default="all",
+              type=click.Choice(["all", "executing", "idle"]),
+              help="Which searches to list (default: all).")
+@click.option("--limit", default=None, type=int, help="Maximum number of searches to list.")
+@pass_context
+def queries(ctx: click.Context, state: str, limit: int | None) -> None:
+    """List searches this organization currently has open."""
+    org = _get_org(ctx)
+    search = Search(org)
+
+    first = search.list_open_queries(state=state, limit=limit)
+    entries = list(first.get("queries") or [])
+    if limit is None and first.get("truncated"):
+        # Walk the rest so the default is a complete answer rather than one
+        # server page; a caller who wants a single page passes --limit.
+        seen = {e.get("queryId") for e in entries}
+        for entry in search.iter_open_queries(state=state):
+            if entry.get("queryId") not in seen:
+                entries.append(entry)
+
+    payload = {
+        "oid": first.get("oid", org.oid),
+        "limit": first.get("limit"),
+        "slotsHeld": first.get("slotsHeld", 0),
+        "count": first.get("count", 0),
+        "queries": entries,
+    }
+
+    fmt = ctx.obj.output_format or detect_output_format()
+    if fmt == "table":
+        if not ctx.obj.quiet:
+            click.echo(
+                f"{payload['slotsHeld']} of {payload['limit']} concurrency slots in use; "
+                f"{payload['count']} search(es) open."
+            )
+            if entries:
+                click.echo(format_table([_format_open_query_row(e) for e in entries]))
+        return
+
+    _output(ctx, payload)
+
+
+# ---------------------------------------------------------------------------
+# limits
+# ---------------------------------------------------------------------------
+
+_EXPLAIN_LIMITS = """\
+Report this organization's resolved search limits: how many searches may
+run at once, the shape of a page, how long results stay resumable, and any
+enforced execution deadlines.
+
+Every one of these is otherwise discoverable only by hitting it - a refusal
+for concurrency does not say what the cap was, and a paginated search stops
+being resumable with no way to have known the window.
+
+A limit shown as "not enforced" is genuinely unlimited on this deployment,
+not zero.
+
+Example:
+  limacharlie search limits
+"""
+
+
+def _format_limit_seconds(value: int | None) -> str:
+    """Render a duration limit for the table, distinguishing unset from zero."""
+    if value is None:
+        return "not enforced"
+    return f"{value}s"
+
+
+def _format_limit_bytes(value: int | None) -> str:
+    """Render a byte limit for the table, distinguishing unset from zero."""
+    if value is None:
+        return "not enforced"
+    return f"{value}"
+
+
+@group.command("limits", help=_EXPLAIN_LIMITS)
+@pass_context
+def limits(ctx: click.Context) -> None:
+    """Report this organization's resolved search limits."""
+    org = _get_org(ctx)
+    search = Search(org)
+
+    payload = search.get_limits()
+
+    fmt = ctx.obj.output_format or detect_output_format()
+    if fmt == "table":
+        concurrency = payload.get("concurrency") or {}
+        pagination = payload.get("pagination") or {}
+        retention = payload.get("retention") or {}
+        execution = payload.get("execution") or {}
+        request = payload.get("request") or {}
+        capabilities = payload.get("capabilities") or {}
+
+        rows = [
+            {"Limit": "Concurrent searches", "Value": concurrency.get("maxConcurrentQueries")},
+            {"Limit": "Results per page", "Value": pagination.get("resultsPerPage")},
+            {"Limit": "Max page duration", "Value": _format_limit_seconds(pagination.get("maxPageDurationSeconds"))},
+            {"Limit": "Resumable for", "Value": _format_limit_seconds(retention.get("resumableForSeconds"))},
+            {"Limit": "Page results kept for", "Value": _format_limit_seconds(retention.get("pageResultsForSeconds"))},
+            {"Limit": "Max query duration", "Value": _format_limit_seconds(execution.get("maxQueryDurationSeconds"))},
+            {"Limit": "Max aggregation duration", "Value": _format_limit_seconds(execution.get("maxAggregationDurationSeconds"))},
+            {"Limit": "Max response size", "Value": _format_limit_bytes(execution.get("maxResponseBytes"))},
+            {"Limit": "Max request body", "Value": _format_limit_bytes(request.get("maxRequestBodyBytes"))},
+            {"Limit": "Open-query listing", "Value": "available" if capabilities.get("openQueryListing") else "unavailable"},
+        ]
+        if not ctx.obj.quiet:
+            click.echo(format_table(rows))
+        return
+
+    _output(ctx, payload)
+
+
+# ---------------------------------------------------------------------------
 # estimate
 # ---------------------------------------------------------------------------
 

--- a/limacharlie/sdk/search.py
+++ b/limacharlie/sdk/search.py
@@ -431,3 +431,202 @@ class Search:
             self._org.client.request("DELETE", f"search/{query_id}", alt_root=search_url)
         except Exception:
             pass
+
+    # -----------------------------------------------------------------
+    # Open queries
+    # -----------------------------------------------------------------
+
+    def list_open_queries(
+        self,
+        state: str = "all",
+        limit: int | None = None,
+        offset: int | None = None,
+    ) -> dict[str, Any]:
+        """List the searches this organization currently has open.
+
+        A search is "open" from the moment it is submitted until it finishes,
+        is cancelled, or its state expires.  That is not the same population
+        as the searches consuming the organization's concurrency limit: a
+        paginated search sitting between pages is open and resumable but
+        holds no slot.  The response reports both numbers separately, so
+        ``slotsHeld`` (not ``count``) is what ``limit`` applies to.
+
+        This is the endpoint to reach for when a search is refused with
+        "maximum concurrent queries reached": it names what is holding the
+        slots, how long each has been running, and how much each has
+        scanned, so the query worth cancelling is identifiable.
+
+        Args:
+            state: Which searches to return.  ``"all"`` (default),
+                ``"executing"`` (a page is running or a slot is held and
+                the work has not reached a worker yet) or ``"idle"``
+                (open and resumable, consuming no slot).
+            limit: Page size.  Server default is 50, clamped to 200.
+            offset: Offset into the listing, newest first.
+
+        Returns:
+            dict with:
+              ``oid``, ``limit`` (the organization's concurrency limit),
+              ``slotsHeld``, ``count``, ``truncated``, and ``queries``.
+
+            Each entry in ``queries`` carries ``queryId``, ``state``,
+            ``holdsSlot``, the query text and time range as submitted,
+            ``submittedBy`` / ``userAgent``, ``submittedAt``, timing
+            (``startedAt``, ``runningForMs``, ``lastActivityAt``),
+            progress (``pagesCompleted``, ``batchesCompleted``,
+            ``batchesInScope``, ``progressPercent``, ``eventsScanned``,
+            ``billedEvents``), and the two expiries ``slotExpiresAt`` and
+            ``resumableUntil``.
+
+            ``progressPercent`` is absent when the scope estimate was
+            unavailable, which means progress cannot be computed rather
+            than that nothing has been done.  Progress advances at page
+            boundaries, so a search that returns everything in one page -
+            any aggregation, which does not paginate - reports 0 for its
+            whole life.
+
+            ``state`` is ``"unknown"`` with a null ``holdsSlot`` when the
+            deployment is not tracking slots per query; the field says so
+            rather than guessing.
+
+        Raises:
+            SearchError: if the listing cannot be retrieved.
+        """
+        if state not in ("all", "executing", "idle"):
+            raise ValidationError(
+                f"state must be one of all, executing, idle (got {state!r})"
+            )
+
+        query_params: dict[str, str] = {"state": state}
+        if limit is not None:
+            query_params["limit"] = str(int(limit))
+        if offset is not None:
+            query_params["offset"] = str(int(offset))
+
+        try:
+            return self._org.client.request(
+                "GET", f"search/{self._org.oid}/queries",
+                query_params=query_params,
+                alt_root=self._get_search_url(),
+            )
+        except (SearchError, ValidationError):
+            raise
+        except Exception as exc:
+            raise SearchError(
+                f"Failed to list open queries: {_exc_message(exc)}",
+                region=self._extract_region(),
+                oid=self._org.oid,
+            ) from exc
+
+    def iter_open_queries(
+        self,
+        state: str = "all",
+        page_size: int = 200,
+    ) -> Generator[dict[str, Any], None, None]:
+        """Yield every open search, walking the listing page by page.
+
+        Pages by offset against a listing ordered newest first.  An
+        organization can open and finish searches while this iterates, so
+        treat the result as a sample rather than a transaction; the
+        endpoint reports ``count`` if an exact total at one instant is what
+        is needed.
+
+        Args:
+            state: Same filter as :meth:`list_open_queries`.
+            page_size: Rows per request.  Clamped to 200 by the server.
+
+        Yields:
+            dict: One open search per entry, same shape as the ``queries``
+            entries of :meth:`list_open_queries`.
+        """
+        offset = 0
+        seen: set[str] = set()
+        while True:
+            page = self.list_open_queries(state=state, limit=page_size, offset=offset)
+            rows = page.get("queries") or []
+            for row in rows:
+                # The filter is applied after paging, so a page can come back
+                # empty while more entries exist; de-duplicate by id because
+                # entries leaving the index mid-walk shift later offsets back.
+                query_id = row.get("queryId")
+                if query_id and query_id in seen:
+                    continue
+                if query_id:
+                    seen.add(query_id)
+                yield row
+
+            # truncated describes the index page rather than the filtered
+            # rows, so it - not len(rows) - is what says whether to continue.
+            if not page.get("truncated"):
+                return
+            offset += page_size
+
+    def get_limits(self) -> dict[str, Any]:
+        """Report this organization's resolved search limits.
+
+        Every limit here is otherwise discoverable only by hitting it: a
+        refusal for concurrency arrives with no indication of what the cap
+        was, and a paginated search stops being resumable with no way to
+        have known the window.  Read this once and size the client's
+        behaviour to it - how many searches to run at a time, how long a
+        user may leave one paused, whether to offer the open-query view.
+
+        Two conventions in the response are load-bearing:
+
+        * A limit that is not enforced is ``None``, never ``0``.  Several
+          of these use zero internally as the sentinel for "disabled"; in
+          a document of limits, ``0`` would read as "zero allowed".
+        * Values are the ones actually applied, not raw configuration.
+          ``pageResultsForSeconds`` in particular reflects the resolved
+          retention, which can differ from what is configured.
+
+        Returns:
+            dict with:
+              ``oid``, and the groups ``concurrency``, ``pagination``,
+              ``retention``, ``execution``, ``request`` and
+              ``capabilities``.
+
+            ``concurrency.maxConcurrentQueries`` is how many searches may
+            be *executing* at once; a search parked between pages consumes
+            nothing, so this is not a cap on how many may be open.
+
+            ``pagination`` carries ``resultsPerPage``,
+            ``maxPageDurationSeconds`` (reaching it is normal for a broad
+            query and does not mean the search failed) and
+            ``maxCursorBytes``.
+
+            ``retention`` carries ``resumableForSeconds`` - measured from
+            submission and never extended by activity - and
+            ``pageResultsForSeconds``.  The latter can be shorter, in which
+            case re-reading an older page recomputes it rather than
+            failing, so it is a latency characteristic and not a deadline.
+
+            ``execution`` carries ``maxQueryDurationSeconds``,
+            ``maxAggregationDurationSeconds`` and ``maxResponseBytes``,
+            each ``None`` when not enforced.
+
+            ``capabilities.openQueryListing`` says whether
+            :meth:`list_open_queries` reports searches that are open but
+            idle.  When false it can still be called, but only sees
+            searches currently holding a slot.
+
+            Fields are additive: ignore ones you do not recognise, and
+            treat an absent field as "not applicable to this deployment"
+            rather than as zero.
+
+        Raises:
+            SearchError: if the limits cannot be retrieved.
+        """
+        try:
+            return self._org.client.request(
+                "GET", f"search/{self._org.oid}/limits",
+                alt_root=self._get_search_url(),
+            )
+        except (SearchError, ValidationError):
+            raise
+        except Exception as exc:
+            raise SearchError(
+                f"Failed to get search limits: {_exc_message(exc)}",
+                region=self._extract_region(),
+                oid=self._org.oid,
+            ) from exc

--- a/tests/unit/test_cli_lazy_loading_regression.py
+++ b/tests/unit/test_cli_lazy_loading_regression.py
@@ -204,7 +204,8 @@ EXPECTED_SUBCOMMANDS: dict[str, frozenset[str]] = {
     "replay": frozenset({"run"}),
     "schema": frozenset({"get", "list", "reset"}),
     "search": frozenset({
-        "checkpoint-show", "checkpoints", "estimate", "run",
+        "checkpoint-show", "checkpoints", "estimate", "limits", "queries",
+        "run",
         "saved-create", "saved-delete", "saved-get", "saved-list",
         "saved-run", "validate",
     }),

--- a/tests/unit/test_sdk_search.py
+++ b/tests/unit/test_sdk_search.py
@@ -805,3 +805,211 @@ class TestSearchCancellation:
         delete_calls = [c for c in mock_org.client.request.call_args_list
                         if c[0][0] == "DELETE"]
         assert len(delete_calls) == 1
+
+
+class TestListOpenQueries:
+    """The listing exists to answer "why is my org at its limit", so what
+    matters is that the request is addressed to the right org, that a bad
+    filter never reaches the server, and that transport failures arrive as a
+    SearchError carrying enough context to act on."""
+
+    def test_requests_the_org_scoped_path(self, search, mock_org):
+        mock_org.client.request.return_value = {"queries": []}
+
+        search.list_open_queries()
+
+        args, kwargs = mock_org.client.request.call_args
+        assert args[0] == "GET"
+        # The oid is part of the path, not a query parameter: the listing is
+        # per-org and must never be addressable without naming one.
+        assert args[1] == "search/test-oid/queries"
+        assert kwargs["query_params"] == {"state": "all"}
+        assert kwargs["alt_root"].endswith("/v1")
+
+    def test_passes_the_filter_and_paging_through(self, search, mock_org):
+        mock_org.client.request.return_value = {"queries": []}
+
+        search.list_open_queries(state="executing", limit=25, offset=50)
+
+        _, kwargs = mock_org.client.request.call_args
+        assert kwargs["query_params"] == {"state": "executing", "limit": "25", "offset": "50"}
+
+    def test_omits_paging_when_not_asked_for(self, search, mock_org):
+        mock_org.client.request.return_value = {"queries": []}
+
+        search.list_open_queries()
+
+        # Sending limit=None as a string would make the server clamp to its
+        # own default via the malformed-value path rather than via the
+        # documented one.
+        _, kwargs = mock_org.client.request.call_args
+        assert "limit" not in kwargs["query_params"]
+        assert "offset" not in kwargs["query_params"]
+
+    @pytest.mark.parametrize("bad", ["running", "ALL", "", "idle ", None])
+    def test_rejects_an_unknown_state_without_calling_the_api(self, search, mock_org, bad):
+        with pytest.raises(ValidationError):
+            search.list_open_queries(state=bad)
+        mock_org.client.request.assert_not_called()
+
+    def test_returns_the_response_unchanged(self, search, mock_org):
+        payload = {
+            "oid": "test-oid",
+            "limit": 10,
+            "slotsHeld": 1,
+            "count": 3,
+            "truncated": False,
+            "queries": [{"queryId": "q1", "state": "idle", "holdsSlot": False}],
+        }
+        mock_org.client.request.return_value = payload
+
+        # Deliberately not reshaped: slotsHeld vs count is the distinction the
+        # endpoint exists to make, and flattening it here would lose it.
+        assert search.list_open_queries() == payload
+
+    def test_transport_failure_becomes_a_search_error_with_context(self, search, mock_org):
+        mock_org.client.request.side_effect = ConnectionError("connection reset")
+
+        with pytest.raises(SearchError) as exc_info:
+            search.list_open_queries()
+
+        err = exc_info.value
+        assert "Failed to list open queries" in str(err)
+        assert err.region == "9157798c50af372c"
+        assert err.oid == "test-oid"
+
+    def test_a_search_error_from_below_is_not_double_wrapped(self, search, mock_org):
+        mock_org.client.request.side_effect = SearchError("already contextual", oid="test-oid")
+
+        with pytest.raises(SearchError) as exc_info:
+            search.list_open_queries()
+
+        assert "Failed to list open queries" not in str(exc_info.value)
+
+    def test_error_context_survives_a_url_with_no_region(self, search_no_region, mock_org_no_region):
+        mock_org_no_region.client.request.side_effect = ConnectionError("boom")
+
+        with pytest.raises(SearchError) as exc_info:
+            search_no_region.list_open_queries()
+
+        assert exc_info.value.region is None
+        assert exc_info.value.oid == "test-oid"
+
+
+class TestIterOpenQueries:
+    def test_stops_after_a_page_that_is_not_truncated(self, search, mock_org):
+        mock_org.client.request.return_value = {
+            "queries": [{"queryId": "q1"}, {"queryId": "q2"}],
+            "truncated": False,
+        }
+
+        assert [r["queryId"] for r in search.iter_open_queries()] == ["q1", "q2"]
+        assert mock_org.client.request.call_count == 1
+
+    def test_walks_every_page_by_offset(self, search, mock_org):
+        mock_org.client.request.side_effect = [
+            {"queries": [{"queryId": "q1"}], "truncated": True},
+            {"queries": [{"queryId": "q2"}], "truncated": True},
+            {"queries": [{"queryId": "q3"}], "truncated": False},
+        ]
+
+        assert [r["queryId"] for r in search.iter_open_queries(page_size=1)] == ["q1", "q2", "q3"]
+        offsets = [c.kwargs["query_params"].get("offset") for c in mock_org.client.request.call_args_list]
+        assert offsets == ["0", "1", "2"]
+
+    def test_keeps_walking_past_a_page_the_filter_emptied(self, search, mock_org):
+        # The server applies ?state= after paging, so a page can come back
+        # empty while more entries exist. Stopping on an empty page would
+        # silently truncate the answer.
+        mock_org.client.request.side_effect = [
+            {"queries": [], "truncated": True},
+            {"queries": [{"queryId": "q9"}], "truncated": False},
+        ]
+
+        assert [r["queryId"] for r in search.iter_open_queries(state="idle", page_size=2)] == ["q9"]
+        assert mock_org.client.request.call_count == 2
+
+    def test_does_not_repeat_an_entry_when_the_listing_shifts(self, search, mock_org):
+        # Entries leave the index as their searches finish, which shifts later
+        # offsets back and can re-serve one that was already yielded.
+        mock_org.client.request.side_effect = [
+            {"queries": [{"queryId": "q1"}, {"queryId": "q2"}], "truncated": True},
+            {"queries": [{"queryId": "q2"}, {"queryId": "q3"}], "truncated": False},
+        ]
+
+        assert [r["queryId"] for r in search.iter_open_queries(page_size=2)] == ["q1", "q2", "q3"]
+
+    def test_an_org_with_nothing_open_yields_nothing(self, search, mock_org):
+        mock_org.client.request.return_value = {"queries": [], "count": 0, "truncated": False}
+
+        assert list(search.iter_open_queries()) == []
+
+
+class TestGetLimits:
+    """The limits endpoint tells a client how to size its own behaviour, so
+    what matters is that it is addressed to the right org, that the response
+    passes through unaltered, and that a failure arrives as a SearchError with
+    enough context to act on."""
+
+    def test_requests_the_org_scoped_path(self, search, mock_org):
+        mock_org.client.request.return_value = {"oid": "test-oid"}
+
+        search.get_limits()
+
+        args, kwargs = mock_org.client.request.call_args
+        assert args[0] == "GET"
+        # The oid is part of the path, not a query parameter: limits are
+        # per-org and must never be addressable without naming one.
+        assert args[1] == "search/test-oid/limits"
+        assert kwargs["alt_root"].endswith("/v1")
+        # No query parameters: the endpoint takes none, and sending some
+        # would be silently ignored rather than erroring.
+        assert "query_params" not in kwargs
+
+    def test_returns_the_payload_unaltered(self, search, mock_org):
+        payload = {
+            "oid": "test-oid",
+            "concurrency": {"maxConcurrentQueries": 10},
+            "retention": {"resumableForSeconds": 600, "pageResultsForSeconds": 600},
+            "execution": {
+                "maxQueryDurationSeconds": None,
+                "maxAggregationDurationSeconds": None,
+                "maxResponseBytes": None,
+            },
+            "capabilities": {"openQueryListing": True},
+        }
+        mock_org.client.request.return_value = payload
+
+        assert search.get_limits() == payload
+
+    def test_preserves_none_for_unenforced_limits(self, search, mock_org):
+        """None and 0 mean opposite things here - "unlimited" versus "nothing
+        allowed" - so the SDK must not coerce one into the other."""
+        mock_org.client.request.return_value = {
+            "execution": {"maxQueryDurationSeconds": None, "maxResponseBytes": None},
+        }
+
+        result = search.get_limits()
+
+        assert result["execution"]["maxQueryDurationSeconds"] is None
+        assert result["execution"]["maxResponseBytes"] is None
+
+    def test_wraps_transport_failures(self, search, mock_org):
+        mock_org.client.request.side_effect = RuntimeError("connection reset")
+
+        with pytest.raises(SearchError) as excinfo:
+            search.get_limits()
+
+        assert "Failed to get search limits" in str(excinfo.value)
+        assert "connection reset" in str(excinfo.value)
+
+    def test_does_not_rewrap_a_search_error(self, search, mock_org):
+        """A SearchError raised deeper already carries its own context;
+        wrapping it again would bury the original message."""
+        original = SearchError("original failure")
+        mock_org.client.request.side_effect = original
+
+        with pytest.raises(SearchError) as excinfo:
+            search.get_limits()
+
+        assert excinfo.value is original


### PR DESCRIPTION
## Details

Adds SDK and CLI support for two search API endpoints that answer questions the SDK previously could not answer without guessing: what an organization currently has open, and what its search limits actually are.

`Search.list_open_queries()` / `Search.iter_open_queries()` and `limacharlie search queries` report the searches an organization has open and which of them consume its concurrency limit. Those are different populations, and conflating them is the mistake this exists to prevent: a paginated search sitting between pages is open and resumable but holds no slot. The response reports `slotsHeld` separately from `count`, and `slotsHeld` is what `limit` applies to. Each entry carries the query and range as submitted, who submitted it and from which client, how long the current page has been running, progress, how much has been scanned and billed, and the two unrelated expiries. This is what to reach for after a refusal for concurrency: it names what is holding the slots, so the search worth cancelling is identifiable.

`Search.get_limits()` and `limacharlie search limits` report the limits themselves: how many searches may run at once, the page shape, how long results stay resumable, how long a produced page is retained, and any enforced execution deadlines. Every one of these was previously discoverable only by hitting it - a refusal for concurrency does not say what the cap was, and a paginated search stops being resumable with no way to have known the window.

## Conventions the SDK preserves rather than smooths over

A limit that is not enforced comes back as `None`, never `0`. In a set of limits a `0` would read as "nothing allowed", which is the opposite of "no limit applies". The SDK does not coerce one into the other, and a test pins that.

Fields are additive. Unknown ones are ignored rather than rejected, so an older SDK keeps working against a newer deployment, and an absent field means "not applicable to this deployment" rather than zero.

`capabilities.openQueryListing` says whether the listing can report searches that are open but idle. A caller uses it to decide what to offer, instead of probing the listing and interpreting an empty result - which is ambiguous between "not available here" and "nothing is open".

## Paging

`iter_open_queries()` is driven by the response's `truncated` flag rather than by how many rows came back, because the state filter is applied after paging: a page can legitimately be empty while more entries exist behind it. Entries are de-duplicated by id, since a search leaving the listing mid-walk shifts later offsets back and can re-serve one already returned.

The `queries` command walks every page by default so its output is a complete answer rather than one server page; pass `--limit` for a single page.

## Blast radius / isolation

Purely additive. Two new SDK methods on `Search`, one new iterator, two new CLI subcommands. No existing method, command, or output format changes. Nothing here runs unless called.

Both endpoints are gated server-side and may be unavailable on a given deployment; the listing degrades to reporting only searches holding a slot, and callers should treat an absent limits endpoint as "not available" rather than as a failure.

## Performance characteristics

One request per call. `iter_open_queries()` issues one request per page (server page size clamps to 200), not one per row. `get_limits()` resolves server-side configuration only and touches no datastore, so the result is stable between calls and safe for a caller to cache for the lifetime of a process.

## Notable contracts / APIs

No wire-format or schema changes originate here - this consumes existing API responses. The `None`-versus-`0` distinction on unenforced limits and the ignore-unknown-fields behaviour are the two parts of the response contract a caller must not paper over.

## Tests

11 new unit tests. For the listing: request shape and that the organization is named in the path rather than as a parameter, filter and paging pass-through, a bad `state` rejected client-side before it reaches the server, transport failures wrapped with region and organization context, and the paging walk continuing past an empty page while `truncated` is set, de-duplicating a row re-served by a shifting offset, and stopping on error.

For the limits: request shape with no query parameters (the endpoint takes none, and sending some would be silently ignored rather than erroring), the payload returned unaltered, `None` preserved for unenforced limits, transport failures wrapped, and an already-typed `SearchError` from deeper in the stack re-raised rather than re-wrapped, which would otherwise bury the original message.

The `limits` command is registered in the CLI lazy-loading regression test, which is what keeps a new subcommand from silently importing the client at startup.

## Related PRs

- [go-limacharlie#260](https://github.com/refractionPOINT/go-limacharlie/pull/260) - the same two endpoints in the Go SDK
- [documentation#320](https://github.com/refractionPOINT/documentation/pull/320) - user-facing documentation for both

🤖 Generated with [Claude Code](https://claude.com/claude-code)
