### PR TITLE
cloudsec: bind the last four routes + the findings owner filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@
   `CloudSec.list_finding_causes()` group findings by the mutable object
   whose single edit resolves all of them ("change this one thing, close N
   findings"), under the same filters as `finding list`. `--cause` returns
-  the exact count for one cause; otherwise the top causes by count plus
+  the count for one cause; otherwise the top causes by count plus
   `distinct`, the total matching causes, so the ranked head discloses its
   tail.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,14 @@
   `distinct`, the total matching causes, so the ranked head discloses its
   tail.
 
+- **Closed vocabularies are validated client-side**: `--risk-band`,
+  `--criticality` and `--tier` accept only `critical`/`high`/`medium`/`low`,
+  because the backend fails CLOSED on an unknown value — a typo would have
+  returned zero rows with a successful exit under a filter the user can see
+  is applied. `--unclassified` selects the no-tier-assigned bucket (the
+  empty value on the wire) and combines with a named tier, mirroring
+  `--unassigned` for owners.
+
 - **Identity access population**: `cloudsec ciem identities` /
   `CloudSec.list_identity_access()` — the ranked, server-filtered,
   keyset-paginated identity rollup (the pageable sibling of `ciem

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@
   --unassigned` is "mine or nobody's" in one filter. `finding facets
   --owner-pin` keeps named owners in the `owner` facet, which is capped at
   the top 50 by count (`owner_truncated` says whether any were dropped) —
-  it is not a filter and changes no count. `export findings` takes the
+  it is not a filter and changes no count, and the pin shares those 50 slots
+  with any `--owner` values, so it is a best effort past ~50 combined. `export findings` takes the
   owner filter too, so an export stays the set the list shows.
 
 - **Shared-fix cause rollup**: `cloudsec finding causes` /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,8 +48,8 @@
   public-access`'s top-N). `ciem facets` now takes the SAME cross-filter
   (source/kind/criticality/risk_band/mfa plus the admin, external, public,
   disabled, crown-jewel, escalation, dormancy and sensitive-access
-  tri-states), so a facet count always describes the population the list
-  returns.
+  tri-states), so a facet count describes the population the list returns —
+  except for the no-tier bucket, which both rails skip when counting.
 
 - **Data Security store list**: `cloudsec data-security stores` /
   `CloudSec.list_data_stores()` — the keyset-paginated DSPM row list, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,46 @@
 
 ### Cloud Security (CNAPP)
 
+- **Findings owner filter**: `cloudsec finding list|facets --owner ALICE
+  [--unassigned]` / `list_findings(owner=[...])` filter the worklist by
+  assigned owner. The gateway has always accepted the selector, so
+  `finding set-owner` could assign an owner nothing could then filter by.
+  The unassigned bucket is the empty owner value, so `--owner alice
+  --unassigned` is "mine or nobody's" in one filter. `finding facets
+  --owner-pin` keeps named owners in the `owner` facet, which is capped at
+  the top 50 by count (`owner_truncated` says whether any were dropped) —
+  it is not a filter and changes no count. `export findings` takes the
+  owner filter too, so an export stays the set the list shows.
+
+- **Shared-fix cause rollup**: `cloudsec finding causes` /
+  `CloudSec.list_finding_causes()` group findings by the mutable object
+  whose single edit resolves all of them ("change this one thing, close N
+  findings"), under the same filters as `finding list`. `--cause` returns
+  the exact count for one cause; otherwise the top causes by count plus
+  `distinct`, the total matching causes, so the ranked head discloses its
+  tail.
+
+- **Identity access population**: `cloudsec ciem identities` /
+  `CloudSec.list_identity_access()` — the ranked, server-filtered,
+  keyset-paginated identity rollup (the pageable sibling of `ciem
+  public-access`'s top-N). `ciem facets` now takes the SAME cross-filter
+  (source/kind/criticality/risk_band/mfa plus the admin, external, public,
+  disabled, crown-jewel, escalation, dormancy and sensitive-access
+  tri-states), so a facet count always describes the population the list
+  returns.
+
+- **Data Security store list**: `cloudsec data-security stores` /
+  `CloudSec.list_data_stores()` — the keyset-paginated DSPM row list, and
+  `data-security facets` now takes the same cross-filter
+  (provider/account/region/store_kind/tier/data_class plus the sensitivity
+  and exposure tri-states).
+
+- **Free-tier standing**: `cloudsec free-tier` /
+  `CloudSec.get_free_tier()` report the org's tier, sensor quota and — for
+  a free-tier org — its provider cap and how many connections it is using,
+  so an upgrade prompt can precede the limit. It only describes the limits;
+  the collector and the provider-record validator enforce them.
+
 - **Sensor↔cloud resolution keeps the resolver-readiness signal**:
   `CloudSec.resolve_sensors()` / `resolve_assets()` chunk large batches and
   merge the responses; the merge dropped `resolver_ready`, so a caller could

--- a/doc/cli/cloud-security.md
+++ b/doc/cli/cloud-security.md
@@ -67,7 +67,7 @@ limacharlie cloudsec finding set-ticket fnd_abc --ticket JIRA-123
 
 ## Attack paths & CIEM
 
-`ciem facets` and `ciem identities` take the SAME cross-filter, so the rail's counts always describe the population the list returns. The boolean filters are tri-state: omitting one leaves the dimension unconstrained, which is not the same as pinning it false. `--mfa unknown` is everyone the MFA question does not apply to (no identity-provider observation, or non-human) — it is not `off`.
+`ciem facets` and `ciem identities` take the SAME cross-filter, so the rail's counts describe the population the list returns — with one exception: the no-tier bucket `--unclassified` selects is skipped when counting, so it is the only selection the rail cannot give a count for (the same is true of `--unclassified` on `data-security`). The boolean filters are tri-state: omitting one leaves the dimension unconstrained, which is not the same as pinning it false. `--mfa unknown` is everyone the MFA question does not apply to (no identity-provider observation, or non-human) — it is not `off`.
 
 `--risk-band` and `--criticality` are closed vocabularies (`critical`, `high`, `medium`, `low`) validated client-side, because the backend fails closed: an unrecognized value would return zero rows with a successful exit. `--unclassified` selects identities with no tier assigned and combines with `--criticality`.
 
@@ -84,7 +84,7 @@ limacharlie cloudsec ciem identity "lcrn:gcp:...:serviceAccount/deploy"   # one 
 
 ## Inventory, resources & data security
 
-`data-security facets` and `data-security stores` share their selectors for the same reason. `--sensitive` / `--public` are tri-state (`--no-sensitive` / `--no-public` pin them false). `--tier` takes the same closed tier vocabulary as `--criticality` above, with `--unclassified` for stores that have none.
+`data-security facets` and `data-security stores` share their selectors for the same reason (with the same `--unclassified` exception). `--sensitive` / `--public` are tri-state (`--no-sensitive` / `--no-public` pin them false). `--tier` takes the same closed tier vocabulary as `--criticality` above, with `--unclassified` for stores that have none.
 
 ```bash
 limacharlie cloudsec inventory list --type gcp_bucket --region us-central1

--- a/doc/cli/cloud-security.md
+++ b/doc/cli/cloud-security.md
@@ -43,7 +43,7 @@ limacharlie cloudsec fleet overview --oid <OID1> --oid <OID2>
 
 Repeatable filters are OR within a key and AND across keys. Finding classes: `toxic_combination`, `public_exposure`, `ciem_risk`, `privilege_escalation`, `vulnerability`, `misconfig`, `coverage_gap`. Sort keys: `lc_risk` (default), `severity`, `first_seen`.
 
-`--owner` filters by assigned owner and `--unassigned` selects the untriaged bucket; they combine, so "mine or nobody's" is one filter with both. On `finding facets` the `owner` facet is capped at the top 50 owners by count (`owner_truncated` reports whether any were dropped) — `--owner-pin` keeps named owners in it even when they would not rank in, and filters nothing.
+`--owner` filters by assigned owner and `--unassigned` selects the untriaged bucket; they combine, so "mine or nobody's" is one filter with both. On `finding facets` the `owner` facet is capped at the top 50 owners by count (`owner_truncated` reports whether any were dropped) — `--owner-pin` keeps named owners in it even when they would not rank in, and filters nothing. That is bounded by the same cap: pins share the 50 slots with any `--owner` values, so past ~50 combined a pin can still be dropped and `owner_truncated` will not say so.
 
 `finding causes` groups findings by the mutable object whose single edit resolves all of them, so a worklist can be worked by fix instead of by row. It takes the same filters as `finding list`; `distinct` is the total number of matching causes, so you can see how much tail the ranked head hides.
 

--- a/doc/cli/cloud-security.md
+++ b/doc/cli/cloud-security.md
@@ -24,7 +24,10 @@ limacharlie cloudsec scan-status --provider aws   # collection sweep status
 limacharlie cloudsec chokepoint list              # shared attack-path hops
 limacharlie cloudsec chokepoint dismiss "lcrn:..." --reason "planned decom"
 limacharlie cloudsec chokepoint restore "lcrn:..."
+limacharlie cloudsec free-tier                    # tier + provider usage vs the limits
 ```
+
+`free-tier` only DESCRIBES the free-tier limits — the collector and the provider-record validator enforce them, so a limit applies whether or not you ask. `enabled_providers` is omitted rather than zeroed when the count could not be read, so an absent field means "unknown", never "none configured". There is no trial countdown: the authoritative clock lives in the datacenter, and a gated collection reports its reason through `scan-status`.
 
 ## Fleet (multi-org, MSSP)
 
@@ -40,10 +43,18 @@ limacharlie cloudsec fleet overview --oid <OID1> --oid <OID2>
 
 Repeatable filters are OR within a key and AND across keys. Finding classes: `toxic_combination`, `public_exposure`, `ciem_risk`, `privilege_escalation`, `vulnerability`, `misconfig`, `coverage_gap`. Sort keys: `lc_risk` (default), `severity`, `first_seen`.
 
+`--owner` filters by assigned owner and `--unassigned` selects the untriaged bucket; they combine, so "mine or nobody's" is one filter with both. On `finding facets` the `owner` facet is capped at the top 50 owners by count (`owner_truncated` reports whether any were dropped) — `--owner-pin` keeps named owners in it even when they would not rank in, and filters nothing.
+
+`finding causes` groups findings by the mutable object whose single edit resolves all of them, so a worklist can be worked by fix instead of by row. It takes the same filters as `finding list`; `distinct` is the total number of matching causes, so you can see how much tail the ranked head hides.
+
 ```bash
 limacharlie cloudsec finding list --severity CRITICAL --severity HIGH
 limacharlie cloudsec finding list --class public_exposure --kev
+limacharlie cloudsec finding list --owner alice@corp.com --unassigned
 limacharlie cloudsec finding facets --status open
+limacharlie cloudsec finding facets --owner-pin me@corp.com
+limacharlie cloudsec finding causes --severity CRITICAL --limit 5
+limacharlie cloudsec finding causes --cause "lcrn:...:firewalls/allow-all"
 limacharlie cloudsec finding get fnd_0123abcd
 
 # Triage
@@ -56,19 +67,29 @@ limacharlie cloudsec finding set-ticket fnd_abc --ticket JIRA-123
 
 ## Attack paths & CIEM
 
+`ciem facets` and `ciem identities` take the SAME cross-filter, so the rail's counts always describe the population the list returns. The boolean filters are tri-state: omitting one leaves the dimension unconstrained, which is not the same as pinning it false. `--mfa unknown` is everyone the MFA question does not apply to (no identity-provider observation, or non-human) — it is not `off`.
+
 ```bash
 limacharlie cloudsec attack-path list --severity CRITICAL
 limacharlie cloudsec ciem public-access    # public/external access to sensitive resources
-limacharlie cloudsec ciem facets           # identity facet counts
+limacharlie cloudsec ciem facets --kind service_account --admin
+limacharlie cloudsec ciem identities --limit 50            # ranked, paginated population
+limacharlie cloudsec ciem identities --external --with-sensitive
+limacharlie cloudsec ciem identities --mfa off --admin
+limacharlie cloudsec ciem identity "lcrn:gcp:...:serviceAccount/deploy"   # one identity
 ```
 
 ## Inventory, resources & data security
+
+`data-security facets` and `data-security stores` share their selectors for the same reason. `--sensitive` / `--public` are tri-state (`--not-sensitive` / `--not-public` pin them false).
 
 ```bash
 limacharlie cloudsec inventory list --type gcp_bucket --region us-central1
 limacharlie cloudsec inventory list --provider okta      # scope to one provider's sweep
 limacharlie cloudsec inventory facets
 limacharlie cloudsec data-security facets                # DSPM data-store rollup
+limacharlie cloudsec data-security stores --sensitive --public
+limacharlie cloudsec data-security stores --store-kind bucket --data-class pii
 limacharlie cloudsec resource get "lcrn:gcp:...:bucket/prod-data"
 ```
 
@@ -96,6 +117,7 @@ The server walks the full filtered set (no pagination), capped at 100k rows; a t
 
 ```bash
 limacharlie cloudsec export findings -o findings.csv --severity CRITICAL
+limacharlie cloudsec export findings --owner alice@corp.com   # same filters as 'finding list'
 limacharlie cloudsec export inventory -o inventory.csv --provider gcp
 limacharlie cloudsec export compliance -o cis-gcp.csv
 limacharlie cloudsec export query --named public-buckets -o rows.csv

--- a/doc/cli/cloud-security.md
+++ b/doc/cli/cloud-security.md
@@ -69,6 +69,8 @@ limacharlie cloudsec finding set-ticket fnd_abc --ticket JIRA-123
 
 `ciem facets` and `ciem identities` take the SAME cross-filter, so the rail's counts always describe the population the list returns. The boolean filters are tri-state: omitting one leaves the dimension unconstrained, which is not the same as pinning it false. `--mfa unknown` is everyone the MFA question does not apply to (no identity-provider observation, or non-human) — it is not `off`.
 
+`--risk-band` and `--criticality` are closed vocabularies (`critical`, `high`, `medium`, `low`) validated client-side, because the backend fails closed: an unrecognized value would return zero rows with a successful exit. `--unclassified` selects identities with no tier assigned and combines with `--criticality`.
+
 ```bash
 limacharlie cloudsec attack-path list --severity CRITICAL
 limacharlie cloudsec ciem public-access    # public/external access to sensitive resources
@@ -76,12 +78,13 @@ limacharlie cloudsec ciem facets --kind service_account --admin
 limacharlie cloudsec ciem identities --limit 50            # ranked, paginated population
 limacharlie cloudsec ciem identities --external --with-sensitive
 limacharlie cloudsec ciem identities --mfa off --admin
+limacharlie cloudsec ciem identities --risk-band critical --unclassified
 limacharlie cloudsec ciem identity "lcrn:gcp:...:serviceAccount/deploy"   # one identity
 ```
 
 ## Inventory, resources & data security
 
-`data-security facets` and `data-security stores` share their selectors for the same reason. `--sensitive` / `--public` are tri-state (`--not-sensitive` / `--not-public` pin them false).
+`data-security facets` and `data-security stores` share their selectors for the same reason. `--sensitive` / `--public` are tri-state (`--no-sensitive` / `--no-public` pin them false). `--tier` takes the same closed tier vocabulary as `--criticality` above, with `--unclassified` for stores that have none.
 
 ```bash
 limacharlie cloudsec inventory list --type gcp_bucket --region us-central1

--- a/doc/sdk/other-classes.md
+++ b/doc/sdk/other-classes.md
@@ -157,11 +157,25 @@ cs.list_findings(severity=["CRITICAL"], status=["open"])
 cs.get_finding("fnd_abc")
 cs.set_finding_status("fnd_abc", "mitigated", reason="SG tightened")
 
+# Owner filter: "" is the unassigned bucket, so this is "mine or nobody's"
+cs.list_findings(owner=["alice@corp.com", ""])
+cs.get_finding_facets(owner_pin=["alice@corp.com"])   # keep my row in the capped facet
+
+# Shared-fix rollup: one edit that closes N findings
+cs.list_finding_causes(severity=["CRITICAL"], limit=5)
+
 # Inventory, graph, compliance, overview
 cs.list_inventory(provider="gcp", resource_type="Bucket")
 cs.run_query(named="public-buckets")
 cs.get_compliance(framework="cis-gcp")
 cs.get_overview(trend_days=90)
+
+# Identity access population + Data Security stores (same selectors as their facets)
+cs.list_identity_access(kind=["service_account"], can_escalate=True)
+cs.list_data_stores(store_kind=["bucket"], sensitivity=True, exposure=True)
+
+# Free-tier standing and the limits that apply
+cs.get_free_tier()
 
 # Multi-org fleet posture (MSSP)
 cs.get_fleet_overview(group="my-group-id")
@@ -174,7 +188,7 @@ cs.test_provider({"provider_type": "gcp", "credentials": "hive://secret/gcp-sa"}
 cs.get_provider_manifests(provider_type="gcp")
 ```
 
-The Cloud Security (CNAPP) surface: findings (CSPM + attack paths + CIEM), resource inventory, security graph queries, compliance, DSPM facets, CAASM ingest/coverage, sensor↔asset resolution, fleet overview, and CSV exports. See [CLI: cloudsec](../cli/cloud-security.md) for the command-line equivalents.
+The Cloud Security (CNAPP) surface: findings (CSPM + attack paths + CIEM) with their facet and shared-fix rollups, resource inventory, security graph queries, compliance, the identity access population, DSPM stores and facets, CAASM ingest/coverage, sensor↔asset resolution, free-tier standing, fleet overview, and CSV exports. See [CLI: cloudsec](../cli/cloud-security.md) for the command-line equivalents.
 
 ## See Also
 

--- a/limacharlie/commands/cloudsec.py
+++ b/limacharlie/commands/cloudsec.py
@@ -1,12 +1,15 @@
 """Cloud Security (CNAPP) commands for LimaCharlie CLI v2.
 
 Commands for the ``/cloudsec`` API surface: the merged, risk-ranked
-findings worklist (CSPM misconfigurations + attack paths + CIEM),
-the cloud resource inventory, the pre-aggregated estate topology and
+findings worklist (CSPM misconfigurations + attack paths + CIEM) with
+its facet and shared-fix (cause) rollups, the identity access
+population, the cloud resource inventory, the Data Security (DSPM)
+store list and facets, the pre-aggregated estate topology and
 security graph, compliance assessment, the risk overview, CAASM
 (third-party asset attack surface), sensor<->cloud-asset resolution,
-finding triage, and the cloudsec_policy authoring aids (vocabulary,
-autocomplete, and the "Simulate" matcher previews).
+finding triage, the free-tier standing, and the cloudsec_policy
+authoring aids (vocabulary, autocomplete, and the "Simulate" matcher
+previews).
 
 Reads require the ``cloudsec.get`` permission and writes require
 ``cloudsec.set``. Every command requires the org to be subscribed to
@@ -78,6 +81,25 @@ Examples:
   limacharlie cloudsec scan-status --provider aws
 """
 
+_EXPLAIN_FREE_TIER = """\
+Where the org stands on the cloud-security free tier, and the limits
+that apply to it: is_free_tier, sensor_quota, and — for a free-tier
+org only — max_providers plus enabled_providers ("you are using N of
+M provider connections"). A paying org has no provider cap, so those
+two fields are absent for one.
+
+This endpoint only DESCRIBES the limits; the collector and the
+provider-record validator enforce them, so a limit applies whether or
+not you call this. enabled_providers is omitted rather than zeroed
+when the count could not be read, so an absent field means "unknown",
+never "none configured". There is no trial countdown here — the
+authoritative clock lives in the datacenter, and the collector
+publishes a gated reason through 'cloudsec scan-status'.
+
+Example:
+  limacharlie cloudsec free-tier
+"""
+
 _EXPLAIN_FINDING_LIST = """\
 List the merged, risk-ranked cloud-security findings (CSPM
 misconfigurations + graph toxic-combination attack paths + CIEM
@@ -92,6 +114,10 @@ privilege_escalation, vulnerability, misconfig, coverage_gap,
 device_posture. The canonical, always current list is served by
 'cloudsec finding classes'.
 
+--owner filters by assigned owner (set with 'finding set-owner');
+--unassigned selects the untriaged bucket and combines with --owner,
+so "mine or nobody's" is --owner me@corp.com --unassigned.
+
 Pagination is keyset-based: pass the previous page's next_cursor
 via --cursor.
 
@@ -99,6 +125,8 @@ Examples:
   limacharlie cloudsec finding list --severity CRITICAL
   limacharlie cloudsec finding list --class public_exposure --kev
   limacharlie cloudsec finding list --status open --limit 50
+  limacharlie cloudsec finding list --owner alice@corp.com --status open
+  limacharlie cloudsec finding list --unassigned --severity CRITICAL
 """
 
 _EXPLAIN_FINDING_FACETS = """\
@@ -106,8 +134,39 @@ Cross-filtered facet counts for the findings worklist under the
 same filter selectors as 'finding list'. Each facet dimension is
 counted against the other active filters.
 
-Example:
+The 'owner' facet is keyed by owner, with the empty string holding the
+unassigned bucket, and is capped at the top 50 owners by count —
+'owner_truncated' says whether any were dropped. --owner-pin keeps
+named owners in that capped facet even when they would not rank into
+it (pass your own identity so your row stays reachable on an estate
+with more owners than the cap). It is NOT a filter: it selects no rows
+and changes no count.
+
+Examples:
   limacharlie cloudsec finding facets --severity CRITICAL
+  limacharlie cloudsec finding facets --owner-pin me@corp.com
+"""
+
+_EXPLAIN_FINDING_CAUSES = """\
+Findings grouped by their CAUSE — the mutable object (a firewall
+rule, the principal an attack path's grants land on) whose single
+edit resolves every finding under it. Lets a worklist be worked by
+fix instead of by row: "change this one thing, close N findings".
+
+Takes the same filters as 'finding list', so a rollup can be scoped
+exactly like the list it summarizes. Pass --cause for the exact
+count of one cause; omit it for the top causes by count (--limit,
+default 20, cap 200). 'distinct' is the total number of matching
+causes, so you can tell how much tail the head hides — the counts
+themselves are always exact.
+
+'kind' is an open vocabulary that grows server-side; treat an
+unrecognized value as "some object" rather than assuming a class.
+
+Examples:
+  limacharlie cloudsec finding causes
+  limacharlie cloudsec finding causes --severity CRITICAL --limit 5
+  limacharlie cloudsec finding causes --cause "lcrn:...:firewalls/allow-all"
 """
 
 _EXPLAIN_FINDING_GET = """\
@@ -192,10 +251,50 @@ Example:
 """
 
 _EXPLAIN_CIEM_FACETS = """\
-CIEM identity facet counts (identity kinds, external/public splits).
+CIEM identity facet counts (identity kinds, MFA state, risk bands,
+plus the admin/external/public/disabled/dormant/escalation/
+sensitive-access rollups and the total), so the identity view can
+lead with insight before the row list.
 
-Example:
+The selectors CROSS-FILTER the rail: each dimension is counted under
+the other active selectors but not its own, so a value's count is
+exactly how many rows selecting it would list. With no selectors the
+response is the whole-population rollup. It takes the SAME selectors
+as 'ciem identities', so the counts and that list always describe the
+same population.
+
+--mfa unknown is everyone the MFA question does not apply to (no
+identity-provider observation, or non-human) — it is NOT 'off'. The
+boolean filters are tri-state: omitting one leaves the dimension
+unconstrained, which is not the same as pinning it false.
+
+Examples:
   limacharlie cloudsec ciem facets
+  limacharlie cloudsec ciem facets --kind service_account --admin
+"""
+
+_EXPLAIN_CIEM_IDENTITIES = """\
+One page of the Access screen's identity population: the same
+per-principal effective-access rollup rows 'ciem public-access'
+carries (grant / privileged / sensitive-reach counts, posture facets,
+risk score), but server-filtered and pageable instead of a
+risk-ranked top-N.
+
+Takes the same selectors as 'ciem facets', so the rail's counts and
+this list always describe the same population. Ranked by risk score
+descending by default; a walk that spans a projector recompute can
+move a row across the cursor, so use it for browsing rather than for
+exact exports.
+
+--account / --region are served from the projector's merged view: on a
+tenant whose view has not been built yet the call fails loudly rather
+than returning a misleading zero.
+
+Examples:
+  limacharlie cloudsec ciem identities --limit 50
+  limacharlie cloudsec ciem identities --kind service_account --can-escalate
+  limacharlie cloudsec ciem identities --external --with-sensitive
+  limacharlie cloudsec ciem identities --mfa off --admin
 """
 
 _EXPLAIN_CIEM_IDENTITY = """\
@@ -247,8 +346,30 @@ _EXPLAIN_DATA_SECURITY_FACETS = """\
 DSPM data-store facet counts: total/sensitive/public/public-sensitive
 data stores plus store-kind, sensitivity, and exposure histograms.
 
-Example:
+The selectors cross-filter the rail (each dimension counted under the
+other active selectors but not its own) and are the SAME ones 'stores'
+takes, so the counts always describe the population that list returns.
+
+Examples:
   limacharlie cloudsec data-security facets
+  limacharlie cloudsec data-security facets --store-kind bucket
+"""
+
+_EXPLAIN_DATA_SECURITY_STORES = """\
+One keyset page of the org's data stores, served from the
+materialized graph store under the same selectors as
+'data-security facets' — so the filtered list stays exact at any
+estate size instead of client-filtering a capped walk.
+
+--sensitive / --public are tri-state: omitting one leaves the
+dimension unconstrained; --not-sensitive / --not-public pin it to
+false. Rows are ordered by a stable stored key, so a full walk with
+--cursor is safe.
+
+Examples:
+  limacharlie cloudsec data-security stores --limit 50
+  limacharlie cloudsec data-security stores --sensitive --public
+  limacharlie cloudsec data-security stores --store-kind bucket --data-class pii
 """
 
 _EXPLAIN_RESOURCE_GET = """\
@@ -617,8 +738,10 @@ register_explain("cloudsec.changes", _EXPLAIN_CHANGES)
 register_explain("cloudsec.risk-trend", _EXPLAIN_RISK_TREND)
 register_explain("cloudsec.scan-status", _EXPLAIN_SCAN_STATUS)
 register_explain("cloudsec.topology", _EXPLAIN_TOPOLOGY)
+register_explain("cloudsec.free-tier", _EXPLAIN_FREE_TIER)
 register_explain("cloudsec.finding.list", _EXPLAIN_FINDING_LIST)
 register_explain("cloudsec.finding.facets", _EXPLAIN_FINDING_FACETS)
+register_explain("cloudsec.finding.causes", _EXPLAIN_FINDING_CAUSES)
 register_explain("cloudsec.finding.classes", _EXPLAIN_FINDING_CLASSES)
 register_explain("cloudsec.finding.get", _EXPLAIN_FINDING_GET)
 register_explain("cloudsec.finding.resolve", _EXPLAIN_FINDING_RESOLVE)
@@ -629,9 +752,11 @@ register_explain("cloudsec.attack-path.list", _EXPLAIN_ATTACK_PATH_LIST)
 register_explain("cloudsec.ciem.public-access", _EXPLAIN_CIEM_PUBLIC_ACCESS)
 register_explain("cloudsec.ciem.facets", _EXPLAIN_CIEM_FACETS)
 register_explain("cloudsec.ciem.identity", _EXPLAIN_CIEM_IDENTITY)
+register_explain("cloudsec.ciem.identities", _EXPLAIN_CIEM_IDENTITIES)
 register_explain("cloudsec.inventory.list", _EXPLAIN_INVENTORY_LIST)
 register_explain("cloudsec.inventory.facets", _EXPLAIN_INVENTORY_FACETS)
 register_explain("cloudsec.data-security.facets", _EXPLAIN_DATA_SECURITY_FACETS)
+register_explain("cloudsec.data-security.stores", _EXPLAIN_DATA_SECURITY_STORES)
 register_explain("cloudsec.resource.get", _EXPLAIN_RESOURCE_GET)
 register_explain("cloudsec.graph.neighbors", _EXPLAIN_GRAPH_NEIGHBORS)
 register_explain("cloudsec.query.list", _EXPLAIN_QUERY_LIST)
@@ -816,6 +941,10 @@ _SIMULATE_TARGET_CHOICES = click.Choice(
 _SUGGEST_DIMENSION_CHOICES = click.Choice(
     ["name", "account"], case_sensitive=False,
 )
+# The identity MFA selector is three-state by contract ("unknown" is not
+# "off"), and the set is closed server-side — a Choice keeps a typo from
+# reading as "no MFA constraint".
+_MFA_CHOICES = click.Choice(["on", "off", "unknown"], case_sensitive=False)
 # Provider and CAASM-source values are deliberately NOT click.Choice lists:
 # both are growing server-side registries (new providers/sources ship without
 # a CLI release) and the server rejects unknown values with a clean error.
@@ -833,6 +962,20 @@ def _paging_options(f):
     return f
 
 
+def _owner_selector(owners, unassigned: bool) -> list[str] | None:
+    """Fold --owner/--unassigned into the wire `owner` selector.
+
+    The unassigned bucket IS an owner value on the wire: the empty
+    string. It rides the same repeatable selector, so "mine or
+    nobody's" is one filter with two values. No selection at all
+    returns None so the request carries no owner constraint.
+    """
+    values = list(owners)
+    if unassigned:
+        values.append("")
+    return values or None
+
+
 def _finding_filter_options(f):
     """The findings worklist filter selectors (shared by list/facets).
 
@@ -842,6 +985,16 @@ def _finding_filter_options(f):
     f = click.option(
         "-q", "--search", "q", default=None,
         help="Substring search over the findings.",
+    )(f)
+    f = click.option(
+        "--unassigned", is_flag=True, default=False,
+        help="Include findings with no owner (the untriaged bucket); "
+             "combines with --owner.",
+    )(f)
+    f = click.option(
+        "--owner", "owners", multiple=True,
+        help="Filter by assigned owner; repeatable (OR). Use --unassigned "
+             "for findings nobody owns.",
     )(f)
     f = click.option(
         "--kev/--no-kev", "kev", default=None,
@@ -898,6 +1051,125 @@ def _inventory_filter_options(f):
     return f
 
 
+def _identity_filter_options(f):
+    """The merged-identity cross-filter (shared by ciem facets/identities).
+
+    One decorator for both routes on purpose: a dimension that reaches
+    the list and not the rail is how a facet count stops describing the
+    list it annotates. The boolean flags are tri-state — omitted leaves
+    the dimension unconstrained, which is not the same as pinning it
+    false, which is why every one of them defaults to None rather than
+    being an is_flag.
+    """
+    f = click.option(
+        "-q", "--search", "q", default=None,
+        help="Substring filter over the identity's urn/email/kind.",
+    )(f)
+    for opt, help_text in [
+        ("--with-sensitive/--no-with-sensitive",
+         "Holds (or not) at least one non-deny grant on a sensitive resource."),
+        ("--dormant-90d/--no-dormant-90d",
+         "No observed activity in 90 days (or some)."),
+        ("--can-escalate/--no-can-escalate",
+         "Can (or cannot) escalate its own privileges."),
+        ("--crown-jewel/--no-crown-jewel",
+         "Declared sensitive by the org's cloudsec_policy (or not)."),
+        ("--disabled/--no-disabled", "Disabled (or enabled) identities."),
+        ("--public/--no-public",
+         "Public principals (allUsers / allAuthenticatedUsers and "
+         "equivalents), or not."),
+        ("--external/--no-external",
+         "Outside (or inside) the org's own domains."),
+        ("--admin/--no-admin", "Holds (or does not hold) an admin role."),
+    ]:
+        f = click.option(
+            opt, default=None, help=f"{help_text} Omit for no constraint.",
+        )(f)
+    f = click.option(
+        "--mfa", default=None, type=_MFA_CHOICES,
+        help="MFA state: on | off | unknown. 'unknown' is everyone the "
+             "question does not apply to (no IdP observation, or non-human) "
+             "— it is NOT 'off'.",
+    )(f)
+    f = click.option(
+        "--risk-band", "risk_bands", multiple=True,
+        help="Filter by risk band (critical/high/medium/low); repeatable (OR).",
+    )(f)
+    f = click.option(
+        "--criticality", "criticalities", multiple=True,
+        help="Filter by crown-jewel tier; repeatable (OR).",
+    )(f)
+    f = click.option(
+        "--kind", "kinds", multiple=True,
+        help="Filter by identity kind (user, service_account, group, "
+             "ai_agent, ...); repeatable (OR).",
+    )(f)
+    f = click.option(
+        "--region", "regions", multiple=True,
+        help="Filter by region; repeatable (OR). Served from the projector's "
+             "merged view — fails loudly on a tenant whose view is unbuilt.",
+    )(f)
+    f = click.option(
+        "--account", "accounts", multiple=True,
+        help="Filter by account/project; repeatable (OR). Served from the "
+             "merged view, like --region.",
+    )(f)
+    f = click.option(
+        "--source", "sources", multiple=True,
+        help="Filter by producing sweep (okta, gcp, google_workspace, ...); "
+             "repeatable (OR). Alias of --provider.",
+    )(f)
+    return f
+
+
+def _data_store_filter_options(f):
+    """The Data Security cross-filter (shared by data-security facets/stores).
+
+    Shared for the same reason as the identity filter: the facet counts
+    must describe the population the store list returns.
+    """
+    f = click.option(
+        "-q", "--search", "q", default=None,
+        help="Substring filter over the store's name/urn.",
+    )(f)
+    f = click.option(
+        "--public/--not-public", "exposure", default=None,
+        help="The 'exposure' dimension: only publicly-exposed (or only "
+             "non-public) stores. Omit for no constraint.",
+    )(f)
+    f = click.option(
+        "--sensitive/--not-sensitive", "sensitivity", default=None,
+        help="The 'sensitivity' dimension: only sensitive (or only "
+             "non-sensitive) stores. Omit for no constraint.",
+    )(f)
+    f = click.option(
+        "--data-class", "data_classes", multiple=True,
+        help="Filter by content class (pii, secrets, ...); repeatable (OR).",
+    )(f)
+    f = click.option(
+        "--tier", "tiers", multiple=True,
+        help="Filter by criticality tier; repeatable (OR).",
+    )(f)
+    f = click.option(
+        "--store-kind", "store_kinds", multiple=True,
+        help="Filter by store kind (bucket, sql_instance, ...); "
+             "repeatable (OR).",
+    )(f)
+    f = click.option(
+        "--region", "regions", multiple=True,
+        help="Filter by region; repeatable (OR).",
+    )(f)
+    f = click.option(
+        "--account", "accounts", multiple=True,
+        help="Filter by account/project; repeatable (OR).",
+    )(f)
+    f = click.option(
+        "--provider", "providers", multiple=True,
+        help="Filter by provider; repeatable (OR).",
+    )(f)
+    return f
+
+
 def _sort_options(f):
     f = click.option(
         "--order", default=None, type=_ORDER_CHOICES,
@@ -930,12 +1202,13 @@ def group() -> None:
       risk-trend          Risk-score history
       scan-status         Cloud-collection run status per provider
       topology            Pre-aggregated estate topology (exact at scale)
+      free-tier           Free-tier standing and the limits that apply
       fleet overview      Multi-org fleet posture board (MSSP)
-      finding ...         Findings worklist + triage (resolve, owner, ticket, classes)
+      finding ...         Findings worklist + triage (resolve, owner, ticket, causes)
       attack-path list    Headline toxic-combination attack paths
-      ciem ...            Identity access views (public-access, facets, identity)
+      ciem ...            Identity access views (public-access, facets, identities)
       inventory ...       Cloud resource inventory
-      data-security ...   DSPM data-store facets
+      data-security ...   DSPM data-store facets + store list
       resource get        Canonical record for any urn
       graph neighbors     1-hop graph expansion around a urn
       query ...           Graph queries (list pack, run)
@@ -1027,6 +1300,19 @@ def topology(ctx) -> None:
     _output(ctx, cs.get_topology())
 
 
+@group.command("free-tier")
+@pass_context
+def free_tier(ctx) -> None:
+    """Free-tier standing and the limits that apply to the org.
+
+    \b
+    Example:
+      limacharlie cloudsec free-tier
+    """
+    cs = _get_cloudsec(ctx)
+    _output(ctx, cs.get_free_tier())
+
+
 # ---------------------------------------------------------------------------
 # fleet subgroup (multi-org)
 # ---------------------------------------------------------------------------
@@ -1083,13 +1369,16 @@ def finding_group() -> None:
 @_paging_options
 @pass_context
 def finding_list(ctx, severities, finding_classes, statuses, accounts,
-                 reachable, kev, q, sort, order, cursor, limit) -> None:
+                 owners, unassigned, reachable, kev, q, sort, order,
+                 cursor, limit) -> None:
     """List the merged, risk-ranked cloud-security findings.
 
     \b
     Examples:
       limacharlie cloudsec finding list --severity CRITICAL --severity HIGH
       limacharlie cloudsec finding list --class public_exposure --kev
+      limacharlie cloudsec finding list --owner alice@corp.com
+      limacharlie cloudsec finding list --unassigned
     """
     cs = _get_cloudsec(ctx)
     _output(ctx, cs.list_findings(
@@ -1097,6 +1386,7 @@ def finding_list(ctx, severities, finding_classes, statuses, accounts,
         finding_class=list(finding_classes) or None,
         status=list(statuses) or None,
         account=list(accounts) or None,
+        owner=_owner_selector(owners, unassigned),
         reachable=reachable,
         kev=kev,
         q=q,
@@ -1109,14 +1399,20 @@ def finding_list(ctx, severities, finding_classes, statuses, accounts,
 
 @finding_group.command("facets")
 @_finding_filter_options
+@click.option("--owner-pin", "owner_pins", multiple=True,
+              help="Keep these owners in the capped 'owner' facet even when "
+                   "they would not rank into it (pass your own identity); "
+                   "repeatable. NOT a filter — selects no rows, changes no "
+                   "count.")
 @pass_context
 def finding_facets(ctx, severities, finding_classes, statuses, accounts,
-                   reachable, kev, q) -> None:
+                   owners, unassigned, reachable, kev, q, owner_pins) -> None:
     """Cross-filtered facet counts for the findings worklist.
 
     \b
-    Example:
+    Examples:
       limacharlie cloudsec finding facets --severity CRITICAL
+      limacharlie cloudsec finding facets --owner-pin me@corp.com
     """
     cs = _get_cloudsec(ctx)
     _output(ctx, cs.get_finding_facets(
@@ -1124,9 +1420,45 @@ def finding_facets(ctx, severities, finding_classes, statuses, accounts,
         finding_class=list(finding_classes) or None,
         status=list(statuses) or None,
         account=list(accounts) or None,
+        owner=_owner_selector(owners, unassigned),
+        owner_pin=list(owner_pins) or None,
         reachable=reachable,
         kev=kev,
         q=q,
+    ))
+
+
+@finding_group.command("causes")
+@_finding_filter_options
+@click.option("--cause", default=None,
+              help="One cause key: return the exact count for that cause "
+                   "alone instead of the ranked rollup.")
+@click.option("--limit", default=None, type=int,
+              help="Rollup size (default 20, cap 200). Not a page size — the "
+                   "rollup is not paginated; 'distinct' reports the tail.")
+@pass_context
+def finding_causes(ctx, severities, finding_classes, statuses, accounts,
+                   owners, unassigned, reachable, kev, q, cause,
+                   limit) -> None:
+    """Findings grouped by CAUSE: one edit that closes N findings.
+
+    \b
+    Examples:
+      limacharlie cloudsec finding causes --severity CRITICAL --limit 5
+      limacharlie cloudsec finding causes --cause "lcrn:...:firewalls/allow-all"
+    """
+    cs = _get_cloudsec(ctx)
+    _output(ctx, cs.list_finding_causes(
+        cause=cause,
+        severity=list(severities) or None,
+        finding_class=list(finding_classes) or None,
+        status=list(statuses) or None,
+        account=list(accounts) or None,
+        owner=_owner_selector(owners, unassigned),
+        reachable=reachable,
+        kev=kev,
+        q=q,
+        limit=limit,
     ))
 
 
@@ -1293,16 +1625,76 @@ def ciem_public_access(ctx) -> None:
 
 
 @ciem_group.command("facets")
+@_identity_filter_options
 @pass_context
-def ciem_facets(ctx) -> None:
-    """CIEM identity facet counts.
+def ciem_facets(ctx, sources, accounts, regions, kinds, criticalities,
+                risk_bands, mfa, admin, external, public, disabled,
+                crown_jewel, can_escalate, dormant_90d, with_sensitive,
+                q) -> None:
+    """CIEM identity facet counts (cross-filtered by the same selectors).
 
     \b
-    Example:
+    Examples:
       limacharlie cloudsec ciem facets
+      limacharlie cloudsec ciem facets --kind service_account --admin
     """
     cs = _get_cloudsec(ctx)
-    _output(ctx, cs.get_identity_facets())
+    _output(ctx, cs.get_identity_facets(
+        source=list(sources) or None,
+        account=list(accounts) or None,
+        region=list(regions) or None,
+        kind=list(kinds) or None,
+        criticality=list(criticalities) or None,
+        risk_band=list(risk_bands) or None,
+        mfa=mfa,
+        admin=admin,
+        external=external,
+        public=public,
+        disabled=disabled,
+        crown_jewel=crown_jewel,
+        can_escalate=can_escalate,
+        dormant_90d=dormant_90d,
+        with_sensitive=with_sensitive,
+        q=q,
+    ))
+
+
+@ciem_group.command("identities")
+@_identity_filter_options
+@_paging_options
+@pass_context
+def ciem_identities(ctx, sources, accounts, regions, kinds, criticalities,
+                    risk_bands, mfa, admin, external, public, disabled,
+                    crown_jewel, can_escalate, dormant_90d, with_sensitive,
+                    q, cursor, limit) -> None:
+    """One risk-ranked page of the identity access population.
+
+    \b
+    Examples:
+      limacharlie cloudsec ciem identities --limit 50
+      limacharlie cloudsec ciem identities --external --with-sensitive
+    """
+    cs = _get_cloudsec(ctx)
+    _output(ctx, cs.list_identity_access(
+        source=list(sources) or None,
+        account=list(accounts) or None,
+        region=list(regions) or None,
+        kind=list(kinds) or None,
+        criticality=list(criticalities) or None,
+        risk_band=list(risk_bands) or None,
+        mfa=mfa,
+        admin=admin,
+        external=external,
+        public=public,
+        disabled=disabled,
+        crown_jewel=crown_jewel,
+        can_escalate=can_escalate,
+        dormant_90d=dormant_90d,
+        with_sensitive=with_sensitive,
+        q=q,
+        cursor=cursor,
+        limit=limit,
+    ))
 
 
 @ciem_group.command("identity")
@@ -1374,16 +1766,60 @@ def data_security_group() -> None:
 
 
 @data_security_group.command("facets")
+@_data_store_filter_options
 @pass_context
-def data_security_facets(ctx) -> None:
-    """DSPM data-store facet counts.
+def data_security_facets(ctx, providers, accounts, regions, store_kinds,
+                         tiers, data_classes, sensitivity, exposure,
+                         q) -> None:
+    """DSPM data-store facet counts (cross-filtered by the same selectors).
 
     \b
-    Example:
+    Examples:
       limacharlie cloudsec data-security facets
+      limacharlie cloudsec data-security facets --store-kind bucket
     """
     cs = _get_cloudsec(ctx)
-    _output(ctx, cs.get_data_security_facets())
+    _output(ctx, cs.get_data_security_facets(
+        provider=list(providers) or None,
+        account=list(accounts) or None,
+        region=list(regions) or None,
+        store_kind=list(store_kinds) or None,
+        tier=list(tiers) or None,
+        data_class=list(data_classes) or None,
+        sensitivity=sensitivity,
+        exposure=exposure,
+        q=q,
+    ))
+
+
+@data_security_group.command("stores")
+@_data_store_filter_options
+@_paging_options
+@pass_context
+def data_security_stores(ctx, providers, accounts, regions, store_kinds,
+                         tiers, data_classes, sensitivity, exposure, q,
+                         cursor, limit) -> None:
+    """One keyset page of the org's data stores.
+
+    \b
+    Examples:
+      limacharlie cloudsec data-security stores --limit 50
+      limacharlie cloudsec data-security stores --sensitive --public
+    """
+    cs = _get_cloudsec(ctx)
+    _output(ctx, cs.list_data_stores(
+        provider=list(providers) or None,
+        account=list(accounts) or None,
+        region=list(regions) or None,
+        store_kind=list(store_kinds) or None,
+        tier=list(tiers) or None,
+        data_class=list(data_classes) or None,
+        sensitivity=sensitivity,
+        exposure=exposure,
+        q=q,
+        cursor=cursor,
+        limit=limit,
+    ))
 
 
 # ---------------------------------------------------------------------------
@@ -1987,13 +2423,15 @@ def export_group() -> None:
 @_export_output_option
 @pass_context
 def export_findings(ctx, severities, finding_classes, statuses, accounts,
-                    reachable, kev, q, sort, order, output_path) -> None:
+                    owners, unassigned, reachable, kev, q, sort, order,
+                    output_path) -> None:
     """Export the (filtered) findings worklist as CSV.
 
     \b
     Examples:
       limacharlie cloudsec export findings -o findings.csv
       limacharlie cloudsec export findings --severity CRITICAL --status open
+      limacharlie cloudsec export findings --owner alice@corp.com
     """
     cs = _get_cloudsec(ctx)
     _emit_csv(ctx, cs.export_findings_csv(
@@ -2001,6 +2439,7 @@ def export_findings(ctx, severities, finding_classes, statuses, accounts,
         finding_class=list(finding_classes) or None,
         status=list(statuses) or None,
         account=list(accounts) or None,
+        owner=_owner_selector(owners, unassigned),
         reachable=reachable,
         kev=kev,
         q=q,

--- a/limacharlie/commands/cloudsec.py
+++ b/limacharlie/commands/cloudsec.py
@@ -142,6 +142,12 @@ it (pass your own identity so your row stays reachable on an estate
 with more owners than the cap). It is NOT a filter: it selects no rows
 and changes no count.
 
+That guarantee is bounded by the same cap rather than absolute: pins
+share the 50 slots with any --owner values (and the unassigned bucket
+takes one, outranking every pin), so past ~50 combined a pin can still
+be dropped and 'owner_truncated' cannot tell you it was. Render a
+pinned-but-absent owner as zero.
+
 Examples:
   limacharlie cloudsec finding facets --severity CRITICAL
   limacharlie cloudsec finding facets --owner-pin me@corp.com
@@ -152,6 +158,13 @@ Findings grouped by their CAUSE — the mutable object (a firewall
 rule, the principal an attack path's grants land on) whose single
 edit resolves every finding under it. Lets a worklist be worked by
 fix instead of by row: "change this one thing, close N findings".
+
+Only CAUSE-BEARING findings are in scope, and that is a small slice of
+an estate: causes are stamped on the attack-path classes, while
+vulnerability findings (~90% of a typical estate) deliberately carry
+none. So these counts never sum to the worklist total, and
+'--class vulnerability' legitimately returns no causes at all — that
+means "no shared fix on this class", not "no findings".
 
 Takes the same filters as 'finding list', so a rollup can be scoped
 exactly like the list it summarizes. Pass --cause for the count of
@@ -1120,7 +1133,9 @@ def _identity_filter_options(f):
         "--unclassified", "unclassified", is_flag=True, default=False,
         help="Include identities with no TIER assigned; combines with "
              "--criticality. Wider than --no-crown-jewel: a declared crown "
-             "jewel whose policy rule sets no tier lands here too.",
+             "jewel whose policy rule sets no tier lands here too. The "
+             "criticality facet does not count this bucket, so 'facets' "
+             "cannot predict how many rows it returns.",
     )(f)
     f = click.option(
         "--criticality", "criticalities", multiple=True, type=_TIER_CHOICES,
@@ -1180,7 +1195,8 @@ def _data_store_filter_options(f):
     f = click.option(
         "--unclassified", "unclassified", is_flag=True, default=False,
         help="Include stores with no criticality tier assigned; combines "
-             "with --tier.",
+             "with --tier. The tier facet does not count this bucket, so "
+             "'facets' cannot predict how many rows it returns.",
     )(f)
     f = click.option(
         "--tier", "tiers", multiple=True, type=_TIER_CHOICES,
@@ -1440,7 +1456,9 @@ def finding_list(ctx, severities, finding_classes, statuses, accounts,
               help="Keep these owners in the capped 'owner' facet even when "
                    "they would not rank into it (pass your own identity); "
                    "repeatable. NOT a filter — selects no rows, changes no "
-                   "count.")
+                   "count. Bounded by the cap: pins share the facet's 50 "
+                   "slots with any --owner values, so past ~50 combined a "
+                   "pin can still be dropped.")
 @pass_context
 def finding_facets(ctx, severities, finding_classes, statuses, accounts,
                    owners, unassigned, reachable, kev, q, owner_pins) -> None:

--- a/limacharlie/commands/cloudsec.py
+++ b/limacharlie/commands/cloudsec.py
@@ -154,11 +154,17 @@ edit resolves every finding under it. Lets a worklist be worked by
 fix instead of by row: "change this one thing, close N findings".
 
 Takes the same filters as 'finding list', so a rollup can be scoped
-exactly like the list it summarizes. Pass --cause for the exact
-count of one cause; omit it for the top causes by count (--limit,
-default 20, cap 200). 'distinct' is the total number of matching
-causes, so you can tell how much tail the head hides — the counts
-themselves are always exact.
+exactly like the list it summarizes. Pass --cause for the count of
+one cause (an empty 'causes' means no finding under the filter
+carries it); omit it for the top causes by count (--limit, default
+20, cap 200). 'distinct' is the total number of matching causes, so
+you can tell how much tail the head hides.
+
+A count is a whole-population figure rather than a capped one, but it
+is computed on each finding's STORED status, which lags a disposition
+that expired on its own: an acceptance past its expiry still counts as
+accepted until the backstop rewrites it, while reading that finding
+returns it as open. Treat a count as a ranking and scale signal.
 
 'kind' is an open vocabulary that grows server-side; treat an
 unrecognized value as "some object" rather than assuming a class.
@@ -362,7 +368,7 @@ materialized graph store under the same selectors as
 estate size instead of client-filtering a capped walk.
 
 --sensitive / --public are tri-state: omitting one leaves the
-dimension unconstrained; --not-sensitive / --not-public pin it to
+dimension unconstrained; --no-sensitive / --no-public pin it to
 false. Rows are ordered by a stable stored key, so a full walk with
 --cursor is safe.
 
@@ -945,6 +951,16 @@ _SUGGEST_DIMENSION_CHOICES = click.Choice(
 # "off"), and the set is closed server-side — a Choice keeps a typo from
 # reading as "no MFA constraint".
 _MFA_CHOICES = click.Choice(["on", "off", "unknown"], case_sensitive=False)
+# Risk bands partition the whole score space and criticality tiers are a
+# fixed assign-side vocabulary, so both are closed sets like --kind is not.
+# They get a Choice because the backend fails CLOSED on an unknown value:
+# an unrecognized band contributes a FALSE predicate and a misspelled tier
+# matches no row, so a typo would exit 0 with an empty result under a
+# filter the user can see is applied — the worst of both answers.
+_RISK_BAND_CHOICES = click.Choice(
+    ["critical", "high", "medium", "low"], case_sensitive=False,
+)
+_TIER_CHOICES = _RISK_BAND_CHOICES
 # Provider and CAASM-source values are deliberately NOT click.Choice lists:
 # both are growing server-side registries (new providers/sources ship without
 # a CLI release) and the server rejects unknown values with a clean error.
@@ -962,18 +978,20 @@ def _paging_options(f):
     return f
 
 
-def _owner_selector(owners, unassigned: bool) -> list[str] | None:
-    """Fold --owner/--unassigned into the wire `owner` selector.
+def _selector_with_empty(values, include_empty: bool) -> list[str] | None:
+    """Fold a "…or none of them" flag into a repeatable wire selector.
 
-    The unassigned bucket IS an owner value on the wire: the empty
-    string. It rides the same repeatable selector, so "mine or
-    nobody's" is one filter with two values. No selection at all
-    returns None so the request carries no owner constraint.
+    Several dimensions express "not set" as the EMPTY value rather than
+    as a separate parameter: an unowned finding, an unclassified
+    criticality tier. That value rides the same repeatable selector, so
+    "mine or nobody's" is one filter with two values. No selection at
+    all returns None, so the request carries no constraint on the
+    dimension (an empty list would narrow it to the not-set bucket).
     """
-    values = list(owners)
-    if unassigned:
-        values.append("")
-    return values or None
+    out = list(values)
+    if include_empty:
+        out.append("")
+    return out or None
 
 
 def _finding_filter_options(f):
@@ -1092,12 +1110,19 @@ def _identity_filter_options(f):
              "— it is NOT 'off'.",
     )(f)
     f = click.option(
-        "--risk-band", "risk_bands", multiple=True,
-        help="Filter by risk band (critical/high/medium/low); repeatable (OR).",
+        "--risk-band", "risk_bands", multiple=True, type=_RISK_BAND_CHOICES,
+        help="Filter by risk band; repeatable (OR). The band token the rail "
+             "renders, not a numeric range.",
     )(f)
     f = click.option(
-        "--criticality", "criticalities", multiple=True,
-        help="Filter by crown-jewel tier; repeatable (OR).",
+        "--unclassified", "unclassified", is_flag=True, default=False,
+        help="Include identities with no crown-jewel tier assigned; "
+             "combines with --criticality.",
+    )(f)
+    f = click.option(
+        "--criticality", "criticalities", multiple=True, type=_TIER_CHOICES,
+        help="Filter by crown-jewel tier; repeatable (OR). Use "
+             "--unclassified for identities with no tier.",
     )(f)
     f = click.option(
         "--kind", "kinds", multiple=True,
@@ -1117,7 +1142,8 @@ def _identity_filter_options(f):
     f = click.option(
         "--source", "sources", multiple=True,
         help="Filter by producing sweep (okta, gcp, google_workspace, ...); "
-             "repeatable (OR). Alias of --provider.",
+             "repeatable (OR). Same dimension 'inventory list' calls "
+             "--provider.",
     )(f)
     return f
 
@@ -1133,12 +1159,12 @@ def _data_store_filter_options(f):
         help="Substring filter over the store's name/urn.",
     )(f)
     f = click.option(
-        "--public/--not-public", "exposure", default=None,
+        "--public/--no-public", "exposure", default=None,
         help="The 'exposure' dimension: only publicly-exposed (or only "
              "non-public) stores. Omit for no constraint.",
     )(f)
     f = click.option(
-        "--sensitive/--not-sensitive", "sensitivity", default=None,
+        "--sensitive/--no-sensitive", "sensitivity", default=None,
         help="The 'sensitivity' dimension: only sensitive (or only "
              "non-sensitive) stores. Omit for no constraint.",
     )(f)
@@ -1147,8 +1173,14 @@ def _data_store_filter_options(f):
         help="Filter by content class (pii, secrets, ...); repeatable (OR).",
     )(f)
     f = click.option(
-        "--tier", "tiers", multiple=True,
-        help="Filter by criticality tier; repeatable (OR).",
+        "--unclassified", "unclassified", is_flag=True, default=False,
+        help="Include stores with no criticality tier assigned; combines "
+             "with --tier.",
+    )(f)
+    f = click.option(
+        "--tier", "tiers", multiple=True, type=_TIER_CHOICES,
+        help="Filter by criticality tier; repeatable (OR). Use "
+             "--unclassified for stores with no tier.",
     )(f)
     f = click.option(
         "--store-kind", "store_kinds", multiple=True,
@@ -1204,9 +1236,9 @@ def group() -> None:
       topology            Pre-aggregated estate topology (exact at scale)
       free-tier           Free-tier standing and the limits that apply
       fleet overview      Multi-org fleet posture board (MSSP)
-      finding ...         Findings worklist + triage (resolve, owner, ticket, causes)
+      finding ...         Findings worklist + triage (resolve, owner, ticket, causes, classes)
       attack-path list    Headline toxic-combination attack paths
-      ciem ...            Identity access views (public-access, facets, identities)
+      ciem ...            Identity access (public-access, facets, identities, identity)
       inventory ...       Cloud resource inventory
       data-security ...   DSPM data-store facets + store list
       resource get        Canonical record for any urn
@@ -1386,7 +1418,7 @@ def finding_list(ctx, severities, finding_classes, statuses, accounts,
         finding_class=list(finding_classes) or None,
         status=list(statuses) or None,
         account=list(accounts) or None,
-        owner=_owner_selector(owners, unassigned),
+        owner=_selector_with_empty(owners, unassigned),
         reachable=reachable,
         kev=kev,
         q=q,
@@ -1420,7 +1452,7 @@ def finding_facets(ctx, severities, finding_classes, statuses, accounts,
         finding_class=list(finding_classes) or None,
         status=list(statuses) or None,
         account=list(accounts) or None,
-        owner=_owner_selector(owners, unassigned),
+        owner=_selector_with_empty(owners, unassigned),
         owner_pin=list(owner_pins) or None,
         reachable=reachable,
         kev=kev,
@@ -1454,7 +1486,7 @@ def finding_causes(ctx, severities, finding_classes, statuses, accounts,
         finding_class=list(finding_classes) or None,
         status=list(statuses) or None,
         account=list(accounts) or None,
-        owner=_owner_selector(owners, unassigned),
+        owner=_selector_with_empty(owners, unassigned),
         reachable=reachable,
         kev=kev,
         q=q,
@@ -1628,9 +1660,9 @@ def ciem_public_access(ctx) -> None:
 @_identity_filter_options
 @pass_context
 def ciem_facets(ctx, sources, accounts, regions, kinds, criticalities,
-                risk_bands, mfa, admin, external, public, disabled,
-                crown_jewel, can_escalate, dormant_90d, with_sensitive,
-                q) -> None:
+                unclassified, risk_bands, mfa, admin, external, public,
+                disabled, crown_jewel, can_escalate, dormant_90d,
+                with_sensitive, q) -> None:
     """CIEM identity facet counts (cross-filtered by the same selectors).
 
     \b
@@ -1644,7 +1676,7 @@ def ciem_facets(ctx, sources, accounts, regions, kinds, criticalities,
         account=list(accounts) or None,
         region=list(regions) or None,
         kind=list(kinds) or None,
-        criticality=list(criticalities) or None,
+        criticality=_selector_with_empty(criticalities, unclassified),
         risk_band=list(risk_bands) or None,
         mfa=mfa,
         admin=admin,
@@ -1664,9 +1696,9 @@ def ciem_facets(ctx, sources, accounts, regions, kinds, criticalities,
 @_paging_options
 @pass_context
 def ciem_identities(ctx, sources, accounts, regions, kinds, criticalities,
-                    risk_bands, mfa, admin, external, public, disabled,
-                    crown_jewel, can_escalate, dormant_90d, with_sensitive,
-                    q, cursor, limit) -> None:
+                    unclassified, risk_bands, mfa, admin, external, public,
+                    disabled, crown_jewel, can_escalate, dormant_90d,
+                    with_sensitive, q, cursor, limit) -> None:
     """One risk-ranked page of the identity access population.
 
     \b
@@ -1680,7 +1712,7 @@ def ciem_identities(ctx, sources, accounts, regions, kinds, criticalities,
         account=list(accounts) or None,
         region=list(regions) or None,
         kind=list(kinds) or None,
-        criticality=list(criticalities) or None,
+        criticality=_selector_with_empty(criticalities, unclassified),
         risk_band=list(risk_bands) or None,
         mfa=mfa,
         admin=admin,
@@ -1769,8 +1801,8 @@ def data_security_group() -> None:
 @_data_store_filter_options
 @pass_context
 def data_security_facets(ctx, providers, accounts, regions, store_kinds,
-                         tiers, data_classes, sensitivity, exposure,
-                         q) -> None:
+                         tiers, unclassified, data_classes, sensitivity,
+                         exposure, q) -> None:
     """DSPM data-store facet counts (cross-filtered by the same selectors).
 
     \b
@@ -1784,7 +1816,7 @@ def data_security_facets(ctx, providers, accounts, regions, store_kinds,
         account=list(accounts) or None,
         region=list(regions) or None,
         store_kind=list(store_kinds) or None,
-        tier=list(tiers) or None,
+        tier=_selector_with_empty(tiers, unclassified),
         data_class=list(data_classes) or None,
         sensitivity=sensitivity,
         exposure=exposure,
@@ -1797,8 +1829,8 @@ def data_security_facets(ctx, providers, accounts, regions, store_kinds,
 @_paging_options
 @pass_context
 def data_security_stores(ctx, providers, accounts, regions, store_kinds,
-                         tiers, data_classes, sensitivity, exposure, q,
-                         cursor, limit) -> None:
+                         tiers, unclassified, data_classes, sensitivity,
+                         exposure, q, cursor, limit) -> None:
     """One keyset page of the org's data stores.
 
     \b
@@ -1812,7 +1844,7 @@ def data_security_stores(ctx, providers, accounts, regions, store_kinds,
         account=list(accounts) or None,
         region=list(regions) or None,
         store_kind=list(store_kinds) or None,
-        tier=list(tiers) or None,
+        tier=_selector_with_empty(tiers, unclassified),
         data_class=list(data_classes) or None,
         sensitivity=sensitivity,
         exposure=exposure,
@@ -2439,7 +2471,7 @@ def export_findings(ctx, severities, finding_classes, statuses, accounts,
         finding_class=list(finding_classes) or None,
         status=list(statuses) or None,
         account=list(accounts) or None,
-        owner=_owner_selector(owners, unassigned),
+        owner=_selector_with_empty(owners, unassigned),
         reachable=reachable,
         kev=kev,
         q=q,

--- a/limacharlie/commands/cloudsec.py
+++ b/limacharlie/commands/cloudsec.py
@@ -279,8 +279,10 @@ The selectors CROSS-FILTER the rail: each dimension is counted under
 the other active selectors but not its own, so a value's count is
 exactly how many rows selecting it would list. With no selectors the
 response is the whole-population rollup. It takes the SAME selectors
-as 'ciem identities', so the counts and that list always describe the
-same population.
+as 'ciem identities', so the counts and that list describe the same
+population — with ONE exception: the no-tier bucket that
+--unclassified selects is skipped when counting, so it is the only
+selection whose count the rail cannot give you.
 
 --mfa unknown is everyone the MFA question does not apply to (no
 identity-provider observation, or non-human) — it is NOT 'off'. The
@@ -300,7 +302,8 @@ risk score), but server-filtered and pageable instead of a
 risk-ranked top-N.
 
 Takes the same selectors as 'ciem facets', so the rail's counts and
-this list always describe the same population. Ranked by risk score
+this list describe the same population — except for the no-tier bucket
+(--unclassified), which the rail skips when counting. Ranked by risk score
 descending by default; a walk that spans a projector recompute can
 move a row across the cursor, so use it for browsing rather than for
 exact exports.
@@ -367,7 +370,9 @@ data stores plus store-kind, sensitivity, and exposure histograms.
 
 The selectors cross-filter the rail (each dimension counted under the
 other active selectors but not its own) and are the SAME ones 'stores'
-takes, so the counts always describe the population that list returns.
+takes, so the counts describe the population that list returns — except
+for the no-tier bucket (--unclassified), which the rail skips when
+counting and therefore cannot predict.
 
 Examples:
   limacharlie cloudsec data-security facets
@@ -1172,7 +1177,8 @@ def _data_store_filter_options(f):
     """The Data Security cross-filter (shared by data-security facets/stores).
 
     Shared for the same reason as the identity filter: the facet counts
-    must describe the population the store list returns.
+    must describe the population the store list returns. The one value
+    this cannot cover is the empty tier, which the facet pass skips.
     """
     f = click.option(
         "-q", "--search", "q", default=None,

--- a/limacharlie/commands/cloudsec.py
+++ b/limacharlie/commands/cloudsec.py
@@ -1091,7 +1091,9 @@ def _identity_filter_options(f):
         ("--can-escalate/--no-can-escalate",
          "Can (or cannot) escalate its own privileges."),
         ("--crown-jewel/--no-crown-jewel",
-         "Declared sensitive by the org's cloudsec_policy (or not)."),
+         "Declared sensitive by the org's cloudsec_policy (or not) — the "
+         "flag any matching rule sets, independent of whether that rule "
+         "also assigned a tier (see --criticality)."),
         ("--disabled/--no-disabled", "Disabled (or enabled) identities."),
         ("--public/--no-public",
          "Public principals (allUsers / allAuthenticatedUsers and "
@@ -1116,12 +1118,15 @@ def _identity_filter_options(f):
     )(f)
     f = click.option(
         "--unclassified", "unclassified", is_flag=True, default=False,
-        help="Include identities with no crown-jewel tier assigned; "
-             "combines with --criticality.",
+        help="Include identities with no TIER assigned; combines with "
+             "--criticality. Wider than --no-crown-jewel: a declared crown "
+             "jewel whose policy rule sets no tier lands here too.",
     )(f)
     f = click.option(
         "--criticality", "criticalities", multiple=True, type=_TIER_CHOICES,
-        help="Filter by crown-jewel tier; repeatable (OR). Use "
+        help="Filter by assigned criticality tier; repeatable (OR). The tier "
+             "a cloudsec_policy rule assigned, which is a different column "
+             "from the crown-jewel flag --crown-jewel reads. Use "
              "--unclassified for identities with no tier.",
     )(f)
     f = click.option(
@@ -1463,8 +1468,9 @@ def finding_facets(ctx, severities, finding_classes, statuses, accounts,
 @finding_group.command("causes")
 @_finding_filter_options
 @click.option("--cause", default=None,
-              help="One cause key: return the exact count for that cause "
-                   "alone instead of the ranked rollup.")
+              help="One cause key: return the count for that cause alone "
+                   "instead of the ranked rollup (empty when no finding "
+                   "under the filter carries it).")
 @click.option("--limit", default=None, type=int,
               help="Rollup size (default 20, cap 200). Not a page size — the "
                    "rollup is not paginated; 'distinct' reports the tail.")

--- a/limacharlie/sdk/cloudsec.py
+++ b/limacharlie/sdk/cloudsec.py
@@ -341,6 +341,14 @@ class CloudSec:
                 The unassigned bucket is always included and outranks every
                 pin.
 
+                The guarantee is BOUNDED BY THAT CAP, not absolute: the
+                pins and the active ``owner`` filter share the 50 slots
+                (and the unassigned bucket takes one), so past ~50
+                combined values a pin can still be dropped — and
+                ``owner_truncated`` cannot distinguish that from ordinary
+                tail truncation. Render a pinned-but-absent owner as zero
+                rather than assuming the map is complete.
+
         Returns:
             ``{"facets": {..., "owner": {"": 12, "alice@corp.com": 3},
             "owner_truncated": false}}``.

--- a/limacharlie/sdk/cloudsec.py
+++ b/limacharlie/sdk/cloudsec.py
@@ -116,8 +116,9 @@ def _finding_query_pairs(
 
 
 # The merged-identity cross-filter, shared verbatim by the identity facet
-# rail and the ranked Access list so a facet count always describes the
-# population the list would return.
+# rail and the ranked Access list so a facet count describes the
+# population the list would return (the empty-tier bucket excepted — the
+# rail does not count it; see get_identity_facets).
 def _identity_query_pairs(
     *,
     provider: list[str] | None = None,
@@ -586,8 +587,9 @@ class CloudSec:
         """CIEM identity facet counts.
 
         Takes the same cross-filter as :meth:`list_identity_access`, so a
-        facet count always describes the population that list would
-        return. With no selectors the response is the whole-population
+        facet count describes the population that list would return — with
+        the single documented exception of the no-tier bucket under
+        ``criticality`` (see below). With no selectors the response is the whole-population
         rollup. Each dimension is counted under the OTHER active
         selectors but not its own, so a value's count is exactly how many
         rows selecting it would list.
@@ -776,10 +778,15 @@ class CloudSec:
         """DSPM data-store facet counts (total/sensitive/public, store kinds).
 
         Takes the same cross-filter as :meth:`list_data_stores`, so the
-        counts always describe the population that list would return. Each
+        counts describe the population that list would return. Each
         dimension is counted under the OTHER active selectors but not its
         own. With no selectors the response is the whole-population
         rollup.
+
+            ONE exception to that: the no-tier bucket. Both this rail and
+            the identity rail skip the empty value when counting, so
+            selecting it (``tier=[""]``) returns rows the facets never
+            counted. Every other value's count predicts its list exactly.
 
         Args:
             provider, account, region: Placement filters, OR'd within a
@@ -789,7 +796,10 @@ class CloudSec:
             tier: Criticality tiers, OR'd. Same closed vocabulary as the
                 identity filter's ``criticality`` — ``critical`` /
                 ``high`` / ``medium`` / ``low``, plus the empty string for
-                stores with no tier assigned.
+                stores with no tier assigned. That empty-tier bucket is the
+                ONE selection this rail does not count (the tier facet
+                skips it), so it is the one case where a facet count cannot
+                predict the list.
             data_class: Content classes (``pii``, ``secrets``, ...), OR'd.
             sensitivity: Tri-state — ``True`` only sensitive stores,
                 ``False`` only non-sensitive, ``None`` unconstrained.

--- a/limacharlie/sdk/cloudsec.py
+++ b/limacharlie/sdk/cloudsec.py
@@ -2,14 +2,17 @@
 
 Wraps the ``/cloudsec/{oid}/...`` REST routes served by the API
 gateway: the merged, risk-ranked findings worklist (CSPM + attack
-paths + CIEM), the single-identity access rollup, the resource
-inventory, the pre-aggregated estate topology and security graph,
-compliance assessment, the risk overview, CAASM (third-party asset
-attack surface), sensor<->cloud-asset resolution, the finding triage
+paths + CIEM) with its facet and shared-fix (cause) rollups, the
+identity access population and single-identity rollup, the resource
+inventory, the Data Security (DSPM) store list and facets, the
+pre-aggregated estate topology and security graph, compliance
+assessment, the risk overview, CAASM (third-party asset attack
+surface), sensor<->cloud-asset resolution, the finding triage
 writes, the cloudsec_policy authoring aids (vocabulary, live
 autocomplete, and the two "Simulate" preflights), CSV exports of the
-read surface, per-provider coverage manifests, and the multi-org
-fleet overview (``/cloudsec/fleet/overview``).
+read surface, per-provider coverage manifests, the free-tier
+standing, and the multi-org fleet overview
+(``/cloudsec/fleet/overview``).
 
 Reads require the ``cloudsec.get`` permission and writes require
 ``cloudsec.set``; every route additionally requires the org to be
@@ -87,6 +90,8 @@ def _finding_query_pairs(
     finding_class: list[str] | None = None,
     status: list[str] | None = None,
     account: list[str] | None = None,
+    owner: list[str] | None = None,
+    owner_pin: list[str] | None = None,
     reachable: bool | None = None,
     kev: bool | None = None,
     q: str | None = None,
@@ -95,11 +100,79 @@ def _finding_query_pairs(
     cursor: str | None = None,
     limit: int | None = None,
 ) -> list[tuple[str, str]]:
-    """Assemble the findings worklist selectors shared by list/facets."""
+    """Assemble the findings worklist selectors shared by list/facets.
+
+    ``owner`` is the one selector here whose EMPTY value is a real
+    selection: ``owner=[""]`` asks for the UNASSIGNED bucket, so it must
+    reach the wire as ``?owner=`` rather than being dropped. Pass ``None``
+    (or ``[]``) for no owner constraint.
+    """
     return _query_pairs(
         severity=severity, finding_class=finding_class, status=status,
-        account=account, reachable=reachable, kev=kev, q=q,
+        account=account, owner=owner, owner_pin=owner_pin,
+        reachable=reachable, kev=kev, q=q,
         sort=sort, order=order, cursor=cursor, limit=limit,
+    )
+
+
+# The merged-identity cross-filter, shared verbatim by the identity facet
+# rail and the ranked Access list so a facet count always describes the
+# population the list would return.
+def _identity_query_pairs(
+    *,
+    provider: list[str] | None = None,
+    account: list[str] | None = None,
+    region: list[str] | None = None,
+    source: list[str] | None = None,
+    kind: list[str] | None = None,
+    criticality: list[str] | None = None,
+    risk_band: list[str] | None = None,
+    mfa: str | None = None,
+    admin: bool | None = None,
+    external: bool | None = None,
+    public: bool | None = None,
+    disabled: bool | None = None,
+    crown_jewel: bool | None = None,
+    can_escalate: bool | None = None,
+    dormant_90d: bool | None = None,
+    with_sensitive: bool | None = None,
+    q: str | None = None,
+    cursor: str | None = None,
+    limit: int | None = None,
+) -> list[tuple[str, str]]:
+    """Assemble the identity cross-filter shared by facets/access list."""
+    return _query_pairs(
+        provider=provider, account=account, region=region, source=source,
+        kind=kind, criticality=criticality, risk_band=risk_band, mfa=mfa,
+        admin=admin, external=external, public=public, disabled=disabled,
+        crown_jewel=crown_jewel, can_escalate=can_escalate,
+        dormant_90d=dormant_90d, with_sensitive=with_sensitive,
+        q=q, cursor=cursor, limit=limit,
+    )
+
+
+# The Data Security (DSPM) cross-filter, shared by the store facets and the
+# store list for the same reason.
+def _data_store_query_pairs(
+    *,
+    provider: list[str] | None = None,
+    account: list[str] | None = None,
+    region: list[str] | None = None,
+    store_kind: list[str] | None = None,
+    tier: list[str] | None = None,
+    data_class: list[str] | None = None,
+    sensitivity: bool | None = None,
+    exposure: bool | None = None,
+    q: str | None = None,
+    cursor: str | None = None,
+    limit: int | None = None,
+) -> list[tuple[str, str]]:
+    """Assemble the data-store cross-filter shared by facets/list."""
+    return _query_pairs(
+        provider=provider, account=account, region=region,
+        store_kind=store_kind, tier=tier, data_class=data_class,
+        sensitivity=sensitivity, exposure=exposure,
+        q=q, cursor=cursor, limit=limit,
     )
 
 
@@ -189,6 +262,7 @@ class CloudSec:
         finding_class: list[str] | None = None,
         status: list[str] | None = None,
         account: list[str] | None = None,
+        owner: list[str] | None = None,
         reachable: bool | None = None,
         kev: bool | None = None,
         q: str | None = None,
@@ -214,6 +288,13 @@ class CloudSec:
                 ``open`` again. The same three values are the keys of the
                 ``status`` map returned by :meth:`get_finding_facets`.
             account: Cloud account filter values, OR'd.
+            owner: Assigned-owner filter values, OR'd. The EMPTY STRING is
+                a real value selecting the UNASSIGNED bucket, so
+                ``owner=[""]`` is the untriaged backlog and
+                ``owner=["alice@corp.com", ""]`` is "mine or nobody's".
+                Pass ``None`` for no owner constraint. Owners are set with
+                :meth:`set_finding_owner` and counted by the ``owner``
+                facet of :meth:`get_finding_facets`.
             reachable: Only findings on (non-)reachable resources.
             kev: Only findings with (without) a KEV vulnerability.
             q: Substring search.
@@ -228,7 +309,7 @@ class CloudSec:
         """
         return self._get("findings", _finding_query_pairs(
             severity=severity, finding_class=finding_class, status=status,
-            account=account, reachable=reachable, kev=kev, q=q,
+            account=account, owner=owner, reachable=reachable, kev=kev, q=q,
             sort=sort, order=order, cursor=cursor, limit=limit,
         ))
 
@@ -239,6 +320,8 @@ class CloudSec:
         finding_class: list[str] | None = None,
         status: list[str] | None = None,
         account: list[str] | None = None,
+        owner: list[str] | None = None,
+        owner_pin: list[str] | None = None,
         reachable: bool | None = None,
         kev: bool | None = None,
         q: str | None = None,
@@ -248,13 +331,74 @@ class CloudSec:
         Takes the same filter selectors as :meth:`list_findings`; each
         facet dimension is counted against the other active filters.
 
+        Args:
+            owner_pin: Owners to keep in the ``owner`` facet even when they
+                would not rank into it. NOT a filter — it selects no rows
+                and changes no count. The ``owner`` facet is capped at the
+                top 50 owners by count (``owner_truncated`` reports whether
+                any were dropped), so pin the calling user to keep their own
+                row reachable on an estate with more owners than the cap.
+                The unassigned bucket is always included and outranks every
+                pin.
+
         Returns:
-            ``{"facets": {...}}``.
+            ``{"facets": {..., "owner": {"": 12, "alice@corp.com": 3},
+            "owner_truncated": false}}``.
         """
         return self._get("findings/facets", _finding_query_pairs(
             severity=severity, finding_class=finding_class, status=status,
-            account=account, reachable=reachable, kev=kev, q=q,
+            account=account, owner=owner, owner_pin=owner_pin,
+            reachable=reachable, kev=kev, q=q,
         ))
+
+    def list_finding_causes(
+        self,
+        *,
+        cause: str | None = None,
+        severity: list[str] | None = None,
+        finding_class: list[str] | None = None,
+        status: list[str] | None = None,
+        account: list[str] | None = None,
+        owner: list[str] | None = None,
+        reachable: bool | None = None,
+        kev: bool | None = None,
+        q: str | None = None,
+        limit: int | None = None,
+    ) -> dict[str, Any]:
+        """Findings grouped by their CAUSE (the shared-fix rollup).
+
+        A cause is the mutable object — a firewall rule, the principal an
+        attack path's grants land on — whose single edit resolves every
+        finding grouped under it, so a worklist can be worked by fix
+        instead of by row. Takes the same filter selectors as
+        :meth:`list_findings`, so a rollup can be scoped exactly like the
+        list it summarizes.
+
+        Args:
+            cause: One cause key. Set it for the exact count of that cause
+                alone (returned as a single-entry ``causes``); omit it for
+                the top causes by count. Clamped to 512 chars server-side.
+            limit: Rollup size when ``cause`` is omitted (default 20,
+                server cap 200). Not a page size — the rollup is not
+                paginated, and ``distinct`` reports the tail it hides.
+
+        Returns:
+            ``{"causes": [{"key": str, "name": str, "kind": str,
+            "count": int}, ...], "distinct": int}``. ``kind`` is an OPEN
+            vocabulary (``firewall_rule``, ``entitled_identity``, ...) that
+            grows server-side — treat an unrecognized value as "some
+            object" rather than assuming a class. ``distinct`` is the total
+            number of causes matching the filter and MAY exceed
+            ``len(causes)`` when ``limit`` truncates; the counts themselves
+            are always exact.
+        """
+        pairs = _finding_query_pairs(
+            severity=severity, finding_class=finding_class, status=status,
+            account=account, owner=owner, reachable=reachable, kev=kev, q=q,
+            limit=limit,
+        )
+        _add_scalar(pairs, "cause", cause)
+        return self._get("findings/causes", pairs)
 
     def get_finding(self, finding_id: str) -> dict[str, Any]:
         """Get one finding by id (e.g. ``fnd_<fingerprint>``).
@@ -388,13 +532,121 @@ class CloudSec:
         """
         return self._get("ciem/public-access")
 
-    def get_identity_facets(self) -> dict[str, Any]:
+    def get_identity_facets(
+        self,
+        *,
+        provider: list[str] | None = None,
+        account: list[str] | None = None,
+        region: list[str] | None = None,
+        source: list[str] | None = None,
+        kind: list[str] | None = None,
+        criticality: list[str] | None = None,
+        risk_band: list[str] | None = None,
+        mfa: str | None = None,
+        admin: bool | None = None,
+        external: bool | None = None,
+        public: bool | None = None,
+        disabled: bool | None = None,
+        crown_jewel: bool | None = None,
+        can_escalate: bool | None = None,
+        dormant_90d: bool | None = None,
+        with_sensitive: bool | None = None,
+        q: str | None = None,
+    ) -> dict[str, Any]:
         """CIEM identity facet counts.
+
+        Takes the same cross-filter as :meth:`list_identity_access`, so a
+        facet count always describes the population that list would
+        return. With no selectors the response is the whole-population
+        rollup. Each dimension is counted under the OTHER active
+        selectors but not its own, so a value's count is exactly how many
+        rows selecting it would list.
+
+        Args:
+            provider: Producing sweeps, OR'd (alias of ``source``).
+            account, region: Placement filters, OR'd. These two are served
+                from the projector's merged view; on a tenant whose view
+                has not been built yet the call FAILS rather than
+                returning a misleading zero.
+            source: Producing sweeps (``okta``, ``gcp``,
+                ``google_workspace``, ...), OR'd.
+            kind: Identity kinds (``user``, ``service_account``, ``group``,
+                ``ai_agent``, ...), OR'd.
+            criticality: Crown-jewel tiers, OR'd.
+            risk_band: Risk bands (``critical``/``high``/``medium``/
+                ``low``) — the band token, not a numeric range, OR'd.
+            mfa: ``on`` | ``off`` | ``unknown``. ``unknown`` is everyone
+                the MFA question does not apply to (no identity-provider
+                observation, or non-human) — it is NOT ``off``.
+            admin, external, public, disabled, crown_jewel, can_escalate,
+                dormant_90d, with_sensitive: Tri-state — ``None`` leaves
+                the dimension unconstrained, which is NOT the same as
+                ``False`` (which pins it).
+            q: Substring filter over the identity's urn/email/kind.
 
         Returns:
             ``{"facets": {...}}``.
         """
-        return self._get("ciem/facets")
+        return self._get("ciem/facets", _identity_query_pairs(
+            provider=provider, account=account, region=region, source=source,
+            kind=kind, criticality=criticality, risk_band=risk_band, mfa=mfa,
+            admin=admin, external=external, public=public, disabled=disabled,
+            crown_jewel=crown_jewel, can_escalate=can_escalate,
+            dormant_90d=dormant_90d, with_sensitive=with_sensitive, q=q,
+        ))
+
+    def list_identity_access(
+        self,
+        *,
+        provider: list[str] | None = None,
+        account: list[str] | None = None,
+        region: list[str] | None = None,
+        source: list[str] | None = None,
+        kind: list[str] | None = None,
+        criticality: list[str] | None = None,
+        risk_band: list[str] | None = None,
+        mfa: str | None = None,
+        admin: bool | None = None,
+        external: bool | None = None,
+        public: bool | None = None,
+        disabled: bool | None = None,
+        crown_jewel: bool | None = None,
+        can_escalate: bool | None = None,
+        dormant_90d: bool | None = None,
+        with_sensitive: bool | None = None,
+        q: str | None = None,
+        cursor: str | None = None,
+        limit: int | None = None,
+    ) -> dict[str, Any]:
+        """One page of the Access screen's identity population.
+
+        The same per-principal effective-access rollup rows
+        :meth:`get_public_access` carries (grant / privileged /
+        sensitive-reach counts, posture facets, risk score), but
+        server-filtered and pageable instead of a risk-ranked top-N.
+        Takes the same selectors as :meth:`get_identity_facets` — see
+        there for what each one means.
+
+        Ranked by risk score descending by default. A walk that spans a
+        projector recompute can move a row across the cursor, so use it
+        for browsing, not for exact exports.
+
+        Args:
+            cursor, limit: Keyset pagination (default page 500).
+
+        Returns:
+            ``{"principals": [...], "next_cursor": str | None}``, plus
+            ``served_from`` / ``data_as_of`` when the page came from the
+            projector's materialized merged view.
+        """
+        return self._get("ciem/identities", _identity_query_pairs(
+            provider=provider, account=account, region=region, source=source,
+            kind=kind, criticality=criticality, risk_band=risk_band, mfa=mfa,
+            admin=admin, external=external, public=public, disabled=disabled,
+            crown_jewel=crown_jewel, can_escalate=can_escalate,
+            dormant_90d=dormant_90d, with_sensitive=with_sensitive,
+            q=q, cursor=cursor, limit=limit,
+        ))
 
     def get_identity(self, urn: str) -> dict[str, Any]:
         """The single-identity effective-access rollup for one identity urn.
@@ -469,13 +721,87 @@ class CloudSec:
         """
         return self._get("topology")
 
-    def get_data_security_facets(self) -> dict[str, Any]:
+    def get_data_security_facets(
+        self,
+        *,
+        provider: list[str] | None = None,
+        account: list[str] | None = None,
+        region: list[str] | None = None,
+        store_kind: list[str] | None = None,
+        tier: list[str] | None = None,
+        data_class: list[str] | None = None,
+        sensitivity: bool | None = None,
+        exposure: bool | None = None,
+        q: str | None = None,
+    ) -> dict[str, Any]:
         """DSPM data-store facet counts (total/sensitive/public, store kinds).
+
+        Takes the same cross-filter as :meth:`list_data_stores`, so the
+        counts always describe the population that list would return. Each
+        dimension is counted under the OTHER active selectors but not its
+        own. With no selectors the response is the whole-population
+        rollup.
+
+        Args:
+            provider, account, region: Placement filters, OR'd within a
+                key. An empty-string value selects the unscoped bucket.
+            store_kind: Store kinds (``bucket``, ``sql_instance``, ...),
+                OR'd.
+            tier: Criticality tiers, OR'd.
+            data_class: Content classes (``pii``, ``secrets``, ...), OR'd.
+            sensitivity: Tri-state — ``True`` only sensitive stores,
+                ``False`` only non-sensitive, ``None`` unconstrained.
+            exposure: Tri-state — ``True`` only publicly-exposed stores,
+                ``False`` only non-public, ``None`` unconstrained.
+            q: Substring filter over the store's name/urn.
 
         Returns:
             ``{"facets": {...}}``.
         """
-        return self._get("data-security/facets")
+        return self._get("data-security/facets", _data_store_query_pairs(
+            provider=provider, account=account, region=region,
+            store_kind=store_kind, tier=tier, data_class=data_class,
+            sensitivity=sensitivity, exposure=exposure, q=q,
+        ))
+
+    def list_data_stores(
+        self,
+        *,
+        provider: list[str] | None = None,
+        account: list[str] | None = None,
+        region: list[str] | None = None,
+        store_kind: list[str] | None = None,
+        tier: list[str] | None = None,
+        data_class: list[str] | None = None,
+        sensitivity: bool | None = None,
+        exposure: bool | None = None,
+        q: str | None = None,
+        cursor: str | None = None,
+        limit: int | None = None,
+    ) -> dict[str, Any]:
+        """One keyset page of the org's data stores (DSPM row list).
+
+        Served from the materialized graph store under the same selectors
+        as :meth:`get_data_security_facets` — see there for what each one
+        means — so the filtered list stays exact at any estate size
+        instead of client-filtering a capped walk. Ordered by the stored
+        key, which is stable and safe for a full walk.
+
+        Args:
+            cursor, limit: Keyset pagination (server caps the page at
+                1000).
+
+        Returns:
+            ``{"stores": [{"urn", "name", "store_kind", "provider",
+            "account", "region", "is_public", "is_sensitive",
+            "criticality", "data_classes"}, ...], "next_cursor": str}``.
+        """
+        return self._get("data-security/stores", _data_store_query_pairs(
+            provider=provider, account=account, region=region,
+            store_kind=store_kind, tier=tier, data_class=data_class,
+            sensitivity=sensitivity, exposure=exposure,
+            q=q, cursor=cursor, limit=limit,
+        ))
 
     def get_resource(self, urn: str) -> dict[str, Any]:
         """Get the canonical record for any urn the graph knows.
@@ -952,6 +1278,29 @@ class CloudSec:
             type=provider_type,
         ))
 
+    def get_free_tier(self) -> dict[str, Any]:
+        """The org's cloud-security free-tier standing and its limits.
+
+        Describes where the org stands BEFORE it bounces off a limit; it
+        does not enforce anything (the collector and the provider-record
+        validator do, so a limit applies whether or not this was called).
+
+        The trial countdown is deliberately absent — the authoritative
+        clock lives in the datacenter, and a deadline derived here could
+        disagree with the enforcer. The collector publishes a gated reason
+        through :meth:`get_scan_status` instead.
+
+        Returns:
+            ``{"is_free_tier": bool, "sensor_quota": int}``, plus
+            ``max_providers`` and ``enabled_providers`` for a free-tier
+            org only (a paying org has no provider cap, so reporting one
+            would advertise a limit that does not exist).
+            ``enabled_providers`` is OMITTED — not zeroed — when the
+            count could not be read, so an absent key means "unknown",
+            never "none configured".
+        """
+        return self._get("free-tier")
+
     def test_provider(self, provider: dict[str, Any]) -> dict[str, Any]:
         """Preflight a cloud provider configuration before saving it.
 
@@ -1077,6 +1426,7 @@ class CloudSec:
         finding_class: list[str] | None = None,
         status: list[str] | None = None,
         account: list[str] | None = None,
+        owner: list[str] | None = None,
         reachable: bool | None = None,
         kev: bool | None = None,
         q: str | None = None,
@@ -1094,7 +1444,7 @@ class CloudSec:
         """
         pairs = _finding_query_pairs(
             severity=severity, finding_class=finding_class, status=status,
-            account=account, reachable=reachable, kev=kev, q=q,
+            account=account, owner=owner, reachable=reachable, kev=kev, q=q,
             sort=sort, order=order,
         )
         pairs.append(("format", "csv"))

--- a/limacharlie/sdk/cloudsec.py
+++ b/limacharlie/sdk/cloudsec.py
@@ -382,6 +382,17 @@ class CloudSec:
         :meth:`list_findings`, so a rollup can be scoped exactly like the
         list it summarizes.
 
+        **Only CAUSE-BEARING findings are in scope, which is a small slice
+        of an estate.** Causes are stamped on the attack-path classes;
+        vulnerability findings — roughly 90% of a typical estate —
+        deliberately carry none, because a per-package cause would evict
+        every attack-path fix from the ranking and would cost the sparse
+        index this rollup is fast because of. So the counts here never sum
+        to the worklist total, and a rollup scoped to a class that carries
+        no cause (``finding_class=["vulnerability"]``) legitimately returns
+        ``{"causes": [], "distinct": 0}`` — that is "no shared fix on this
+        class", not "no findings".
+
         Args:
             cause: One cause key. Set it for the count of that cause alone,
                 returned as a single-entry ``causes`` — or an EMPTY
@@ -595,7 +606,10 @@ class CloudSec:
                 ``critical`` / ``high`` / ``medium`` / ``low`` — plus the
                 empty string, which selects identities with no tier
                 assigned. An unrecognized tier matches nothing rather than
-                erroring, so a typo reads as "no such identities".
+                erroring, so a typo reads as "no such identities". The
+                empty-tier bucket is the ONE selection the facet rail does
+                not count (the criticality facet skips it), so it is the
+                one case where a facet count cannot predict the list.
             risk_band: Risk bands, OR'd — ``critical`` / ``high`` /
                 ``medium`` / ``low``, the band token rather than a numeric
                 range. Also closed, and also fails closed: an unrecognized

--- a/limacharlie/sdk/cloudsec.py
+++ b/limacharlie/sdk/cloudsec.py
@@ -375,9 +375,11 @@ class CloudSec:
         list it summarizes.
 
         Args:
-            cause: One cause key. Set it for the exact count of that cause
-                alone (returned as a single-entry ``causes``); omit it for
-                the top causes by count. Clamped to 512 chars server-side.
+            cause: One cause key. Set it for the count of that cause alone,
+                returned as a single-entry ``causes`` — or an EMPTY
+                ``causes`` when no finding under the filter carries it, so
+                read the list rather than indexing ``causes[0]``. Clamped
+                to 512 chars server-side.
             limit: Rollup size when ``cause`` is omitted (default 20,
                 server cap 200). Not a page size — the rollup is not
                 paginated, and ``distinct`` reports the tail it hides.
@@ -389,8 +391,17 @@ class CloudSec:
             grows server-side — treat an unrecognized value as "some
             object" rather than assuming a class. ``distinct`` is the total
             number of causes matching the filter and MAY exceed
-            ``len(causes)`` when ``limit`` truncates; the counts themselves
-            are always exact.
+            ``len(causes)`` when ``limit`` truncates.
+
+            A count is a whole-population figure, not a capped one: it does
+            not degrade to a lower bound the way folding a paginated
+            worklist client-side does. It is computed on each finding's
+            STORED status, though, which lags a disposition that expired on
+            its own — an acceptance past its expiry still counts as
+            accepted until the projector's periodic backstop rewrites it,
+            while reading that finding returns it as open. Treat a count as
+            a ranking and scale signal; the finding's own read is the
+            authority on its status.
         """
         pairs = _finding_query_pairs(
             severity=severity, finding_class=finding_class, status=status,
@@ -572,9 +583,15 @@ class CloudSec:
                 ``google_workspace``, ...), OR'd.
             kind: Identity kinds (``user``, ``service_account``, ``group``,
                 ``ai_agent``, ...), OR'd.
-            criticality: Crown-jewel tiers, OR'd.
-            risk_band: Risk bands (``critical``/``high``/``medium``/
-                ``low``) — the band token, not a numeric range, OR'd.
+            criticality: Crown-jewel tiers, OR'd. A CLOSED vocabulary —
+                ``critical`` / ``high`` / ``medium`` / ``low`` — plus the
+                empty string, which selects identities with no tier
+                assigned. An unrecognized tier matches nothing rather than
+                erroring, so a typo reads as "no such identities".
+            risk_band: Risk bands, OR'd — ``critical`` / ``high`` /
+                ``medium`` / ``low``, the band token rather than a numeric
+                range. Also closed, and also fails closed: an unrecognized
+                band selects nothing.
             mfa: ``on`` | ``off`` | ``unknown``. ``unknown`` is everyone
                 the MFA question does not apply to (no identity-provider
                 observation, or non-human) — it is NOT ``off``.
@@ -747,7 +764,10 @@ class CloudSec:
                 key. An empty-string value selects the unscoped bucket.
             store_kind: Store kinds (``bucket``, ``sql_instance``, ...),
                 OR'd.
-            tier: Criticality tiers, OR'd.
+            tier: Criticality tiers, OR'd. Same closed vocabulary as the
+                identity filter's ``criticality`` — ``critical`` /
+                ``high`` / ``medium`` / ``low``, plus the empty string for
+                stores with no tier assigned.
             data_class: Content classes (``pii``, ``secrets``, ...), OR'd.
             sensitivity: Tri-state — ``True`` only sensitive stores,
                 ``False`` only non-sensitive, ``None`` unconstrained.

--- a/tests/unit/test_cli_cloudsec.py
+++ b/tests/unit/test_cli_cloudsec.py
@@ -1226,13 +1226,6 @@ class TestCiemIdentities:
                         "with_sensitive", "mfa"]:
                 assert kwargs[key] is None, key
 
-    def test_identities_rejects_unknown_mfa_state(self):
-        runner = CliRunner()
-        result = runner.invoke(
-            cli, ["cloudsec", "ciem", "identities", "--mfa", "maybe"],
-        )
-        assert result.exit_code != 0
-
     def test_facets_take_the_same_cross_filter(self):
         p1, p2, p3 = _patches()
         with p1, p2, p3 as cls:
@@ -1353,8 +1346,9 @@ class TestClosedVocabularyGuards:
         )
 
     def test_rejects_unknown_mfa_state_by_parse_failure(self):
-        # The pre-existing --mfa test only asserted a non-zero exit; pin the
-        # parse failure here so the Choice cannot be removed unnoticed.
+        # Replaces an earlier --mfa guard that asserted only a non-zero exit,
+        # which an accepted value also produces without credentials: that one
+        # survived deleting the Choice, so it was not testing anything.
         self._rejects(
             ["cloudsec", "ciem", "identities", "--mfa", "maybe"], "--mfa",
         )

--- a/tests/unit/test_cli_cloudsec.py
+++ b/tests/unit/test_cli_cloudsec.py
@@ -111,8 +111,13 @@ class TestCloudSecHelp:
         runner = CliRunner()
         result = runner.invoke(cli, ["cloudsec", "ciem", "--help"])
         assert result.exit_code == 0
-        for cmd in ["public-access", "facets", "identity", "identities"]:
-            assert cmd in result.output
+        # Asserted against the registered command NAMES, not the help text:
+        # "identity" is a substring of "identities", so a substring check
+        # could not tell the singular point-lookup from the plural list.
+        group = cli.commands["cloudsec"].commands["ciem"]
+        assert set(group.commands) == {
+            "public-access", "facets", "identity", "identities",
+        }
 
     def test_policy_subgroup_help(self):
         runner = CliRunner()
@@ -1176,7 +1181,7 @@ class TestCiemIdentities:
                 ["cloudsec", "ciem", "identities",
                  "--source", "okta", "--source", "gcp",
                  "--account", "proj-1", "--region", "us-central1",
-                 "--kind", "service_account", "--criticality", "tier1",
+                 "--kind", "service_account", "--criticality", "critical",
                  "--risk-band", "critical", "--mfa", "off",
                  "--admin", "--no-external", "--can-escalate",
                  "--with-sensitive", "-q", "deploy",
@@ -1189,7 +1194,7 @@ class TestCiemIdentities:
                 account=["proj-1"],
                 region=["us-central1"],
                 kind=["service_account"],
-                criticality=["tier1"],
+                criticality=["critical"],
                 risk_band=["critical"],
                 mfa="off",
                 admin=True,
@@ -1250,8 +1255,8 @@ class TestDataSecurityStores:
                 ["cloudsec", "data-security", "stores",
                  "--provider", "gcp", "--account", "proj-1",
                  "--region", "us-central1", "--store-kind", "bucket",
-                 "--tier", "tier1", "--data-class", "pii",
-                 "--sensitive", "--not-public", "-q", "prod",
+                 "--tier", "critical", "--data-class", "pii",
+                 "--sensitive", "--no-public", "-q", "prod",
                  "--limit", "50"], cls,
                 return_value={"stores": [], "next_cursor": ""},
             )
@@ -1261,7 +1266,7 @@ class TestDataSecurityStores:
                 account=["proj-1"],
                 region=["us-central1"],
                 store_kind=["bucket"],
-                tier=["tier1"],
+                tier=["critical"],
                 data_class=["pii"],
                 sensitivity=True,
                 exposure=False,
@@ -1308,3 +1313,68 @@ class TestFreeTier:
             assert result.exit_code == 0, result.output
             inst.get_free_tier.assert_called_once_with()
             assert "is_free_tier" in result.output
+
+
+class TestClosedVocabularyGuards:
+    """The closed server vocabularies fail CLOSED, so a typo must not parse.
+
+    An unrecognized risk band contributes a FALSE predicate and a
+    misspelled tier matches no row, so without validation a typo would
+    exit 0 with an empty result under a filter the user can see applied.
+    """
+
+    def test_rejects_unknown_risk_band(self):
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["cloudsec", "ciem", "identities", "--risk-band", "urgent"],
+        )
+        assert result.exit_code != 0
+
+    def test_rejects_unknown_criticality_tier(self):
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["cloudsec", "ciem", "identities", "--criticality", "tier1"],
+        )
+        assert result.exit_code != 0
+
+    def test_rejects_unknown_store_tier(self):
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["cloudsec", "data-security", "stores", "--tier", "tier1"],
+        )
+        assert result.exit_code != 0
+
+    def test_unclassified_identities_selects_the_empty_tier(self):
+        # "no tier assigned" is the EMPTY value on the wire, and it
+        # combines with a named tier like --unassigned does for owner.
+        p1, p2, p3 = _patches()
+        with p1, p2, p3 as cls:
+            result, inst = _invoke(
+                ["cloudsec", "ciem", "identities",
+                 "--criticality", "critical", "--unclassified"], cls,
+                return_value={"principals": []},
+            )
+            assert result.exit_code == 0, result.output
+            assert inst.list_identity_access.call_args[1]["criticality"] == [
+                "critical", "",
+            ]
+
+    def test_unclassified_stores_selects_the_empty_tier(self):
+        p1, p2, p3 = _patches()
+        with p1, p2, p3 as cls:
+            result, inst = _invoke(
+                ["cloudsec", "data-security", "stores", "--unclassified"], cls,
+                return_value={"stores": []},
+            )
+            assert result.exit_code == 0, result.output
+            assert inst.list_data_stores.call_args[1]["tier"] == [""]
+
+    def test_no_tier_flags_send_no_constraint(self):
+        p1, p2, p3 = _patches()
+        with p1, p2, p3 as cls:
+            result, inst = _invoke(
+                ["cloudsec", "data-security", "stores"], cls,
+                return_value={"stores": []},
+            )
+            assert result.exit_code == 0, result.output
+            assert inst.list_data_stores.call_args[1]["tier"] is None

--- a/tests/unit/test_cli_cloudsec.py
+++ b/tests/unit/test_cli_cloudsec.py
@@ -1321,28 +1321,43 @@ class TestClosedVocabularyGuards:
     An unrecognized risk band contributes a FALSE predicate and a
     misspelled tier matches no row, so without validation a typo would
     exit 0 with an empty result under a filter the user can see applied.
+
+    Each assertion pins the PARSE failure (exit 2 + click's "Invalid value
+    for '--flag'"), not merely a non-zero exit: these run unmocked, so an
+    accepted value also exits non-zero once it reaches the credential-less
+    client, and `exit_code != 0` alone would pass with the Choice removed.
     """
 
-    def test_rejects_unknown_risk_band(self):
+    def _rejects(self, args, flag):
         runner = CliRunner()
-        result = runner.invoke(
-            cli, ["cloudsec", "ciem", "identities", "--risk-band", "urgent"],
+        result = runner.invoke(cli, args)
+        assert result.exit_code == 2, result.output
+        assert f"Invalid value for {flag!r}" in result.output, result.output
+
+    def test_rejects_unknown_risk_band(self):
+        self._rejects(
+            ["cloudsec", "ciem", "identities", "--risk-band", "urgent"],
+            "--risk-band",
         )
-        assert result.exit_code != 0
 
     def test_rejects_unknown_criticality_tier(self):
-        runner = CliRunner()
-        result = runner.invoke(
-            cli, ["cloudsec", "ciem", "identities", "--criticality", "tier1"],
+        self._rejects(
+            ["cloudsec", "ciem", "identities", "--criticality", "tier1"],
+            "--criticality",
         )
-        assert result.exit_code != 0
 
     def test_rejects_unknown_store_tier(self):
-        runner = CliRunner()
-        result = runner.invoke(
-            cli, ["cloudsec", "data-security", "stores", "--tier", "tier1"],
+        self._rejects(
+            ["cloudsec", "data-security", "stores", "--tier", "tier1"],
+            "--tier",
         )
-        assert result.exit_code != 0
+
+    def test_rejects_unknown_mfa_state_by_parse_failure(self):
+        # The pre-existing --mfa test only asserted a non-zero exit; pin the
+        # parse failure here so the Choice cannot be removed unnoticed.
+        self._rejects(
+            ["cloudsec", "ciem", "identities", "--mfa", "maybe"], "--mfa",
+        )
 
     def test_unclassified_identities_selects_the_empty_tier(self):
         # "no tier assigned" is the EMPTY value on the wire, and it

--- a/tests/unit/test_cli_cloudsec.py
+++ b/tests/unit/test_cli_cloudsec.py
@@ -28,14 +28,15 @@ def _invoke(args, mock_cs_cls, return_value=None, stdin=None):
         f"{name}.return_value": return_value
         for name in [
             "get_overview", "list_changes", "get_risk_trend", "get_scan_status",
-            "get_topology",
+            "get_topology", "get_free_tier",
             "list_findings", "get_finding_facets", "get_finding_classes",
-            "get_finding",
+            "get_finding", "list_finding_causes",
             "set_finding_status", "bulk_set_finding_status",
             "set_finding_owner", "set_finding_ticket",
             "list_attack_paths", "get_public_access", "get_identity_facets",
-            "get_identity",
+            "get_identity", "list_identity_access",
             "list_inventory", "get_inventory_facets", "get_data_security_facets",
+            "list_data_stores",
             "get_resource", "get_graph_neighbors", "list_queries", "run_query",
             "get_compliance", "list_compliance_frameworks",
             "list_compliance_assignments",
@@ -71,7 +72,7 @@ class TestCloudSecHelp:
         assert result.exit_code == 0
         for cmd in [
             "overview", "changes", "risk-trend", "scan-status", "topology",
-            "fleet", "finding", "attack-path", "ciem", "inventory",
+            "free-tier", "fleet", "finding", "attack-path", "ciem", "inventory",
             "data-security", "resource", "graph", "query", "compliance",
             "chokepoint", "resolve", "caasm", "provider", "policy",
             "simulate", "export",
@@ -82,7 +83,7 @@ class TestCloudSecHelp:
         runner = CliRunner()
         result = runner.invoke(cli, ["cloudsec", "finding", "--help"])
         assert result.exit_code == 0
-        for cmd in ["list", "facets", "classes", "get", "resolve",
+        for cmd in ["list", "facets", "causes", "classes", "get", "resolve",
                     "bulk-resolve", "set-owner", "set-ticket"]:
             assert cmd in result.output
 
@@ -110,7 +111,7 @@ class TestCloudSecHelp:
         runner = CliRunner()
         result = runner.invoke(cli, ["cloudsec", "ciem", "--help"])
         assert result.exit_code == 0
-        for cmd in ["public-access", "facets", "identity"]:
+        for cmd in ["public-access", "facets", "identity", "identities"]:
             assert cmd in result.output
 
     def test_policy_subgroup_help(self):
@@ -138,7 +139,8 @@ class TestCloudSecHelp:
         runner = CliRunner()
         result = runner.invoke(cli, ["cloudsec", "data-security", "--help"])
         assert result.exit_code == 0
-        assert "facets" in result.output
+        for cmd in ["facets", "stores"]:
+            assert cmd in result.output
 
     def test_resource_subgroup_help(self):
         runner = CliRunner()
@@ -261,6 +263,7 @@ class TestFindingCommands:
                 finding_class=["toxic_combination"],
                 status=None,
                 account=None,
+                owner=None,
                 reachable=True,
                 kev=True,
                 q="prod",
@@ -819,7 +822,7 @@ class TestExport:
             assert result.output == "col_a,col_b\n1,2\n"
             inst.export_findings_csv.assert_called_once_with(
                 severity=["CRITICAL"], finding_class=None, status=["open"],
-                account=None, reachable=None, kev=None, q=None,
+                account=None, owner=None, reachable=None, kev=None, q=None,
                 sort=None, order=None,
             )
 
@@ -1062,3 +1065,246 @@ class TestSimulate:
             inst.simulate_finding_match.assert_called_once_with(
                 {}, sample_limit=None,
             )
+
+
+class TestFindingOwnerSelector:
+    def test_owner_and_unassigned_ride_one_selector(self):
+        # "mine or nobody's" is ONE repeatable filter with two values, and
+        # the unassigned bucket travels as the empty string.
+        p1, p2, p3 = _patches()
+        with p1, p2, p3 as cls:
+            result, inst = _invoke(
+                ["cloudsec", "finding", "list",
+                 "--owner", "alice@corp.com", "--unassigned"], cls,
+                return_value={"findings": []},
+            )
+            assert result.exit_code == 0, result.output
+            assert inst.list_findings.call_args[1]["owner"] == [
+                "alice@corp.com", "",
+            ]
+
+    def test_unassigned_alone_selects_the_empty_owner(self):
+        p1, p2, p3 = _patches()
+        with p1, p2, p3 as cls:
+            result, inst = _invoke(
+                ["cloudsec", "finding", "list", "--unassigned"], cls,
+                return_value={"findings": []},
+            )
+            assert result.exit_code == 0, result.output
+            assert inst.list_findings.call_args[1]["owner"] == [""]
+
+    def test_no_owner_flags_send_no_constraint(self):
+        # An empty selector must be None, not [] — [""] would silently
+        # narrow the read to the untriaged bucket.
+        p1, p2, p3 = _patches()
+        with p1, p2, p3 as cls:
+            result, inst = _invoke(
+                ["cloudsec", "finding", "list"], cls,
+                return_value={"findings": []},
+            )
+            assert result.exit_code == 0, result.output
+            assert inst.list_findings.call_args[1]["owner"] is None
+
+    def test_facets_owner_pin_is_separate_from_the_filter(self):
+        p1, p2, p3 = _patches()
+        with p1, p2, p3 as cls:
+            result, inst = _invoke(
+                ["cloudsec", "finding", "facets",
+                 "--owner-pin", "me@corp.com", "--owner-pin", "bob@corp.com"],
+                cls, return_value={"facets": {}},
+            )
+            assert result.exit_code == 0, result.output
+            kwargs = inst.get_finding_facets.call_args[1]
+            assert kwargs["owner_pin"] == ["me@corp.com", "bob@corp.com"]
+            # A pin selects nothing: the owner FILTER stays unset.
+            assert kwargs["owner"] is None
+
+    def test_export_findings_takes_the_owner_filter(self):
+        # The export must be the same filtered set the list shows.
+        p1, p2, p3 = _patches()
+        with p1, p2, p3 as cls:
+            result, inst = _invoke(
+                ["cloudsec", "export", "findings", "--owner", "alice@corp.com"],
+                cls,
+            )
+            assert result.exit_code == 0, result.output
+            assert inst.export_findings_csv.call_args[1]["owner"] == [
+                "alice@corp.com",
+            ]
+
+
+class TestFindingCauses:
+    def test_causes_rollup_with_filters(self):
+        p1, p2, p3 = _patches()
+        with p1, p2, p3 as cls:
+            result, inst = _invoke(
+                ["cloudsec", "finding", "causes",
+                 "--severity", "CRITICAL", "--limit", "5"], cls,
+                return_value={"causes": [], "distinct": 0},
+            )
+            assert result.exit_code == 0, result.output
+            inst.list_finding_causes.assert_called_once_with(
+                cause=None,
+                severity=["CRITICAL"],
+                finding_class=None,
+                status=None,
+                account=None,
+                owner=None,
+                reachable=None,
+                kev=None,
+                q=None,
+                limit=5,
+            )
+
+    def test_causes_single_cause(self):
+        p1, p2, p3 = _patches()
+        with p1, p2, p3 as cls:
+            result, inst = _invoke(
+                ["cloudsec", "finding", "causes", "--cause", "lcrn:fw"], cls,
+                return_value={"causes": [{"key": "lcrn:fw", "count": 22}],
+                              "distinct": 1},
+            )
+            assert result.exit_code == 0, result.output
+            assert inst.list_finding_causes.call_args[1]["cause"] == "lcrn:fw"
+
+
+class TestCiemIdentities:
+    def test_identities_full_cross_filter(self):
+        p1, p2, p3 = _patches()
+        with p1, p2, p3 as cls:
+            result, inst = _invoke(
+                ["cloudsec", "ciem", "identities",
+                 "--source", "okta", "--source", "gcp",
+                 "--account", "proj-1", "--region", "us-central1",
+                 "--kind", "service_account", "--criticality", "tier1",
+                 "--risk-band", "critical", "--mfa", "off",
+                 "--admin", "--no-external", "--can-escalate",
+                 "--with-sensitive", "-q", "deploy",
+                 "--limit", "50", "--cursor", "c1"], cls,
+                return_value={"principals": [], "next_cursor": None},
+            )
+            assert result.exit_code == 0, result.output
+            inst.list_identity_access.assert_called_once_with(
+                source=["okta", "gcp"],
+                account=["proj-1"],
+                region=["us-central1"],
+                kind=["service_account"],
+                criticality=["tier1"],
+                risk_band=["critical"],
+                mfa="off",
+                admin=True,
+                external=False,
+                public=None,
+                disabled=None,
+                crown_jewel=None,
+                can_escalate=True,
+                dormant_90d=None,
+                with_sensitive=True,
+                q="deploy",
+                cursor="c1",
+                limit=50,
+            )
+
+    def test_identities_unset_booleans_are_none_not_false(self):
+        # Tri-state: an omitted flag must leave the dimension
+        # unconstrained rather than pinning it to false.
+        p1, p2, p3 = _patches()
+        with p1, p2, p3 as cls:
+            result, inst = _invoke(
+                ["cloudsec", "ciem", "identities"], cls,
+                return_value={"principals": []},
+            )
+            assert result.exit_code == 0, result.output
+            kwargs = inst.list_identity_access.call_args[1]
+            for key in ["admin", "external", "public", "disabled",
+                        "crown_jewel", "can_escalate", "dormant_90d",
+                        "with_sensitive", "mfa"]:
+                assert kwargs[key] is None, key
+
+    def test_identities_rejects_unknown_mfa_state(self):
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["cloudsec", "ciem", "identities", "--mfa", "maybe"],
+        )
+        assert result.exit_code != 0
+
+    def test_facets_take_the_same_cross_filter(self):
+        p1, p2, p3 = _patches()
+        with p1, p2, p3 as cls:
+            result, inst = _invoke(
+                ["cloudsec", "ciem", "facets",
+                 "--kind", "user", "--mfa", "unknown"], cls,
+                return_value={"facets": {}},
+            )
+            assert result.exit_code == 0, result.output
+            kwargs = inst.get_identity_facets.call_args[1]
+            assert kwargs["kind"] == ["user"]
+            assert kwargs["mfa"] == "unknown"
+
+
+class TestDataSecurityStores:
+    def test_stores_full_cross_filter(self):
+        p1, p2, p3 = _patches()
+        with p1, p2, p3 as cls:
+            result, inst = _invoke(
+                ["cloudsec", "data-security", "stores",
+                 "--provider", "gcp", "--account", "proj-1",
+                 "--region", "us-central1", "--store-kind", "bucket",
+                 "--tier", "tier1", "--data-class", "pii",
+                 "--sensitive", "--not-public", "-q", "prod",
+                 "--limit", "50"], cls,
+                return_value={"stores": [], "next_cursor": ""},
+            )
+            assert result.exit_code == 0, result.output
+            inst.list_data_stores.assert_called_once_with(
+                provider=["gcp"],
+                account=["proj-1"],
+                region=["us-central1"],
+                store_kind=["bucket"],
+                tier=["tier1"],
+                data_class=["pii"],
+                sensitivity=True,
+                exposure=False,
+                q="prod",
+                cursor=None,
+                limit=50,
+            )
+
+    def test_stores_unset_tristates_are_none(self):
+        p1, p2, p3 = _patches()
+        with p1, p2, p3 as cls:
+            result, inst = _invoke(
+                ["cloudsec", "data-security", "stores"], cls,
+                return_value={"stores": []},
+            )
+            assert result.exit_code == 0, result.output
+            kwargs = inst.list_data_stores.call_args[1]
+            assert kwargs["sensitivity"] is None
+            assert kwargs["exposure"] is None
+
+    def test_facets_take_the_same_cross_filter(self):
+        p1, p2, p3 = _patches()
+        with p1, p2, p3 as cls:
+            result, inst = _invoke(
+                ["cloudsec", "data-security", "facets",
+                 "--store-kind", "bucket", "--public"], cls,
+                return_value={"facets": {}},
+            )
+            assert result.exit_code == 0, result.output
+            kwargs = inst.get_data_security_facets.call_args[1]
+            assert kwargs["store_kind"] == ["bucket"]
+            assert kwargs["exposure"] is True
+
+
+class TestFreeTier:
+    def test_free_tier(self):
+        p1, p2, p3 = _patches()
+        with p1, p2, p3 as cls:
+            result, inst = _invoke(
+                ["cloudsec", "free-tier"], cls,
+                return_value={"is_free_tier": True, "sensor_quota": 2,
+                              "max_providers": 2, "enabled_providers": 1},
+            )
+            assert result.exit_code == 0, result.output
+            inst.get_free_tier.assert_called_once_with()
+            assert "is_free_tier" in result.output

--- a/tests/unit/test_cli_lazy_loading_regression.py
+++ b/tests/unit/test_cli_lazy_loading_regression.py
@@ -150,7 +150,7 @@ EXPECTED_SUBCOMMANDS: dict[str, frozenset[str]] = {
     "cloud-adapter": frozenset({"delete", "disable", "enable", "get", "list", "list-types", "schema", "sensors", "set", "tag"}),
     "cloudsec": frozenset({
         "overview", "changes", "risk-trend", "scan-status", "topology",
-        "fleet", "finding", "attack-path", "ciem", "inventory",
+        "free-tier", "fleet", "finding", "attack-path", "ciem", "inventory",
         "data-security", "resource", "graph", "query", "compliance",
         "chokepoint", "resolve", "caasm", "provider", "policy",
         "simulate", "export",

--- a/tests/unit/test_sdk_cloudsec.py
+++ b/tests/unit/test_sdk_cloudsec.py
@@ -685,3 +685,185 @@ class TestPolicyAuthoring:
         cs.simulate_finding_match({})
         _, body = _post_call(mock_org)
         assert body == {"match": {}}
+
+
+class TestOwnerSelector:
+    def test_owner_values_are_repeated(self, cs, mock_org):
+        mock_org.client.request.return_value = {"findings": []}
+        cs.list_findings(owner=["alice@corp.com", "bob@corp.com"])
+        url, qp = _get_call(mock_org)
+        assert url == f"cloudsec/{OID}/findings"
+        assert qp == [
+            ("owner", "alice@corp.com"), ("owner", "bob@corp.com"),
+        ]
+
+    def test_empty_owner_selects_the_unassigned_bucket(self, cs, mock_org):
+        # The empty string is a REAL selection here (findings nobody owns),
+        # so it must reach the wire as `owner=` rather than be dropped as
+        # an unset value — dropping it would widen the read to the estate.
+        mock_org.client.request.return_value = {"findings": []}
+        cs.list_findings(owner=[""])
+        _, qp = _get_call(mock_org)
+        assert qp == [("owner", "")]
+
+    def test_owner_mine_or_nobodys(self, cs, mock_org):
+        mock_org.client.request.return_value = {"findings": []}
+        cs.list_findings(owner=["alice@corp.com", ""])
+        _, qp = _get_call(mock_org)
+        assert qp == [("owner", "alice@corp.com"), ("owner", "")]
+
+    def test_no_owner_sends_no_selector(self, cs, mock_org):
+        mock_org.client.request.return_value = {"findings": []}
+        cs.list_findings()
+        _, qp = _get_call(mock_org)
+        assert qp is None
+
+    def test_facets_owner_pin_rides_alongside_the_filter(self, cs, mock_org):
+        mock_org.client.request.return_value = {"facets": {}}
+        cs.get_finding_facets(owner=[""], owner_pin=["me@corp.com"])
+        url, qp = _get_call(mock_org)
+        assert url == f"cloudsec/{OID}/findings/facets"
+        assert qp == [("owner", ""), ("owner_pin", "me@corp.com")]
+
+    def test_export_carries_the_owner_filter(self, cs, mock_org):
+        mock_org.client.request.return_value = "urn\n"
+        cs.export_findings_csv(owner=["alice@corp.com"], status=["open"])
+        _, kwargs = mock_org.client.request.call_args
+        assert kwargs["query_params"] == [
+            ("status", "open"), ("owner", "alice@corp.com"), ("format", "csv"),
+        ]
+
+
+class TestFindingCauses:
+    def test_rollup_defaults(self, cs, mock_org):
+        mock_org.client.request.return_value = {"causes": [], "distinct": 0}
+        cs.list_finding_causes()
+        url, qp = _get_call(mock_org)
+        assert url == f"cloudsec/{OID}/findings/causes"
+        assert qp is None
+
+    def test_rollup_with_filters_and_limit(self, cs, mock_org):
+        mock_org.client.request.return_value = {"causes": [], "distinct": 0}
+        cs.list_finding_causes(
+            severity=["CRITICAL"], status=["open"], owner=[""], limit=5,
+        )
+        _, qp = _get_call(mock_org)
+        assert qp == [
+            ("severity", "CRITICAL"), ("status", "open"), ("owner", ""),
+            ("limit", "5"),
+        ]
+
+    def test_single_cause_count(self, cs, mock_org):
+        mock_org.client.request.return_value = {
+            "causes": [{"key": "lcrn:fw", "count": 22}], "distinct": 1,
+        }
+        cs.list_finding_causes(cause="lcrn:fw")
+        _, qp = _get_call(mock_org)
+        assert qp == [("cause", "lcrn:fw")]
+
+
+class TestIdentityAccessList:
+    def test_full_cross_filter(self, cs, mock_org):
+        mock_org.client.request.return_value = {
+            "principals": [], "next_cursor": None,
+        }
+        cs.list_identity_access(
+            source=["okta", "gcp"], account=["proj-1"],
+            region=["us-central1"], kind=["service_account"],
+            criticality=["tier1"], risk_band=["critical"], mfa="off",
+            admin=True, external=False, with_sensitive=True,
+            q="deploy", cursor="c1", limit=50,
+        )
+        url, qp = _get_call(mock_org)
+        assert url == f"cloudsec/{OID}/ciem/identities"
+        assert qp == [
+            ("account", "proj-1"), ("region", "us-central1"),
+            ("source", "okta"), ("source", "gcp"),
+            ("kind", "service_account"), ("criticality", "tier1"),
+            ("risk_band", "critical"), ("mfa", "off"),
+            ("admin", "true"), ("external", "false"),
+            ("with_sensitive", "true"), ("q", "deploy"),
+            ("cursor", "c1"), ("limit", "50"),
+        ]
+
+    def test_unset_tristate_sends_nothing(self, cs, mock_org):
+        # Absent is NOT false: forwarding a false would pin the dimension.
+        mock_org.client.request.return_value = {"principals": []}
+        cs.list_identity_access()
+        _, qp = _get_call(mock_org)
+        assert qp is None
+
+    def test_false_tristate_is_forwarded(self, cs, mock_org):
+        mock_org.client.request.return_value = {"principals": []}
+        cs.list_identity_access(admin=False)
+        _, qp = _get_call(mock_org)
+        assert qp == [("admin", "false")]
+
+    def test_facets_take_the_same_filter(self, cs, mock_org):
+        mock_org.client.request.return_value = {"facets": {}}
+        cs.get_identity_facets(kind=["user"], mfa="unknown", public=True)
+        url, qp = _get_call(mock_org)
+        assert url == f"cloudsec/{OID}/ciem/facets"
+        assert qp == [("kind", "user"), ("mfa", "unknown"), ("public", "true")]
+
+    def test_facets_unfiltered_is_unchanged(self, cs, mock_org):
+        mock_org.client.request.return_value = {"facets": {}}
+        cs.get_identity_facets()
+        url, qp = _get_call(mock_org)
+        assert url == f"cloudsec/{OID}/ciem/facets"
+        assert qp is None
+
+
+class TestDataStoreList:
+    def test_full_cross_filter(self, cs, mock_org):
+        mock_org.client.request.return_value = {
+            "stores": [], "next_cursor": "",
+        }
+        cs.list_data_stores(
+            provider=["gcp"], account=["proj-1"], region=["us-central1"],
+            store_kind=["bucket"], tier=["tier1"], data_class=["pii"],
+            sensitivity=True, exposure=False, q="prod", limit=50,
+        )
+        url, qp = _get_call(mock_org)
+        assert url == f"cloudsec/{OID}/data-security/stores"
+        assert qp == [
+            ("provider", "gcp"), ("account", "proj-1"),
+            ("region", "us-central1"), ("store_kind", "bucket"),
+            ("tier", "tier1"), ("data_class", "pii"),
+            ("sensitivity", "true"), ("exposure", "false"),
+            ("q", "prod"), ("limit", "50"),
+        ]
+
+    def test_unscoped_bucket_selector_survives(self, cs, mock_org):
+        # An empty placement value selects the unscoped bucket.
+        mock_org.client.request.return_value = {"stores": []}
+        cs.list_data_stores(account=[""])
+        _, qp = _get_call(mock_org)
+        assert qp == [("account", "")]
+
+    def test_facets_take_the_same_filter(self, cs, mock_org):
+        mock_org.client.request.return_value = {"facets": {}}
+        cs.get_data_security_facets(store_kind=["bucket"], exposure=True)
+        url, qp = _get_call(mock_org)
+        assert url == f"cloudsec/{OID}/data-security/facets"
+        assert qp == [("store_kind", "bucket"), ("exposure", "true")]
+
+    def test_facets_unfiltered_is_unchanged(self, cs, mock_org):
+        mock_org.client.request.return_value = {"facets": {}}
+        cs.get_data_security_facets()
+        url, qp = _get_call(mock_org)
+        assert url == f"cloudsec/{OID}/data-security/facets"
+        assert qp is None
+
+
+class TestFreeTier:
+    def test_free_tier(self, cs, mock_org):
+        mock_org.client.request.return_value = {
+            "is_free_tier": True, "sensor_quota": 2, "max_providers": 2,
+            "enabled_providers": 1,
+        }
+        out = cs.get_free_tier()
+        url, qp = _get_call(mock_org)
+        assert url == f"cloudsec/{OID}/free-tier"
+        assert qp is None
+        assert out["max_providers"] == 2

--- a/tests/unit/test_sdk_cloudsec.py
+++ b/tests/unit/test_sdk_cloudsec.py
@@ -770,7 +770,7 @@ class TestIdentityAccessList:
         cs.list_identity_access(
             source=["okta", "gcp"], account=["proj-1"],
             region=["us-central1"], kind=["service_account"],
-            criticality=["tier1"], risk_band=["critical"], mfa="off",
+            criticality=["critical"], risk_band=["critical"], mfa="off",
             admin=True, external=False, with_sensitive=True,
             q="deploy", cursor="c1", limit=50,
         )
@@ -779,7 +779,7 @@ class TestIdentityAccessList:
         assert qp == [
             ("account", "proj-1"), ("region", "us-central1"),
             ("source", "okta"), ("source", "gcp"),
-            ("kind", "service_account"), ("criticality", "tier1"),
+            ("kind", "service_account"), ("criticality", "critical"),
             ("risk_band", "critical"), ("mfa", "off"),
             ("admin", "true"), ("external", "false"),
             ("with_sensitive", "true"), ("q", "deploy"),
@@ -821,7 +821,7 @@ class TestDataStoreList:
         }
         cs.list_data_stores(
             provider=["gcp"], account=["proj-1"], region=["us-central1"],
-            store_kind=["bucket"], tier=["tier1"], data_class=["pii"],
+            store_kind=["bucket"], tier=["critical"], data_class=["pii"],
             sensitivity=True, exposure=False, q="prod", limit=50,
         )
         url, qp = _get_call(mock_org)
@@ -829,7 +829,7 @@ class TestDataStoreList:
         assert qp == [
             ("provider", "gcp"), ("account", "proj-1"),
             ("region", "us-central1"), ("store_kind", "bucket"),
-            ("tier", "tier1"), ("data_class", "pii"),
+            ("tier", "critical"), ("data_class", "pii"),
             ("sensitivity", "true"), ("exposure", "false"),
             ("q", "prod"), ("limit", "50"),
         ]


### PR DESCRIPTION
## What was asked

Close the remaining gaps in the `cloudsec` integration surface: bind the four `/v1/cloudsec/*`
routes the SDK/CLI did not cover (`/findings/causes`, `/ciem/identities`,
`/data-security/stores`, `/free-tier`), and expose the `owner` findings filter the API accepts
but no client could send.

## What was done

**The four unbound routes**, each mirroring the API's actual parameter set (read from the
gateway handlers, not guessed) and following the existing surface's conventions — cursor/limit
paging, `--output` rendering, docstrings, `--ai-help` explain text, tests:

| SDK | CLI |
|---|---|
| `list_finding_causes()` | `cloudsec finding causes` |
| `list_identity_access()` | `cloudsec ciem identities` |
| `list_data_stores()` | `cloudsec data-security stores` |
| `get_free_tier()` | `cloudsec free-tier` |

**The owner filter.** `finding list|facets` and `export findings` take `--owner` (repeatable)
and `--unassigned`; `finding facets` also takes `--owner-pin`. Without this, `finding
set-owner` could assign an owner that no API caller could then filter by — the write existed
and the read did not.

The unassigned bucket **is** an owner value on the wire (the empty string), so both flags ride
one repeatable selector and "mine or nobody's" is a single filter with two values.
`_owner_selector` folds them and returns `None` when neither is given, so an unfiltered read
sends exactly what it sent before. `--owner-pin` is deliberately separate and documented as
*not* a filter: it keeps named owners visible in the `owner` facet, which is capped at the top
50 by count (`owner_truncated` reports drops), and selects no rows.

**Two facet bindings gained their list's selectors.** `ciem facets` and `data-security facets`
previously took none, while their new list siblings take a full cross-filter — and a facet
count that is computed over a different population than the list it labels is a bug waiting to
be believed. Both now share one selector set with their list. Additive: an unfiltered call
emits the same request as before (covered by a test each). The identity/store booleans are
tri-state — absent leaves the dimension unconstrained, which is *not* the same as pinning it
false — so every one defaults to `None` rather than being a plain flag, and `--mfa` is a
three-value choice because `unknown` is not `off`.

Files: `limacharlie/sdk/cloudsec.py`, `limacharlie/commands/cloudsec.py`, tests in
`tests/unit/test_sdk_cloudsec.py` + `tests/unit/test_cli_cloudsec.py` (+ the cloudsec
subcommand snapshot in `test_cli_lazy_loading_regression.py`), and the user docs
(`doc/cli/cloud-security.md`, `doc/sdk/other-classes.md`, `CHANGELOG.md`).

Not done, deliberately: config CRUD stays out of this surface — `cloudsec_*` records are
managed through the generic `hive` commands, as the module header has always stated.

## Testing

- Full suite: **3803 passed, 5 skipped** (`pytest tests/unit/ tests/microbenchmarks/
  --benchmark-disable`), which is what CI runs.
- New tests cover the wire shapes rather than the plumbing: that an empty owner value survives
  as `?owner=` (dropping it would silently widen the read to the whole estate), that no owner
  flags send no constraint at all, that an omitted tri-state sends nothing while an explicit
  false sends `false`, that a pin is not a filter, and that each new route hits the right path
  with the right selectors.
- Live-verified **read-only** against an internal test org (no write verbs): all four routes
  returned their documented shapes, and the owner round-trip agrees end to end — the facet
  reported 59 unassigned plus 1 assigned within a filter scope, `--unassigned` returned only
  unowned rows, the assigned-owner filter returned exactly that one row, and an owner nobody
  holds returned zero, so the selector is applied rather than ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L7CkEf1fEa9Y8dBn5Utrx1
