### PR TITLE
fix(cloudsec): broken --project flag + wrong help examples

### DIFF
--- a/limacharlie/commands/cloudsec.py
+++ b/limacharlie/commands/cloudsec.py
@@ -16,7 +16,8 @@ the ``ext-cloud-security`` extension:
 
 Provider credentials and the cloudsec policies are hive records —
 manage them with the hive commands (``limacharlie hive list
-cloudsec_provider``, ``... cloudsec_policy``, ``... cloudsec_query``);
+--hive-name cloudsec_provider``, same for ``cloudsec_policy`` and
+``cloudsec_query``);
 the one provider command here is the pre-save credential preflight
 (``cloudsec provider test``).
 """
@@ -139,7 +140,7 @@ Disposition a finding: record an operator resolution, or reopen it.
 
 Examples:
   limacharlie cloudsec finding resolve fnd_abc... --kind mitigated --reason "SG tightened"
-  limacharlie cloudsec finding resolve fnd_abc... --kind accepted --expires-at 1767225600
+  limacharlie cloudsec finding resolve fnd_abc... --kind accepted --expires-at "$(date -d '+90 days' +%s)"
   limacharlie cloudsec finding resolve fnd_abc... --kind open
 """
 
@@ -276,7 +277,7 @@ List the named graph queries available in the query pack (name,
 title, description, and the underlying DSL).
 
 Saved org-defined queries live in the cloudsec_query hive
-(limacharlie hive list cloudsec_query).
+(limacharlie hive list --hive-name cloudsec_query).
 
 Example:
   limacharlie cloudsec query list
@@ -288,9 +289,9 @@ one of --named (a query-pack name), --text (a text query), or
 --query-json (a raw DSL object). Returns alias->urn rows.
 
 Examples:
-  limacharlie cloudsec query run --named public-buckets
-  limacharlie cloudsec query run --text "public bucket with sensitive data"
-  limacharlie cloudsec query run --query-json '{"match": ...}' --project a,b
+  limacharlie cloudsec query run --named public_data_stores
+  limacharlie cloudsec query run --text 'MATCH (d:DataStore {is_sensitive: true})<-[:has_permission_on]-(i:Identity {is_external: true}) RETURN i, d'
+  limacharlie cloudsec query run --query-json '{"anchor": ...}' --project graph
 """
 
 _EXPLAIN_COMPLIANCE_REPORT = """\
@@ -505,8 +506,8 @@ selectors as 'query run' (exactly one of --named / --text /
 --query-json).
 
 Examples:
-  limacharlie cloudsec export query --named public-buckets -o rows.csv
-  limacharlie cloudsec export query --text "public bucket with sensitive data"
+  limacharlie cloudsec export query --named public_data_stores -o rows.csv
+  limacharlie cloudsec export query --text 'MATCH (d:DataStore {is_sensitive: true})<-[:has_permission_on]-(i:Identity {is_external: true}) RETURN i, d'
 """
 
 _EXPLAIN_PROVIDER_TEST = """\
@@ -541,7 +542,7 @@ keys, network tags, resource types) — so you author against real
 tokens instead of guessing.
 
 The policies themselves are hive records (limacharlie hive list
-cloudsec_policy).
+--hive-name cloudsec_policy).
 
 Example:
   limacharlie cloudsec policy vocabulary
@@ -1458,16 +1459,16 @@ def query_list(ctx) -> None:
 @click.option("--named", default=None, help="A query-pack name (see 'query list').")
 @click.option("--text", default=None, help="A text query.")
 @click.option("--query-json", default=None, help="A raw query DSL object as JSON.")
-@click.option("--project", default=None,
-              help="Comma-separated aliases to project into the rows.")
+@click.option("--project", type=click.Choice(["graph"]), default=None,
+              help="Also return a drawable projection: 'graph' adds an induced subgraph over the matched URNs.")
 @pass_context
 def query_run(ctx, named, text, query_json, project) -> None:
     """Run a graph query (one of --named / --text / --query-json).
 
     \b
     Examples:
-      limacharlie cloudsec query run --named public-buckets
-      limacharlie cloudsec query run --text "public bucket with sensitive data"
+      limacharlie cloudsec query run --named public_data_stores
+      limacharlie cloudsec query run --text 'MATCH (d:DataStore {is_sensitive: true})<-[:has_permission_on]-(i:Identity {is_external: true}) RETURN i, d'
     """
     _one_of("the query", named=named, text=text, query_json=query_json)
     query = None
@@ -1476,10 +1477,9 @@ def query_run(ctx, named, text, query_json, project) -> None:
         # Unconditional: a JSON `null` must not slip through as "no query".
         if not isinstance(query, dict):
             raise click.BadParameter("must decode to a JSON object", param_hint="--query-json")
-    project_list = [p.strip() for p in project.split(",") if p.strip()] if project else None
     cs = _get_cloudsec(ctx)
     _output(ctx, cs.run_query(
-        named=named, text=text, query=query, project=project_list,
+        named=named, text=text, query=query, project=project,
     ))
 
 
@@ -2054,8 +2054,8 @@ def export_compliance(ctx, framework, assignment, output_path) -> None:
 @click.option("--named", default=None, help="A query-pack name (see 'query list').")
 @click.option("--text", default=None, help="A text query.")
 @click.option("--query-json", default=None, help="A raw query DSL object as JSON.")
-@click.option("--project", default=None,
-              help="Comma-separated aliases to project into the rows.")
+@click.option("--project", type=click.Choice(["graph"]), default=None,
+              help="Also return a drawable projection: 'graph' adds an induced subgraph over the matched URNs.")
 @_export_output_option
 @pass_context
 def export_query(ctx, named, text, query_json, project, output_path) -> None:
@@ -2063,7 +2063,7 @@ def export_query(ctx, named, text, query_json, project, output_path) -> None:
 
     \b
     Examples:
-      limacharlie cloudsec export query --named public-buckets -o rows.csv
+      limacharlie cloudsec export query --named public_data_stores -o rows.csv
     """
     _one_of("the query", named=named, text=text, query_json=query_json)
     query = None
@@ -2071,8 +2071,7 @@ def export_query(ctx, named, text, query_json, project, output_path) -> None:
         query = _parse_json_opt(query_json, "--query-json")
         if not isinstance(query, dict):
             raise click.BadParameter("must decode to a JSON object", param_hint="--query-json")
-    project_list = [p.strip() for p in project.split(",") if p.strip()] if project else None
     cs = _get_cloudsec(ctx)
     _emit_csv(ctx, cs.export_query_csv(
-        named=named, text=text, query=query, project=project_list,
+        named=named, text=text, query=query, project=project,
     ), output_path)

--- a/limacharlie/sdk/cloudsec.py
+++ b/limacharlie/sdk/cloudsec.py
@@ -107,7 +107,7 @@ def _query_run_body(
     named: str | None,
     text: str | None,
     query: dict[str, Any] | None,
-    project: list[str] | None,
+    project: str | None,
 ) -> dict[str, Any]:
     """Assemble the graph-query POST body (shared by run/export)."""
     body: dict[str, Any] = {}
@@ -652,7 +652,7 @@ class CloudSec:
         named: str | None = None,
         text: str | None = None,
         query: dict[str, Any] | None = None,
-        project: list[str] | None = None,
+        project: str | None = None,
     ) -> dict[str, Any]:
         """Run a graph query. Provide exactly one of named / text / query.
 
@@ -660,7 +660,9 @@ class CloudSec:
             named: A query-pack name (see :meth:`list_queries`).
             text: A text query.
             query: A raw DSL object.
-            project: Optional aliases to project into the rows.
+            project: Optional drawable projection; the only value is
+                ``"graph"``, which adds an induced subgraph (``nodes`` +
+                ``edges``) over the matched URNs next to the rows.
 
         Returns:
             ``{"rows": [{alias: urn, ...}, ...]}``.
@@ -1148,7 +1150,7 @@ class CloudSec:
         named: str | None = None,
         text: str | None = None,
         query: dict[str, Any] | None = None,
-        project: list[str] | None = None,
+        project: str | None = None,
     ) -> str:
         """Run a graph query and export the rows as CSV text.
 

--- a/tests/unit/test_cli_cloudsec.py
+++ b/tests/unit/test_cli_cloudsec.py
@@ -409,12 +409,12 @@ class TestGraphAndQuery:
         p1, p2, p3 = _patches()
         with p1, p2, p3 as cls:
             result, inst = _invoke(
-                ["cloudsec", "query", "run", "--named", "public-buckets"], cls,
+                ["cloudsec", "query", "run", "--named", "public_data_stores"], cls,
                 return_value={"rows": []},
             )
             assert result.exit_code == 0, result.output
             inst.run_query.assert_called_once_with(
-                named="public-buckets", text=None, query=None, project=None,
+                named="public_data_stores", text=None, query=None, project=None,
             )
 
     def test_query_run_dsl_with_project(self):
@@ -424,14 +424,14 @@ class TestGraphAndQuery:
                 [
                     "cloudsec", "query", "run",
                     "--query-json", '{"match": "x"}',
-                    "--project", "a, b",
+                    "--project", "graph",
                 ],
                 cls,
                 return_value={"rows": []},
             )
             assert result.exit_code == 0, result.output
             inst.run_query.assert_called_once_with(
-                named=None, text=None, query={"match": "x"}, project=["a", "b"],
+                named=None, text=None, query={"match": "x"}, project="graph",
             )
 
     def test_query_run_requires_exactly_one_source(self):
@@ -861,11 +861,11 @@ class TestExport:
         p1, p2, p3 = _patches()
         with p1, p2, p3 as cls:
             result, inst = _invoke(
-                ["cloudsec", "export", "query", "--named", "public-buckets"], cls,
+                ["cloudsec", "export", "query", "--named", "public_data_stores"], cls,
             )
             assert result.exit_code == 0, result.output
             inst.export_query_csv.assert_called_once_with(
-                named="public-buckets", text=None, query=None, project=None,
+                named="public_data_stores", text=None, query=None, project=None,
             )
 
     def test_export_query_requires_exactly_one(self):

--- a/tests/unit/test_sdk_cloudsec.py
+++ b/tests/unit/test_sdk_cloudsec.py
@@ -225,16 +225,16 @@ class TestGraphAndQueries:
 
     def test_run_query_named(self, cs, mock_org):
         mock_org.client.request.return_value = {"rows": []}
-        cs.run_query(named="public-buckets")
+        cs.run_query(named="public_data_stores")
         url, body = _post_call(mock_org)
         assert url == f"cloudsec/{OID}/query"
-        assert body == {"named": "public-buckets"}
+        assert body == {"named": "public_data_stores"}
 
     def test_run_query_dsl_with_projection(self, cs, mock_org):
         mock_org.client.request.return_value = {"rows": []}
-        cs.run_query(query={"match": "x"}, project=["a", "b"])
+        cs.run_query(query={"match": "x"}, project="graph")
         _, body = _post_call(mock_org)
-        assert body == {"query": {"match": "x"}, "project": ["a", "b"]}
+        assert body == {"query": {"match": "x"}, "project": "graph"}
 
 
 class TestCompliance:
@@ -573,11 +573,11 @@ class TestCsvExports:
 
     def test_export_query_csv(self, cs, mock_org):
         mock_org.client.request.return_value = "a\n"
-        cs.export_query_csv(named="public-buckets")
+        cs.export_query_csv(named="public_data_stores")
         args, kwargs = mock_org.client.request.call_args
         assert args == ("POST", f"cloudsec/{OID}/query")
         assert kwargs["query_params"] == [("format", "csv")]
-        assert json.loads(kwargs["raw_body"]) == {"named": "public-buckets"}
+        assert json.loads(kwargs["raw_body"]) == {"named": "public_data_stores"}
         assert kwargs["raw_response"] is True
 
     def test_export_inventory_csv_all_accounts(self, cs, mock_org):


### PR DESCRIPTION
Found while auditing the Cloud Security docs against the product (companion to https://github.com/refractionPOINT/documentation/pull/322): the `cloudsec` CLI group's own `--help`/`--ai-help` contradicted the server in four places, and one flag was silently broken.

## Fixes

- **`--project` was silently ignored.** The CLI split its value into a list and the SDK sent a JSON array, but the server's `project` body field is a string that only accepts `"graph"` — so no value ever had any effect. It is now `Choice(["graph"])`, passed through verbatim, with help text describing what it actually does (adds the induced subgraph next to the rows). SDK signature updated to `project: str | None`, docstring corrected.
- **`--named public-buckets` in help examples** — not a real query-pack name; copying the example errors. Now `public_data_stores`.
- **Natural-language `--text` examples** — `--text` is the Cypher-lite `MATCH … RETURN` grammar; `"public bucket with sensitive data"` cannot parse. Replaced with a valid query (the same one the docs use).
- **`limacharlie hive list cloudsec_query` (positional)** — invalid syntax; `hive list` requires `--hive-name`. Fixed in all four help texts.
- **Stale `--expires-at 1767225600` example** — that epoch (2026-01-01) is in the past, so an acceptance created from it is expired on arrival. Now uses `"$(date -d '+90 days' +%s)"`.

## Testing

Unit tests updated for the `--project` semantics and pack name; full unit suite passes (3,676 passed, 6 pre-existing skips).

Note: `--project` previously accepted arbitrary comma-separated values and did nothing; it now rejects anything but `graph`. That's a behavior change only for invocations that were already broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013wAL18rVrkErdz8kBTkkRi