### PR TITLE
release: cut 5.6.0 and file the 5.5.2 to 5.5.5 entries under their tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 5.6.0 - July 30, 2026
 
 ### Search
 
@@ -25,16 +25,6 @@
   `None` rather than `0`, since in a set of limits a zero would read as "nothing allowed".
   `capabilities.openQueryListing` says whether `search queries` can report searches that are
   open but idle on this deployment.
-
-### Organization
-
-- **Set org description (org info)**: `Organization.set_description()` /
-  `limacharlie org set-description --description ...` update an organization's
-  description without renaming it (the helper re-submits the current name so
-  only the description changes). `Organization.rename()` and `limacharlie org
-  rename` also take an optional `description` to set both at once. The
-  backend only exposes the description through the rename endpoint, so these
-  are thin wrappers over `POST /v1/orgs/{oid}/name`.
 
 ### Cloud Security (CNAPP)
 
@@ -87,6 +77,22 @@
   so an upgrade prompt can precede the limit. It only describes the limits;
   the collector and the provider-record validator enforce them.
 
+## 5.5.5 - July 28, 2026
+
+### CLI
+
+- **`--brief` listings for document hives**: `sop list --brief`, `note list
+  --brief` and `ai-skill list --brief` reduce each record's `data` to the
+  fields that say what it is (`description`, and for skills also `name` /
+  `when_to_use`), dropping the body. The hive listing endpoint returns whole
+  records, so listing these otherwise pulls back every procedure, note, and
+  SKILL.md — including skills' bundled supporting files. That is costly when
+  the caller is an agent deciding what applies and paying for the output in
+  context: `--brief` gives it the index, and `get --key <name>` fetches the
+  ones that matter. Default output is unchanged.
+
+### Cloud Security (CNAPP)
+
 - **Sensor↔cloud resolution keeps the resolver-readiness signal**:
   `CloudSec.resolve_sensors()` / `resolve_assets()` chunk large batches and
   merge the responses; the merge dropped `resolver_ready`, so a caller could
@@ -94,6 +100,35 @@
   provisioned in this datacenter". It is now carried through, pessimistically
   (one not-ready chunk makes the whole batch not-ready), and stays absent when
   the backend never sent it.
+
+## 5.5.4 - July 23, 2026
+
+### Organization
+
+- **Set org description (org info)**: `Organization.set_description()` /
+  `limacharlie org set-description --description ...` update an organization's
+  description without renaming it (the helper re-submits the current name so
+  only the description changes). `Organization.rename()` and `limacharlie org
+  rename` also take an optional `description` to set both at once. The
+  backend only exposes the description through the rename endpoint, so these
+  are thin wrappers over `POST /v1/orgs/{oid}/name`.
+
+## 5.5.3 - July 20, 2026
+
+### Dependencies & Python support
+
+- **`requests` 2.32.3 -> 2.33.0**: picks up the fix for GHSA-gc5v-m9x4-r6x2
+  (insecure temp-file reuse in `extract_zipped_paths()`; vulnerable `<2.33.0`).
+- **Minimum Python is now 3.10** (was 3.9). `requests` 2.33.0 requires Python
+  `>=3.10`, and Python 3.9 reached end-of-life in October 2025. The 3.9 entries
+  in the CI matrices, Cloud Build, and PyPI classifiers are removed, and the
+  orjson/pytest version shims that existed only to keep 3.9 working are
+  simplified (orjson uncapped `>=3.10.0`; pytest pinned to the CVE-fixed 9.0.3
+  for all supported versions).
+
+## 5.5.2 - July 17, 2026
+
+### Cloud Security (CNAPP)
 
 - **Multi-org fleet overview**: `limacharlie cloudsec fleet overview` /
   `CloudSec.get_fleet_overview()` — one posture row per authorized org plus
@@ -118,30 +153,9 @@
   request-scoped JWT (multi-org for user credentials when `oid` is omitted)
   without touching the client's own token, cache, or refresh callback.
 
-### Dependencies & Python support
-
-- **`requests` 2.32.3 -> 2.33.0**: picks up the fix for GHSA-gc5v-m9x4-r6x2
-  (insecure temp-file reuse in `extract_zipped_paths()`; vulnerable `<2.33.0`).
-- **Minimum Python is now 3.10** (was 3.9). `requests` 2.33.0 requires Python
-  `>=3.10`, and Python 3.9 reached end-of-life in October 2025. The 3.9 entries
-  in the CI matrices, Cloud Build, and PyPI classifiers are removed, and the
-  orjson/pytest version shims that existed only to keep 3.9 working are
-  simplified (orjson uncapped `>=3.10.0`; pytest pinned to the CVE-fixed 9.0.3
-  for all supported versions).
-
 ## 5.2.0 - March 20, 2026
 
 ### CLI
-
-- **`--brief` listings for document hives**: `sop list --brief`, `note list
-  --brief` and `ai-skill list --brief` reduce each record's `data` to the
-  fields that say what it is (`description`, and for skills also `name` /
-  `when_to_use`), dropping the body. The hive listing endpoint returns whole
-  records, so listing these otherwise pulls back every procedure, note, and
-  SKILL.md — including skills' bundled supporting files. That is costly when
-  the caller is an agent deciding what applies and paying for the output in
-  context: `--brief` gives it the index, and `get --key <name>` fetches the
-  ones that matter. Default output is unchanged.
 
 - **Lazy command loading**: CLI startup is significantly faster. Commands are
   now loaded on-demand via a static map instead of eagerly importing all 49


### PR DESCRIPTION
## Details

Cuts the 5.6.0 release and files the already-released CHANGELOG entries under the tags that actually carry them.

The CHANGELOG had drifted: the last versioned heading was `## 5.2.0`, but five releases (5.5.1 through 5.5.5, plus 5.3.x/5.4.x) were tagged out of a growing `## Unreleased` section. Work that shipped to PyPI weeks ago was still presented to readers as unreleased, and there was no way to tell from the CHANGELOG which version to install to get a given feature. Each block now sits under the version whose tag contains it, dated from that tag's commit:

| Version | Date | Entries moved there |
| --- | --- | --- |
| 5.6.0 | July 30, 2026 | search open-query listing and limits ([#327](https://github.com/refractionPOINT/python-limacharlie/pull/327)); the last four cloudsec routes and the findings owner filter ([#329](https://github.com/refractionPOINT/python-limacharlie/pull/329)) |
| 5.5.5 | July 28, 2026 | `--brief` document-hive listings ([#321](https://github.com/refractionPOINT/python-limacharlie/pull/321)); `resolver_ready` kept through the chunked resolve merge ([#323](https://github.com/refractionPOINT/python-limacharlie/pull/323)) |
| 5.5.4 | July 23, 2026 | org set-description ([#320](https://github.com/refractionPOINT/python-limacharlie/pull/320)) |
| 5.5.3 | July 20, 2026 | requests 2.33.0 and the Python 3.10 minimum ([#318](https://github.com/refractionPOINT/python-limacharlie/pull/318)) |
| 5.5.2 | July 17, 2026 | cloudsec fleet overview, provider manifests, CSV exports, inventory provider filter, `Client.request(raw_response=True)` and `Client.mint_jwt()` ([#312](https://github.com/refractionPOINT/python-limacharlie/pull/312)) |

The `--brief` entry additionally moves out of the `## 5.2.0` section, where it had been filed by mistake - it shipped in 5.5.5, four months after 5.2.0.

No entry text is added, removed or reworded: every non-heading line in the file is byte identical to master, and the whole diff is seven new headings plus the regrouping they impose. That is deliberate, so the diff is reviewable as a pure move.

Genuinely new in 5.6.0 are the two PRs merged since 5.5.5. [#327](https://github.com/refractionPOINT/python-limacharlie/pull/327) adds `limacharlie search queries` / `Search.list_open_queries()` and `limacharlie search limits` / `Search.get_limits()`, so an organization can see which searches it currently has open, which of them hold a concurrency slot, and what its resolved limits actually are - previously each limit was discoverable only by hitting it. [#329](https://github.com/refractionPOINT/python-limacharlie/pull/329) binds the last four unbound Cloud Security gateway routes (`finding causes`, `ciem identities`, `data-security stores`, `free-tier`), adds the findings owner filter across `finding list|facets` and `export findings`, and moves `--risk-band` / `--criticality` / `--tier` to client-side validation because the backend fails closed on an unknown value, which turned a typo into zero rows with a successful exit.

There is no version constant to edit anywhere in the tree: `pyproject.toml` declares `version` dynamic and setuptools-scm derives it from the git tag, writing `limacharlie/_version.py` at build time, which is what `limacharlie.__version__`, `limacharlie --version` and the `lc-cli` user agent all read. Publishing 5.6.0 means pushing the `5.6.0` tag after this merges, which triggers the PyPI workflow.

### Known gap

The restored 5.5.x sections contain the entries that were written at the time, which is not everything those releases shipped. These merged without a CHANGELOG entry and are still undocumented: #311 and #313 in 5.5.2, #314 and #315 in 5.5.3, #319 in 5.5.4, #322, #326 and #328 in 5.5.5. Releases 5.3.0 through 5.5.1 have no CHANGELOG coverage at all. Backfilling those is a separate pass and is not attempted here.

## Blast radius / isolation

Documentation only. The single changed file is `CHANGELOG.md`; no Python module, dependency pin, packaging metadata, or CI configuration is touched. Nothing that runs at import time, request time, or build time reads this file, and no test asserts on its structure. The one downstream effect is on the release process itself: the tag pushed after this merge determines the published version.

## Performance characteristics

None. No code paths change.

## Notable contracts / APIs

No contract changes in this PR. The API surface added by the release is already merged and documented in the section being cut: two new `Search` methods plus their CLI commands, four new `CloudSec` methods plus their CLI commands, and the findings owner filter. All are additive - no existing signature, flag, output shape or wire format changes, so 5.6.0 is backward compatible with 5.5.5 for both SDK and CLI callers.

The version number is a minor bump rather than a patch because the release adds six new commands and their SDK methods, matching the precedent set by 5.3.0 and 5.4.0 for new command groups.

## Related PRs

- [#327](https://github.com/refractionPOINT/python-limacharlie/pull/327) - list an organization's open searches and report its search limits
- [#329](https://github.com/refractionPOINT/python-limacharlie/pull/329) - bind the last four cloudsec routes and the findings owner filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)
