### PR TITLE
Bump pygments to 2.20.0 (CVE-2026-4539)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "pyyaml==6.0.2",
     "tabulate==0.9.0",
     "termcolor==2.5.0",
-    "pygments==2.19.1",
+    "pygments==2.20.0",
     "rich==13.9.4",
     "cryptography==50.0.0",
     "click==8.1.8",


### PR DESCRIPTION
## Summary

| CVE | Severity | Package | Old | New |
|---|---|---|---|---|
| CVE-2026-4539 | LOW | Pygments | 2.19.1 | 2.20.0 |

Affected range `< 2.20.0`. This is the alert left over after #333, which bumped only cryptography.

## Test plan

- [x] `pip install -e .` in a clean venv — resolves cleanly, `Pygments 2.20.0` confirmed
- [x] `pytest tests/unit` — **3758 passed, 19 skipped**

## Notes

Single-line change to `pyproject.toml`.