### PR TITLE
cloudsec: bind the AppSec code lane (code repos|status|sbom, --repo)

### DIFF
--- a/limacharlie/commands/cloudsec.py
+++ b/limacharlie/commands/cloudsec.py
@@ -1049,6 +1049,15 @@ def _finding_filter_options(f):
         help="Only findings on (non-)reachable resources.",
     )(f)
     f = click.option(
+        "--repo", "repos", multiple=True,
+        help="Filter to findings about a source repository, keyed "
+             "'<owner>/<name>' as 'cloudsec code repos' returns it; "
+             "repeatable (OR). This is the AppSec code lane's selector — "
+             "cloud findings have no repository, so any --repo excludes "
+             "them, and an unknown repository returns nothing rather than "
+             "everything.",
+    )(f)
+    f = click.option(
         "--account", "accounts", multiple=True,
         help="Filter by cloud account; repeatable (OR).",
     )(f)
@@ -1284,6 +1293,7 @@ def group() -> None:
       compliance ...      Framework assessment, frameworks, assignments
       chokepoint ...      Estate-wide chokepoints (list, dismiss, restore)
       resolve ...         Sensor <-> cloud asset resolution
+      code ...            AppSec code lane (repos, status, sbom)
       caasm ...           Third-party asset inventory, coverage, ingest
       provider ...        Credential preflight + coverage manifests
       policy ...          cloudsec_policy vocabulary + autocomplete
@@ -1383,6 +1393,128 @@ def free_tier(ctx) -> None:
 
 
 # ---------------------------------------------------------------------------
+# code subgroup (AppSec code lane)
+# ---------------------------------------------------------------------------
+
+@group.group("code")
+def code_group() -> None:
+    """AppSec code lane: repositories, scan status, SBOM export.
+
+    The lane scans a connected source-control organization's repositories
+    and emits findings into the same worklist the cloud collectors feed,
+    so the findings themselves are read with 'cloudsec finding list
+    --repo <owner>/<name>'. The commands here are the repository-shaped
+    views that worklist cannot give you.
+    """
+
+
+@code_group.command("repos")
+@click.option("-q", "--search", "q", default=None,
+              help="Substring over the repository key and urn.")
+@click.option("--with-findings/--without-findings", "has_findings", default=None,
+              help="Only repositories that do (or do not) have at least one "
+                   "OPEN finding. Omit for no constraint — note that "
+                   "--without-findings is a real selection, not 'no filter'.")
+@click.option("--provider", default=None,
+              help="Source-control provider (e.g. github). Omit for all.")
+@click.option("--all", "walk_all", is_flag=True, default=False,
+              help="Follow the cursor and return EVERY matching repository "
+                   "instead of one page. Filtered pages can be short without "
+                   "being last, so this is the safe way to get a full list.")
+@_paging_options
+@pass_context
+def code_repos(ctx, q, has_findings, provider, walk_all, cursor, limit) -> None:
+    """List the org's repositories with their scan state and finding counts.
+
+    Each row carries 'repo' (the '<owner>/<name>' key the other code
+    commands take), the connector's view of the repository, the code-scan
+    state, and the OPEN finding rollup.
+
+    'scan_status' is scanned, partial or unknown. 'partial' means the scan
+    tripped a limit, so the finding set is INCOMPLETE — not a clean bill.
+    'unknown' means this view has no scan state for the repository and says
+    so rather than guessing; 'cloudsec code status' is the authoritative
+    view of the run.
+
+    \b
+    Examples:
+      limacharlie cloudsec code repos
+      limacharlie cloudsec code repos --with-findings --all
+      limacharlie cloudsec code repos -q appsec-fixtures
+    """
+    cs = _get_cloudsec(ctx)
+    if walk_all:
+        repos = list(cs.iter_code_repos(
+            q=q, has_findings=has_findings, provider=provider, limit=limit))
+        _output(ctx, {"repos": repos, "next_cursor": ""})
+        return
+    _output(ctx, cs.list_code_repos(
+        q=q, has_findings=has_findings, provider=provider,
+        cursor=cursor, limit=limit,
+    ))
+
+
+@code_group.command("status")
+@pass_context
+def code_status(ctx) -> None:
+    """Code-lane run status per source-control connection, plus totals.
+
+    An empty 'code' list means the lane has never run in this org. It does
+    NOT mean the lane is off — that is the org's code_scanning
+    cloudsec_policy record, not this call.
+
+    \b
+    Example:
+      limacharlie cloudsec code status
+    """
+    cs = _get_cloudsec(ctx)
+    _output(ctx, cs.get_code_status())
+
+
+@code_group.command("sbom")
+@click.option("--repo", required=True,
+              help="Repository key '<owner>/<name>' as 'code repos' returns it.")
+@click.option("--provider", default=None,
+              help="Source-control provider the key belongs to (default github).")
+@click.option("-o", "--output", "output_path", default=None,
+              help="Download the SBOM document to this path (gzipped "
+                   "CycloneDX). Omit to print the signed link and its "
+                   "metadata instead.")
+@pass_context
+def code_sbom(ctx, repo, provider, output_path) -> None:
+    """Get a repository's SBOM: the signed link, or the document itself.
+
+    A repository with no SBOM yet is not an error — the command reports the
+    reason (the first scan has not completed, or the lane is not enabled in
+    this datacenter) and exits non-zero only when -o was requested, since
+    there is then nothing to write.
+
+    The link is short-lived and leaves the API's auth boundary, so fetch it
+    promptly and do not store it.
+
+    \b
+    Examples:
+      limacharlie cloudsec code sbom --repo refractionPOINT/lc-appsec-fixtures
+      limacharlie cloudsec code sbom --repo acme/api -o api-sbom.json.gz
+    """
+    cs = _get_cloudsec(ctx)
+    if not output_path:
+        _output(ctx, cs.get_code_sbom(repo, provider=provider))
+        return
+    body = cs.download_code_sbom(repo, provider=provider)
+    if body is None:
+        # Report WHY, from the same response the download consulted, rather
+        # than writing an empty file that looks like an SBOM of nothing.
+        resp = cs.get_code_sbom(repo, provider=provider)
+        raise click.ClickException(
+            "no SBOM available for %s (%s)"
+            % (repo, resp.get("reason") or "unknown reason"))
+    with open(output_path, "wb") as f:
+        f.write(body)
+    _output(ctx, {"repo": repo, "written": output_path, "size_bytes": len(body)})
+
+
+# ---------------------------------------------------------------------------
 # fleet subgroup (multi-org)
 # ---------------------------------------------------------------------------
 
@@ -1437,7 +1569,7 @@ def finding_group() -> None:
 @_sort_options
 @_paging_options
 @pass_context
-def finding_list(ctx, severities, finding_classes, statuses, accounts,
+def finding_list(ctx, severities, finding_classes, statuses, accounts, repos,
                  owners, unassigned, sla_states, reachable, kev, q, sort,
                  order, cursor, limit) -> None:
     """List the merged, risk-ranked cloud-security findings.
@@ -1449,6 +1581,7 @@ def finding_list(ctx, severities, finding_classes, statuses, accounts,
       limacharlie cloudsec finding list --owner alice@corp.com
       limacharlie cloudsec finding list --unassigned
       limacharlie cloudsec finding list --sla breached --sort due_at
+      limacharlie cloudsec finding list --repo refractionPOINT/lc-appsec-fixtures
     """
     cs = _get_cloudsec(ctx)
     _output(ctx, cs.list_findings(
@@ -1456,6 +1589,7 @@ def finding_list(ctx, severities, finding_classes, statuses, accounts,
         finding_class=list(finding_classes) or None,
         status=list(statuses) or None,
         account=list(accounts) or None,
+        repo=list(repos) or None,
         owner=_selector_with_empty(owners, unassigned),
         sla=list(sla_states) or None,
         reachable=reachable,
@@ -1478,7 +1612,7 @@ def finding_list(ctx, severities, finding_classes, statuses, accounts,
                    "slots with any --owner values, so past ~50 combined a "
                    "pin can still be dropped.")
 @pass_context
-def finding_facets(ctx, severities, finding_classes, statuses, accounts,
+def finding_facets(ctx, severities, finding_classes, statuses, accounts, repos,
                    owners, unassigned, sla_states, reachable, kev, q,
                    owner_pins) -> None:
     """Cross-filtered facet counts for the findings worklist.
@@ -1494,6 +1628,7 @@ def finding_facets(ctx, severities, finding_classes, statuses, accounts,
         finding_class=list(finding_classes) or None,
         status=list(statuses) or None,
         account=list(accounts) or None,
+        repo=list(repos) or None,
         owner=_selector_with_empty(owners, unassigned),
         owner_pin=list(owner_pins) or None,
         sla=list(sla_states) or None,
@@ -1513,7 +1648,7 @@ def finding_facets(ctx, severities, finding_classes, statuses, accounts,
               help="Rollup size (default 20, cap 200). Not a page size — the "
                    "rollup is not paginated; 'distinct' reports the tail.")
 @pass_context
-def finding_causes(ctx, severities, finding_classes, statuses, accounts,
+def finding_causes(ctx, severities, finding_classes, statuses, accounts, repos,
                    owners, unassigned, sla_states, reachable, kev, q, cause,
                    limit) -> None:
     """Findings grouped by CAUSE: one edit that closes N findings.
@@ -1530,6 +1665,7 @@ def finding_causes(ctx, severities, finding_classes, statuses, accounts,
         finding_class=list(finding_classes) or None,
         status=list(statuses) or None,
         account=list(accounts) or None,
+        repo=list(repos) or None,
         owner=_selector_with_empty(owners, unassigned),
         sla=list(sla_states) or None,
         reachable=reachable,
@@ -2499,7 +2635,7 @@ def export_group() -> None:
 @_sort_options
 @_export_output_option
 @pass_context
-def export_findings(ctx, severities, finding_classes, statuses, accounts,
+def export_findings(ctx, severities, finding_classes, statuses, accounts, repos,
                     owners, unassigned, sla_states, reachable, kev, q, sort,
                     order, output_path) -> None:
     """Export the (filtered) findings worklist as CSV.
@@ -2516,6 +2652,7 @@ def export_findings(ctx, severities, finding_classes, statuses, accounts,
         finding_class=list(finding_classes) or None,
         status=list(statuses) or None,
         account=list(accounts) or None,
+        repo=list(repos) or None,
         owner=_selector_with_empty(owners, unassigned),
         sla=list(sla_states) or None,
         reachable=reachable,

--- a/limacharlie/sdk/cloudsec.py
+++ b/limacharlie/sdk/cloudsec.py
@@ -30,6 +30,8 @@ from __future__ import annotations
 
 import json
 from typing import Any, TYPE_CHECKING
+from urllib.parse import quote as _quote
+from urllib.request import urlopen as _urlopen
 
 from ..errors import AuthenticationError
 
@@ -93,6 +95,7 @@ def _finding_query_pairs(
     owner: list[str] | None = None,
     owner_pin: list[str] | None = None,
     sla: list[str] | None = None,
+    repo: list[str] | None = None,
     reachable: bool | None = None,
     kev: bool | None = None,
     q: str | None = None,
@@ -107,11 +110,15 @@ def _finding_query_pairs(
     selection: ``owner=[""]`` asks for the UNASSIGNED bucket, so it must
     reach the wire as ``?owner=`` rather than being dropped. Pass ``None``
     (or ``[]``) for no owner constraint.
+
+    ``repo`` is deliberately NOT like that. A finding with no repository is
+    every cloud finding in the estate, which is not a bucket anyone selects,
+    so an empty value there matches nothing rather than meaning "unscoped".
     """
     return _query_pairs(
         severity=severity, finding_class=finding_class, status=status,
         account=account, owner=owner, owner_pin=owner_pin, sla=sla,
-        reachable=reachable, kev=kev, q=q,
+        repo=repo, reachable=reachable, kev=kev, q=q,
         sort=sort, order=order, cursor=cursor, limit=limit,
     )
 
@@ -266,6 +273,7 @@ class CloudSec:
         account: list[str] | None = None,
         owner: list[str] | None = None,
         sla: list[str] | None = None,
+        repo: list[str] | None = None,
         reachable: bool | None = None,
         kev: bool | None = None,
         q: str | None = None,
@@ -308,6 +316,12 @@ class CloudSec:
                 default SLA, so on an org that has not written an ``sla``
                 policy every finding is ``none``. Counted by the ``sla``
                 facet of :meth:`get_finding_facets`.
+            repo: Source-repository filter values, OR'd, keyed
+                ``"<owner>/<name>"`` exactly as :meth:`list_code_repos`
+                returns them. This is the AppSec code lane's subject
+                selector; cloud findings have no repository, so any repo
+                filter excludes them. An unknown repository honestly
+                returns nothing rather than widening the read.
             reachable: Only findings on (non-)reachable resources.
             kev: Only findings with (without) a KEV vulnerability.
             q: Substring search.
@@ -325,7 +339,7 @@ class CloudSec:
         """
         return self._get("findings", _finding_query_pairs(
             severity=severity, finding_class=finding_class, status=status,
-            account=account, owner=owner, sla=sla,
+            account=account, owner=owner, sla=sla, repo=repo,
             reachable=reachable, kev=kev, q=q,
             sort=sort, order=order, cursor=cursor, limit=limit,
         ))
@@ -340,6 +354,7 @@ class CloudSec:
         owner: list[str] | None = None,
         owner_pin: list[str] | None = None,
         sla: list[str] | None = None,
+        repo: list[str] | None = None,
         reachable: bool | None = None,
         kev: bool | None = None,
         q: str | None = None,
@@ -372,6 +387,13 @@ class CloudSec:
                 EVERY state key, zeroes included, so a caller never has to
                 invent a missing count (a ``breached`` chip that vanishes
                 reads as "the feature is off", not "you are on top of it").
+            repo: Source-repository filter values — see
+                :meth:`list_findings`. The ``repo`` facet counts the code
+                lane's repositories and NEVER the non-repository findings
+                (there is no empty-key bucket holding the cloud estate). It
+                is capped at the top 200 by count, with any actively
+                selected repository pinned into it; ``repo_truncated``
+                reports whether any were dropped.
 
         Returns:
             ``{"facets": {..., "owner": {"": 12, "alice@corp.com": 3},
@@ -381,7 +403,7 @@ class CloudSec:
         return self._get("findings/facets", _finding_query_pairs(
             severity=severity, finding_class=finding_class, status=status,
             account=account, owner=owner, owner_pin=owner_pin, sla=sla,
-            reachable=reachable, kev=kev, q=q,
+            repo=repo, reachable=reachable, kev=kev, q=q,
         ))
 
     def list_finding_causes(
@@ -394,6 +416,7 @@ class CloudSec:
         account: list[str] | None = None,
         owner: list[str] | None = None,
         sla: list[str] | None = None,
+        repo: list[str] | None = None,
         reachable: bool | None = None,
         kev: bool | None = None,
         q: str | None = None,
@@ -450,7 +473,7 @@ class CloudSec:
         """
         pairs = _finding_query_pairs(
             severity=severity, finding_class=finding_class, status=status,
-            account=account, owner=owner, sla=sla,
+            account=account, owner=owner, sla=sla, repo=repo,
             reachable=reachable, kev=kev, q=q,
             limit=limit,
         )
@@ -1112,6 +1135,151 @@ class CloudSec:
         return self._get("compliance/assignments")
 
     # ------------------------------------------------------------------
+    # AppSec code lane (repositories, scan status, SBOM)
+    # ------------------------------------------------------------------
+
+    def list_code_repos(
+        self,
+        *,
+        q: str | None = None,
+        has_findings: bool | None = None,
+        provider: str | None = None,
+        cursor: str | None = None,
+        limit: int | None = None,
+    ) -> dict[str, Any]:
+        """List the org's source repositories as the code lane sees them.
+
+        Args:
+            q: Case-insensitive substring over the repository key
+                (``"<owner>/<name>"``) and urn.
+            has_findings: ``True`` keeps only repositories with at least one
+                OPEN finding, ``False`` only those with none. ``None`` (the
+                default) leaves the dimension unconstrained — note that
+                ``False`` is a real selection, not "no filter".
+            provider: Source-control provider (e.g. ``github``). Omit for
+                every provider that produces repositories.
+            cursor: Keyset-pagination token from a previous page.
+            limit: Page size (default 100, server clamps to 500).
+
+        Returns:
+            ``{"repos": [...], "next_cursor": str}``. Each entry carries
+            ``repo`` (the ``"<owner>/<name>"`` key every other code call
+            takes), ``urn``, ``owner``, ``provider``, the source-control
+            facts the connector collected, the code-scan state, and the open
+            finding rollup (``open_findings``, ``findings_by_class``,
+            ``findings_by_severity``, ``top_severity``).
+
+            ``scan_status`` is ``scanned``, ``partial`` or ``unknown``.
+            ``partial`` means the scan tripped a limit, so the finding set is
+            INCOMPLETE and must not be read as a clean bill. ``unknown``
+            means this surface has no scan state for the repository and says
+            so rather than implying it was never scanned; a machine-readable
+            ``scan_status_reason`` accompanies it. The authoritative view of
+            the RUN is :meth:`get_code_status`.
+
+        Note:
+            A page can come back SHORT while ``next_cursor`` is still set —
+            the cursor, not the page length, says whether the walk is done.
+            Use :meth:`iter_code_repos` to walk it correctly.
+        """
+        return self._get("code/repos", _query_pairs(
+            q=q, has_findings=has_findings, provider=provider,
+            cursor=cursor, limit=limit,
+        ))
+
+    def iter_code_repos(self, **selectors: Any):
+        """Yield every repository matching the selectors, page by page.
+
+        Wraps :meth:`list_code_repos` and follows ``next_cursor`` to the end,
+        which is the only correct way to walk this endpoint: a filtered page
+        may be short without being the last one, so a caller that stops on a
+        short page silently truncates its own inventory.
+        """
+        selectors.pop("cursor", None)
+        cursor: str | None = None
+        while True:
+            page = self.list_code_repos(cursor=cursor, **selectors)
+            for repo in page.get("repos") or []:
+                yield repo
+            cursor = page.get("next_cursor") or None
+            if not cursor:
+                return
+
+    def get_code_status(self) -> dict[str, Any]:
+        """Code-lane run status and lane-wide finding totals.
+
+        Returns:
+            ``{"code": [...], "any_running": bool, "totals": {...}}``. Each
+            ``code`` entry is one source-control connection's
+            ``code:<provider>`` scan row (``is_running``, ``started_at``,
+            ``completed_at``, ``last_stats``, ``last_error``); ``totals``
+            carries ``open_findings``, ``by_class`` and
+            ``repos_with_findings``.
+
+            An EMPTY ``code`` list means the lane has never run in this org.
+            It does not mean the lane is off — that is a property of the
+            org's ``code_scanning`` policy record, not of this call.
+        """
+        return self._get("code/status")
+
+    def get_code_sbom(
+        self, repo: str, *, provider: str | None = None,
+    ) -> dict[str, Any]:
+        """Get a short-lived signed download link for a repository's SBOM.
+
+        Args:
+            repo: The repository key ``"<owner>/<name>"`` as
+                :meth:`list_code_repos` returns it.
+            provider: The source-control provider the key belongs to;
+                defaults to ``github`` server-side.
+
+        Returns:
+            ``{"repo": str, "urn": str, "sbom": {...} | None,
+            "reason": str}``. When ``sbom`` is present it carries ``url``
+            (a plain unauthenticated GET, valid until ``expires_at``),
+            ``size_bytes``, ``format`` (``cyclonedx``) and
+            ``content_encoding`` (``gzip``).
+
+            A repository with no SBOM yet is a SUCCESSFUL response with
+            ``sbom`` ``None`` and a machine-readable ``reason``
+            (``sbom_not_generated_yet`` or
+            ``code_lane_not_enabled_in_datacenter``) — only a repository the
+            org does not have is an error. Check ``sbom`` for ``None`` before
+            using it.
+
+        Note:
+            The document is served straight from object storage, so the link
+            leaves this API's auth boundary. It is deliberately short-lived;
+            fetch it promptly and do not store it.
+        """
+        # The key contains a '/', so it is percent-encoded into ONE path
+        # segment. The gateway accepts either spelling, but encoding is what
+        # keeps the request unambiguous for anything in between.
+        quoted = _quote(repo, safe="")
+        return self._get(
+            f"code/repos/{quoted}/sbom", _query_pairs(provider=provider))
+
+    def download_code_sbom(
+        self, repo: str, *, provider: str | None = None,
+    ) -> bytes | None:
+        """Fetch a repository's SBOM document itself (gzipped CycloneDX).
+
+        Returns ``None`` — not an exception — when the repository has no SBOM
+        yet, mirroring :meth:`get_code_sbom`. Any other failure raises.
+
+        The signed link is fetched with a bare HTTP GET and deliberately
+        WITHOUT this SDK's auth headers: it is a pre-signed object-storage
+        URL, and sending LimaCharlie credentials to a Google endpoint would
+        put them somewhere they do not belong.
+        """
+        resp = self.get_code_sbom(repo, provider=provider)
+        sbom = resp.get("sbom")
+        if not sbom or not sbom.get("url"):
+            return None
+        with _urlopen(sbom["url"]) as body:
+            return body.read()
+
+    # ------------------------------------------------------------------
     # Overview / trends / chokepoints
     # ------------------------------------------------------------------
 
@@ -1506,6 +1674,7 @@ class CloudSec:
         account: list[str] | None = None,
         owner: list[str] | None = None,
         sla: list[str] | None = None,
+        repo: list[str] | None = None,
         reachable: bool | None = None,
         kev: bool | None = None,
         q: str | None = None,
@@ -1526,7 +1695,7 @@ class CloudSec:
         """
         pairs = _finding_query_pairs(
             severity=severity, finding_class=finding_class, status=status,
-            account=account, owner=owner, sla=sla,
+            account=account, owner=owner, sla=sla, repo=repo,
             reachable=reachable, kev=kev, q=q,
             sort=sort, order=order,
         )

--- a/tests/unit/test_cli_cloudsec.py
+++ b/tests/unit/test_cli_cloudsec.py
@@ -47,6 +47,7 @@ def _invoke(args, mock_cs_cls, return_value=None, stdin=None):
             "test_provider", "get_provider_manifests", "get_fleet_overview",
             "get_policy_vocabulary", "suggest_policy_values",
             "simulate_resource_match", "simulate_finding_match",
+            "list_code_repos", "get_code_status", "get_code_sbom",
         ]
     })
     # CSV exports return raw text, not a JSON-renderable object.
@@ -74,7 +75,7 @@ class TestCloudSecHelp:
             "overview", "changes", "risk-trend", "scan-status", "topology",
             "free-tier", "fleet", "finding", "attack-path", "ciem", "inventory",
             "data-security", "resource", "graph", "query", "compliance",
-            "chokepoint", "resolve", "caasm", "provider", "policy",
+            "chokepoint", "resolve", "caasm", "code", "provider", "policy",
             "simulate", "export",
         ]:
             assert cmd in result.output
@@ -268,6 +269,7 @@ class TestFindingCommands:
                 finding_class=["toxic_combination"],
                 status=None,
                 account=None,
+                repo=None,
                 owner=None,
                 sla=None,
                 reachable=True,
@@ -828,8 +830,8 @@ class TestExport:
             assert result.output == "col_a,col_b\n1,2\n"
             inst.export_findings_csv.assert_called_once_with(
                 severity=["CRITICAL"], finding_class=None, status=["open"],
-                account=None, owner=None, sla=None, reachable=None, kev=None,
-                q=None, sort=None, order=None,
+                account=None, repo=None, owner=None, sla=None, reachable=None,
+                kev=None, q=None, sort=None, order=None,
             )
 
     def test_export_findings_to_file(self, tmp_path):
@@ -1212,6 +1214,7 @@ class TestFindingCauses:
                 finding_class=None,
                 status=None,
                 account=None,
+                repo=None,
                 owner=None,
                 sla=None,
                 reachable=None,
@@ -1446,3 +1449,114 @@ class TestClosedVocabularyGuards:
             )
             assert result.exit_code == 0, result.output
             assert inst.list_data_stores.call_args[1]["tier"] is None
+
+
+# ---------------------------------------------------------------------------
+# code subgroup (AppSec code lane)
+# ---------------------------------------------------------------------------
+
+
+class TestCloudSecCode:
+    def test_code_subgroup_help(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["cloudsec", "code", "--help"])
+        assert result.exit_code == 0
+        for cmd in ["repos", "status", "sbom"]:
+            assert cmd in result.output
+
+    def test_code_repos(self):
+        with _patches()[0], _patches()[1], _patches()[2] as cs_cls:
+            result, inst = _invoke(
+                ["cloudsec", "code", "repos", "-q", "fixtures",
+                 "--with-findings", "--provider", "github", "--limit", "50"],
+                cs_cls, {"repos": [], "next_cursor": ""})
+            assert result.exit_code == 0
+            inst.list_code_repos.assert_called_once()
+            kwargs = inst.list_code_repos.call_args.kwargs
+            assert kwargs["q"] == "fixtures"
+            assert kwargs["has_findings"] is True
+            assert kwargs["provider"] == "github"
+            assert kwargs["limit"] == 50
+
+    def test_code_repos_without_findings_is_a_selection(self):
+        """--without-findings must reach the SDK as False, not as None."""
+        with _patches()[0], _patches()[1], _patches()[2] as cs_cls:
+            result, inst = _invoke(
+                ["cloudsec", "code", "repos", "--without-findings"],
+                cs_cls, {"repos": []})
+            assert result.exit_code == 0
+            assert inst.list_code_repos.call_args.kwargs["has_findings"] is False
+
+    def test_code_repos_all_walks_the_cursor(self):
+        """--all must use the iterator, not a single page.
+
+        A filtered page can be short without being last, so a one-shot page
+        would quietly under-report the repository list.
+        """
+        with _patches()[0], _patches()[1], _patches()[2] as cs_cls:
+            result, inst = _invoke(["cloudsec", "code", "repos", "--all"],
+                                   cs_cls, {"repos": []})
+            inst.iter_code_repos.return_value = iter([])
+            assert result.exit_code == 0
+            inst.iter_code_repos.assert_called_once()
+            inst.list_code_repos.assert_not_called()
+
+    def test_code_status(self):
+        with _patches()[0], _patches()[1], _patches()[2] as cs_cls:
+            result, inst = _invoke(["cloudsec", "code", "status"], cs_cls,
+                                   {"code": [], "totals": {}})
+            assert result.exit_code == 0
+            inst.get_code_status.assert_called_once_with()
+
+    def test_code_sbom_prints_the_link(self):
+        with _patches()[0], _patches()[1], _patches()[2] as cs_cls:
+            result, inst = _invoke(
+                ["cloudsec", "code", "sbom", "--repo", "acme/api"],
+                cs_cls, {"repo": "acme/api", "sbom": {"url": "https://x"}})
+            assert result.exit_code == 0
+            inst.get_code_sbom.assert_called_once_with("acme/api", provider=None)
+            inst.download_code_sbom.assert_not_called()
+
+    def test_code_sbom_download_missing_is_an_explained_failure(self):
+        """-o with no SBOM must NOT write an empty file that looks like one."""
+        with _patches()[0], _patches()[1], _patches()[2] as cs_cls:
+            inst = MagicMock()
+            cs_cls.return_value = inst
+            inst.download_code_sbom.return_value = None
+            inst.get_code_sbom.return_value = {
+                "repo": "acme/api", "sbom": None,
+                "reason": "sbom_not_generated_yet"}
+            runner = CliRunner()
+            with runner.isolated_filesystem():
+                result = runner.invoke(cli, [
+                    "--output", "json", "cloudsec", "code", "sbom",
+                    "--repo", "acme/api", "-o", "out.gz"])
+                assert result.exit_code != 0
+                assert "sbom_not_generated_yet" in result.output
+                import os
+                assert not os.path.exists("out.gz")
+
+    def test_finding_list_forwards_repo(self):
+        with _patches()[0], _patches()[1], _patches()[2] as cs_cls:
+            result, inst = _invoke(
+                ["cloudsec", "finding", "list", "--repo", "acme/api",
+                 "--repo", "acme/web"], cs_cls, {"findings": []})
+            assert result.exit_code == 0
+            assert inst.list_findings.call_args.kwargs["repo"] == [
+                "acme/api", "acme/web"]
+
+    def test_finding_facets_forwards_repo(self):
+        with _patches()[0], _patches()[1], _patches()[2] as cs_cls:
+            result, inst = _invoke(
+                ["cloudsec", "finding", "facets", "--repo", "acme/api"],
+                cs_cls, {"facets": {}})
+            assert result.exit_code == 0
+            assert inst.get_finding_facets.call_args.kwargs["repo"] == ["acme/api"]
+
+    def test_export_findings_forwards_repo(self):
+        with _patches()[0], _patches()[1], _patches()[2] as cs_cls:
+            result, inst = _invoke(
+                ["cloudsec", "export", "findings", "--repo", "acme/api"],
+                cs_cls)
+            assert result.exit_code == 0
+            assert inst.export_findings_csv.call_args.kwargs["repo"] == ["acme/api"]

--- a/tests/unit/test_cli_lazy_loading_regression.py
+++ b/tests/unit/test_cli_lazy_loading_regression.py
@@ -152,7 +152,7 @@ EXPECTED_SUBCOMMANDS: dict[str, frozenset[str]] = {
         "overview", "changes", "risk-trend", "scan-status", "topology",
         "free-tier", "fleet", "finding", "attack-path", "ciem", "inventory",
         "data-security", "resource", "graph", "query", "compliance",
-        "chokepoint", "resolve", "caasm", "provider", "policy",
+        "chokepoint", "resolve", "caasm", "code", "provider", "policy",
         "simulate", "export",
     }),
     "detection": frozenset({"get", "list"}),

--- a/tests/unit/test_sdk_cloudsec.py
+++ b/tests/unit/test_sdk_cloudsec.py
@@ -867,3 +867,106 @@ class TestFreeTier:
         assert url == f"cloudsec/{OID}/free-tier"
         assert qp is None
         assert out["max_providers"] == 2
+
+
+class TestCodeLane:
+    """The AppSec code lane's read surface."""
+
+    def test_list_code_repos_defaults(self, cs, mock_org):
+        mock_org.client.request.return_value = {"repos": []}
+        cs.list_code_repos()
+        url, qp = _get_call(mock_org)
+        assert url == f"cloudsec/{OID}/code/repos"
+        assert qp is None
+
+    def test_list_code_repos_selectors(self, cs, mock_org):
+        mock_org.client.request.return_value = {"repos": []}
+        cs.list_code_repos(q="fixtures", has_findings=True,
+                           provider="github", cursor="c1", limit=50)
+        url, qp = _get_call(mock_org)
+        assert url == f"cloudsec/{OID}/code/repos"
+        assert ("q", "fixtures") in qp
+        assert ("has_findings", "true") in qp
+        assert ("provider", "github") in qp
+        assert ("cursor", "c1") in qp
+        assert ("limit", "50") in qp
+
+    def test_has_findings_false_is_a_real_selection(self, cs, mock_org):
+        """False must reach the wire; only None means 'no constraint'.
+
+        Dropping it would silently return the whole repository list under a
+        filter the caller believes is narrowing it to the clean ones.
+        """
+        mock_org.client.request.return_value = {"repos": []}
+        cs.list_code_repos(has_findings=False)
+        _, qp = _get_call(mock_org)
+        assert ("has_findings", "false") in qp
+
+        mock_org.client.request.return_value = {"repos": []}
+        cs.list_code_repos(has_findings=None)
+        _, qp = _get_call(mock_org)
+        assert qp is None
+
+    def test_iter_code_repos_follows_short_pages(self, cs, mock_org):
+        """A filtered page can be SHORT and still not be the last one.
+
+        The walk must be driven by next_cursor, never by the page length —
+        stopping on a short page silently truncates the caller's inventory.
+        """
+        pages = [
+            {"repos": [{"repo": "acme/api"}], "next_cursor": "c1"},
+            {"repos": [], "next_cursor": "c2"},
+            {"repos": [{"repo": "acme/web"}], "next_cursor": ""},
+        ]
+        mock_org.client.request.side_effect = pages
+        got = list(cs.iter_code_repos(q="acme"))
+        assert [r["repo"] for r in got] == ["acme/api", "acme/web"]
+        assert mock_org.client.request.call_count == 3
+
+    def test_get_code_status(self, cs, mock_org):
+        mock_org.client.request.return_value = {"code": [], "totals": {}}
+        cs.get_code_status()
+        url, qp = _get_call(mock_org)
+        assert url == f"cloudsec/{OID}/code/status"
+        assert qp is None
+
+    def test_get_code_sbom_percent_encodes_the_key(self, cs, mock_org):
+        """The repository key holds a '/', which must not become a path split.
+
+        Left unencoded it would add a path segment and the route would not
+        match at all — a 404 with nothing on the client side to explain it.
+        """
+        mock_org.client.request.return_value = {"sbom": None}
+        cs.get_code_sbom("refractionPOINT/lc-appsec-fixtures")
+        url, qp = _get_call(mock_org)
+        assert url == (
+            f"cloudsec/{OID}/code/repos/"
+            "refractionPOINT%2Flc-appsec-fixtures/sbom")
+        assert qp is None
+
+    def test_get_code_sbom_provider(self, cs, mock_org):
+        mock_org.client.request.return_value = {"sbom": None}
+        cs.get_code_sbom("acme/api", provider="github")
+        _, qp = _get_call(mock_org)
+        assert qp == [("provider", "github")]
+
+    def test_download_code_sbom_returns_none_when_absent(self, cs, mock_org):
+        """No SBOM yet is a normal answer, not an exception."""
+        mock_org.client.request.return_value = {
+            "sbom": None, "reason": "sbom_not_generated_yet"}
+        assert cs.download_code_sbom("acme/api") is None
+
+    def test_repo_filter_rides_the_findings_worklist(self, cs, mock_org):
+        """repo is an ordinary findings selector, on every worklist read."""
+        for call, path in (
+            (lambda: cs.list_findings(repo=["acme/api", "acme/web"]), "findings"),
+            (lambda: cs.get_finding_facets(repo=["acme/api", "acme/web"]), "findings/facets"),
+            (lambda: cs.list_finding_causes(repo=["acme/api", "acme/web"]), "findings/causes"),
+        ):
+            mock_org.client.request.reset_mock()
+            mock_org.client.request.return_value = {}
+            call()
+            url, qp = _get_call(mock_org)
+            assert url == f"cloudsec/{OID}/{path}"
+            assert ("repo", "acme/api") in qp
+            assert ("repo", "acme/web") in qp


### PR DESCRIPTION
Client bindings for the AppSec code lane's read surface. Roadmap **P1.4**; backend legion_graph#136, gateway lc_api-go#882.

## SDK (`limacharlie/sdk/cloudsec.py`)

`list_code_repos` / `iter_code_repos` / `get_code_status` / `get_code_sbom` / `download_code_sbom`, plus the `repo` selector on **every** findings binding — `list_findings`, `get_finding_facets`, `list_finding_causes` and `export_findings_csv` — so a facet count and an export keep describing the same population as the list they annotate.

## CLI (`limacharlie/commands/cloudsec.py`)

```
limacharlie cloudsec code repos [-q] [--with-findings/--without-findings] [--provider] [--all]
limacharlie cloudsec code status
limacharlie cloudsec code sbom --repo <owner>/<name> [-o FILE]
limacharlie cloudsec finding list --repo <owner>/<name>
```

## Three things the bindings do rather than leave to the caller

**`iter_code_repos` exists because a filtered repository page can be SHORT without being the last one.** The walk is driven by `next_cursor`, never by page length; a caller that stops on a short page silently truncates its own inventory. `code repos --all` uses it, and the test drives a middle page that returns zero rows with a cursor still set.

**`has_findings` is a tri-state, not a flag.** `--without-findings` is a real selection — the repositories with a clean bill — so `False` must reach the wire and only `None` means unconstrained. Dropping it would return the whole repository list under a filter the caller believes is narrowing it.

**`code sbom -o` refuses to write when there is no SBOM yet**, and reports the machine-readable reason instead. An empty file that looks like an SBOM of nothing is the worse failure.

Also: `download_code_sbom` fetches the pre-signed link with a bare `urlopen`, deliberately **without** this SDK's auth headers — those credentials do not belong on a Google endpoint. And `get_code_sbom` percent-encodes the repository key so its `/` cannot become a path split.

## Tests

`pytest tests/unit/` green: **3799 passed, 6 skipped**. New: `TestCodeLane` in the SDK suite (route shapes, the tri-state, the short-page walk, the percent-encoding, `download_code_sbom` returning `None` rather than raising, and `repo` riding all three worklist reads) and `TestCloudSecCode` in the CLI suite (subgroup help, option forwarding, `--all` using the iterator, and `-o` with no SBOM failing loudly and writing nothing). The three existing `assert_called_once_with` expectations that enumerate every findings kwarg were updated for `repo`, and the lazy-loading subcommand registry gained `code`.