### PR TITLE
cloudsec: limacharlie cloudsec code scan / ingest (P2.2)

### DIFF
--- a/limacharlie/commands/cloudsec.py
+++ b/limacharlie/commands/cloudsec.py
@@ -28,6 +28,10 @@ the one provider command here is the pre-save credential preflight
 from __future__ import annotations
 
 import json
+import os
+import subprocess
+import tempfile
+import uuid
 from typing import Any
 
 import click
@@ -38,6 +42,15 @@ from ..sdk.organization import Organization
 from ..sdk.cloudsec import CloudSec
 from ..output import format_output, detect_output_format
 from ..discovery import register_explain
+
+
+# DEFAULT_CODE_SCANNER_IMAGE is the published scanner image `cloudsec code scan` runs.
+#
+# It is pinned to a TAG rather than floating on `latest`, because a scan's findings depend on
+# which engines produced them: a moving tag would silently change what a local scan reports
+# between two runs of the same command on the same tree, and the report records the versions
+# it used precisely so that question has an answer.
+DEFAULT_CODE_SCANNER_IMAGE = "gcr.io/legion-212720/github.com/refractionpoint/lc-code-scanner:v0.4.0"
 
 
 # ---------------------------------------------------------------------------
@@ -1512,6 +1525,239 @@ def code_sbom(ctx, repo, provider, output_path) -> None:
     with open(output_path, "wb") as f:
         f.write(body)
     _output(ctx, {"repo": repo, "written": output_path, "size_bytes": len(body)})
+
+
+@code_group.command("ingest")
+@click.option("--repo", required=True,
+              help="Repository key '<owner>/<name>' as 'code repos' returns it.")
+@click.option("--source", required=True,
+              type=click.Choice(["sarif", "cyclonedx", "report"]),
+              help="Format of the document: a SARIF results file, a CycloneDX "
+                   "bill of materials, or the LimaCharlie scanner's own "
+                   "report/v1 document.")
+@click.option("-f", "--file", "file_path", required=True,
+              help="Path to the document. A '.gz' file is sent compressed.")
+@click.option("--commit", default=None,
+              help="The revision the document describes. Recorded, not verified.")
+@click.option("--ref", default=None, help="The branch or tag, for context.")
+@click.option("--provider", default=None,
+              help="Source-control provider the key belongs to (default github).")
+@pass_context
+def code_ingest(ctx, repo, source, file_path, commit, ref, provider) -> None:
+    """Push scan results your own pipeline produced for one repository.
+
+    Findings are deduplicated against the hosted scan by IDENTITY, so
+    pushing something the hosted scanner also found updates it rather than
+    duplicating it, and re-pushing an identical document writes nothing.
+
+    Two things in the response are worth reading rather than skimming.
+    'notes' lists what the FORMAT could not carry — 'secrets_not_ingestable'
+    means credential findings were deliberately dropped, because a pushed
+    document cannot carry the keyed digest a secret is identified by and the
+    plaintext is never accepted. And 'closed' counts findings THIS source
+    previously reported and no longer does; a pushed document can never
+    close what the hosted scanner found.
+
+    \b
+    Examples:
+      limacharlie cloudsec code ingest --repo acme/api --source sarif -f trivy.sarif
+      limacharlie cloudsec code ingest --repo acme/api --source report -f report.json.gz \\
+          --commit "$GITHUB_SHA"
+    """
+    with open(file_path, "rb") as f:
+        document = f.read()
+    cs = _get_cloudsec(ctx)
+    _output(ctx, cs.ingest_code_results(
+        repo, source, document, commit=commit, ref=ref, provider=provider))
+
+
+@code_group.command("scan")
+@click.argument("path", type=click.Path(exists=True, file_okay=False), default=".")
+@click.option("--repo", default=None,
+              help="Repository key '<owner>/<name>' to attribute the results to. "
+                   "Required with --ingest; inferred from the checkout's git "
+                   "origin when it can be.")
+@click.option("--commit", default=None,
+              help="The revision scanned. Read from the checkout when omitted.")
+@click.option("--ingest/--no-ingest", "do_ingest", default=False,
+              help="Push the report to LimaCharlie when the scan finishes.")
+@click.option("--image", "image", default=None,
+              help="Scanner image to run (default: the published lc-code-scanner).")
+@click.option("--binary", "binary", default=None,
+              help="Run this scanner-agent binary instead of the container.")
+@click.option("-o", "--output", "output_path", default=None,
+              help="Write the report here (default: a temporary file).")
+@click.option("--scanners", default="sca,iac,licenses",
+              help="Comma-separated scanners to run. 'secrets' is OFF by default "
+                   "on purpose — see the command help.")
+@click.option("--timeout", "timeout_s", default=1800, show_default=True,
+              help="Seconds to allow the scan.")
+@pass_context
+def code_scan(ctx, path, repo, commit, do_ingest, image, binary,
+              output_path, scanners, timeout_s) -> None:
+    """Scan a local checkout with the LimaCharlie code scanner.
+
+    Runs the scanner over PATH (default: the current directory) and writes a
+    report/v1 document. With --ingest the report is pushed to this org, where
+    it lands on exactly the rows a hosted scan of the same repository would
+    write — the report format is loss-free, so the identities match and
+    nothing is duplicated.
+
+    The scanner runs in a container by default; --binary runs an already
+    installed scanner-agent instead. Nothing about the checkout leaves your
+    machine except the report.
+
+    SECRET SCANNING IS OFF BY DEFAULT and turning it on here is usually not
+    what you want. A secret's identity in this pipeline is a digest keyed by
+    a deployment-side salt this command does not have, so locally-found
+    credentials would not dedupe against the hosted scan's, and the ingest
+    refuses them for the same reason. Use the hosted lane for secrets.
+
+    \b
+    Examples:
+      limacharlie cloudsec code scan
+      limacharlie cloudsec code scan ~/src/api --repo acme/api --ingest \\
+          --commit "$(git -C ~/src/api rev-parse HEAD)"
+    """
+    root = os.path.abspath(path)
+    if commit is None:
+        commit = _git_head(root)
+    if repo is None:
+        repo = _git_repo_key(root)
+    if do_ingest and not repo:
+        raise click.ClickException(
+            "--ingest needs --repo '<owner>/<name>': this checkout's git origin "
+            "did not name one, and the repository a finding belongs to is not "
+            "something to guess")
+    if not do_ingest and not output_path:
+        # Checked BEFORE the scan, not after: the report would be written into a
+        # temporary directory and deleted with it, so the command would spend
+        # minutes of somebody's time and leave nothing behind.
+        raise click.ClickException(
+            "nothing to do with the report: pass --ingest to push it, or "
+            "-o PATH to keep it")
+
+    wanted = [s.strip() for s in scanners.split(",") if s.strip()]
+    with tempfile.TemporaryDirectory(prefix="lc-code-scan-") as workdir:
+        report_path = output_path or os.path.join(workdir, "report.json.gz")
+        spec = {
+            "job_id": "cli-%s" % uuid.uuid4().hex[:12],
+            # Carried for the agent's own logging only; the scan is local and the
+            # agent makes no per-tenant decision from it.
+            "oid": getattr(ctx.obj, 'oid', None) or "",
+            "mode": "repo",
+            "source": {"kind": "local", "org": "", "repo": "", "clone_url": "", "ref": "",
+                       "default_branch": ""},
+            "local_path": root,
+            "scanners": {s: (s in wanted) for s in
+                         ("sca", "secrets", "secrets_history", "iac", "sast", "licenses", "images")},
+        }
+        _run_code_scanner(spec, root, report_path, workdir,
+                          image=image, binary=binary, timeout_s=timeout_s)
+        with open(report_path, "rb") as f:
+            document = f.read()
+
+        result = {"report": output_path or None, "bytes": len(document),
+                  "repo": repo, "commit": commit}
+        if output_path:
+            result["written"] = output_path
+        if do_ingest:
+            cs = _get_cloudsec(ctx)
+            result["ingest"] = cs.ingest_code_results(
+                repo, "report", document, commit=commit)
+        _output(ctx, result)
+
+
+def _git_head(root: str) -> str | None:
+    """The checked-out commit, or None. A checkout that is not a git working
+    tree is a perfectly good thing to scan; it just cannot say which revision
+    it is, and a fabricated one would mislabel every finding."""
+    return _git(root, "rev-parse", "HEAD")
+
+
+def _git_repo_key(root: str) -> str | None:
+    """The '<owner>/<name>' key from the checkout's origin remote, or None.
+
+    Read from the remote rather than from the directory name: the directory
+    is whatever the person cloned it as, and the repository a finding belongs
+    to is an identity, not a label."""
+    url = _git(root, "config", "--get", "remote.origin.url")
+    if not url:
+        return None
+    url = url.rstrip("/")
+    if url.endswith(".git"):
+        url = url[:-4]
+    # Both spellings of a remote: https://host/owner/name and git@host:owner/name
+    tail = url.split(":")[-1] if "://" not in url else url.split("://", 1)[1]
+    parts = [p for p in tail.split("/") if p]
+    if len(parts) < 2:
+        return None
+    return "%s/%s" % (parts[-2], parts[-1])
+
+
+def _git(root: str, *args: str) -> str | None:
+    try:
+        out = subprocess.run(("git", "-C", root) + args, capture_output=True,
+                             timeout=15, check=False)
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if out.returncode != 0:
+        return None
+    return out.stdout.decode("utf-8", "replace").strip() or None
+
+
+def _run_code_scanner(spec: dict, root: str, report_path: str, workdir: str,
+                      *, image: str | None, binary: str | None,
+                      timeout_s: int) -> None:
+    """Run the scanner over a local checkout, writing report_path.
+
+    Two backends, one contract: the agent reads a spec and writes a gzipped
+    report. The container is the default because it carries the pinned engines
+    and their databases; a locally installed binary is offered because a CI
+    job that already has one should not pay for a pull.
+    """
+    spec_path = os.path.join(workdir, "spec.json")
+    if binary:
+        with open(spec_path, "w") as f:
+            json.dump(spec, f)
+        cmd = [binary, "--spec", spec_path, "--out", report_path]
+        _run(cmd, timeout_s)
+        return
+
+    # In the container the checkout is mounted read-only at a fixed path, so
+    # the spec has to name THAT path rather than the host's.
+    container_spec = dict(spec, local_path="/scan/src")
+    with open(spec_path, "w") as f:
+        json.dump(container_spec, f)
+    out_dir = os.path.dirname(os.path.abspath(report_path)) or "."
+    cmd = [
+        "docker", "run", "--rm",
+        "-v", "%s:/scan/src:ro" % root,
+        "-v", "%s:/scan/spec.json:ro" % spec_path,
+        "-v", "%s:/scan/out" % out_dir,
+        image or DEFAULT_CODE_SCANNER_IMAGE,
+        "--spec", "/scan/spec.json",
+        "--out", "/scan/out/%s" % os.path.basename(report_path),
+    ]
+    _run(cmd, timeout_s)
+
+
+def _run(cmd: list[str], timeout_s: int) -> None:
+    try:
+        proc = subprocess.run(cmd, timeout=timeout_s, check=False)
+    except FileNotFoundError:
+        raise click.ClickException(
+            "%s is not installed or not on PATH" % cmd[0])
+    except subprocess.TimeoutExpired:
+        raise click.ClickException(
+            "the scan did not finish within %d seconds" % timeout_s)
+    if proc.returncode != 0:
+        # The agent's exit codes are a closed vocabulary and it prints a
+        # machine-readable line before a fatal exit, so the caller is pointed at
+        # that rather than told a number.
+        raise click.ClickException(
+            "the scanner exited %d; its last line names the reason "
+            "(error_code=...)" % proc.returncode)
 
 
 # ---------------------------------------------------------------------------

--- a/limacharlie/commands/cloudsec.py
+++ b/limacharlie/commands/cloudsec.py
@@ -64,6 +64,20 @@ DEFAULT_CODE_SCANNER_IMAGE = "gcr.io/legion-212720/github.com/refractionpoint/lc
 DEFAULT_TRIVY_DB_REPO = "ghcr.io/aquasecurity/trivy-db:2"
 DEFAULT_TRIVY_JAVA_DB_REPO = "ghcr.io/aquasecurity/trivy-java-db:1"
 
+# The scanner passes a local scan can run, and the two it cannot.
+#
+# `secrets` and `secrets_history` are refused rather than passed through because they cannot
+# WORK here and fail confusingly: the scanner keys a credential's identity with a
+# deployment-side salt this command does not have, refuses to look without one, and exits
+# with a configuration error that reads like a broken install. The honest answer belongs at
+# the flag, not three layers down.
+LOCAL_SCANNERS = ("sca", "iac", "sast", "licenses", "images")
+UNAVAILABLE_LOCAL_SCANNERS = ("secrets", "secrets_history")
+
+# maxCodeIngestBytes on the collection host, mirrored so an over-cap document is refused
+# here — with the size in the message — instead of arriving as a gateway 400 about a body.
+MAX_CODE_INGEST_BYTES = 20 * 1024 * 1024
+
 
 # ---------------------------------------------------------------------------
 # Explain texts
@@ -1578,6 +1592,11 @@ def code_ingest(ctx, repo, source, file_path, commit, ref, provider) -> None:
     """
     with open(file_path, "rb") as f:
         document = f.read()
+    if len(document) > MAX_CODE_INGEST_BYTES:
+        # Refused here, with the size, rather than as a gateway error about a request body.
+        raise click.ClickException(
+            "%s is %d bytes; the ingest limit is %d. Narrow the scan, or push the "
+            "sections separately." % (file_path, len(document), MAX_CODE_INGEST_BYTES))
     cs = _get_cloudsec(ctx)
     _output(ctx, cs.ingest_code_results(
         repo, source, document, commit=commit, ref=ref, provider=provider))
@@ -1611,10 +1630,13 @@ def code_ingest(ctx, repo, source, file_path, commit, ref, provider) -> None:
 @click.option("--checks-repo", "checks_repo", default=None,
               help="Infrastructure-checks bundle. Omit to use the checks compiled into "
                    "the scanner, which is what a local scan normally wants.")
+@click.option("--ref", default=None, help="The branch or tag scanned, for context.")
+@click.option("--provider", default=None,
+              help="Source-control provider the repository key belongs to (default github).")
 @pass_context
 def code_scan(ctx, path, repo, commit, do_ingest, image, binary,
               output_path, scanners, timeout_s, db_repo, java_db_repo,
-              checks_repo) -> None:
+              checks_repo, ref, provider) -> None:
     """Scan a local checkout with the LimaCharlie code scanner.
 
     Runs the scanner over PATH (default: the current directory) and writes a
@@ -1657,7 +1679,22 @@ def code_scan(ctx, path, repo, commit, do_ingest, image, binary,
             "nothing to do with the report: pass --ingest to push it, or "
             "-o PATH to keep it")
 
-    wanted = [s.strip() for s in scanners.split(",") if s.strip()]
+    wanted = _resolve_local_scanners(scanners)
+    if ":" in root:
+        # The checkout is bind-mounted as "<path>:/scan/src:ro", so a ':' in the path
+        # mis-splits and docker answers with an opaque "invalid mode".
+        raise click.ClickException(
+            "the path %r contains ':', which cannot be mounted into the scanner; "
+            "scan it from a path without one" % root)
+    if output_path:
+        # Probed BEFORE the scan for the same reason the two checks above are: discovering
+        # an unwritable destination after twenty minutes of scanning helps nobody.
+        try:
+            with open(output_path, "ab"):
+                pass
+        except OSError as exc:
+            raise click.ClickException("cannot write %s: %s" % (output_path, exc))
+
     with tempfile.TemporaryDirectory(prefix="lc-code-scan-") as workdir:
         # The report is always produced inside this private directory and copied out
         # afterwards. Writing it straight to --output would mean mounting whatever
@@ -1674,7 +1711,7 @@ def code_scan(ctx, path, repo, commit, do_ingest, image, binary,
                        "default_branch": ""},
             "local_path": root,
             "scanners": {s: (s in wanted) for s in
-                         ("sca", "secrets", "secrets_history", "iac", "sast", "licenses", "images")},
+                         LOCAL_SCANNERS + UNAVAILABLE_LOCAL_SCANNERS},
         }
         _run_code_scanner(spec, root, report_path, workdir,
                           image=image, binary=binary, timeout_s=timeout_s,
@@ -1691,8 +1728,33 @@ def code_scan(ctx, path, repo, commit, do_ingest, image, binary,
         if do_ingest:
             cs = _get_cloudsec(ctx)
             result["ingest"] = cs.ingest_code_results(
-                repo, "report", document, commit=commit)
+                repo, "report", document, commit=commit, ref=ref, provider=provider)
         _output(ctx, result)
+
+
+def _resolve_local_scanners(scanners: str) -> list[str]:
+    """Parse --scanners, refusing what a local scan cannot run.
+
+    Unknown names used to be dropped silently, so `--scanners sca,iacc` ran a
+    narrower scan and reported success without ever mentioning the pass that did
+    not happen — a scan that looks clean because nobody looked."""
+    wanted = [s.strip().lower() for s in scanners.split(",") if s.strip()]
+    if not wanted:
+        raise click.ClickException("--scanners is empty; name at least one of: %s"
+                                   % ", ".join(LOCAL_SCANNERS))
+    unavailable = [s for s in wanted if s in UNAVAILABLE_LOCAL_SCANNERS]
+    if unavailable:
+        raise click.ClickException(
+            "%s cannot run in a local scan: a credential's identity here is a digest keyed "
+            "by a value only the hosted lane holds, so locally-found secrets would neither "
+            "dedupe against the hosted scan's nor be accepted by the ingest. Use the hosted "
+            "lane for secrets." % ", ".join(unavailable))
+    unknown = [s for s in wanted if s not in LOCAL_SCANNERS]
+    if unknown:
+        raise click.ClickException(
+            "unknown scanner(s) %s; available: %s"
+            % (", ".join(unknown), ", ".join(LOCAL_SCANNERS)))
+    return wanted
 
 
 def _git_head(root: str) -> str | None:
@@ -1714,8 +1776,26 @@ def _git_repo_key(root: str) -> str | None:
     url = url.rstrip("/")
     if url.endswith(".git"):
         url = url[:-4]
-    # Both spellings of a remote: https://host/owner/name and git@host:owner/name
-    tail = url.split(":")[-1] if "://" not in url else url.split("://", 1)[1]
+    # Both spellings of a HOSTED remote: https://host/owner/name and git@host:owner/name.
+    # A remote with neither — a local path, a `file://` clone — is refused rather than
+    # parsed: `/home/me/src/api` would yield the plausible and wrong key "src/api", which
+    # is exactly the guess the --ingest guard says must not happen. The guard catches an
+    # ABSENT remote; this catches an unparseable one.
+    if "://" in url:
+        scheme, rest = url.split("://", 1)
+        if scheme.lower() in ("file",) or "/" not in rest:
+            return None
+        host, _, tail = rest.partition("/")
+        if "." not in host and host.lower() != "localhost":
+            return None
+    elif ":" in url:
+        host, _, tail = url.partition(":")
+        # scp-style: [user@]host:owner/name
+        host = host.rpartition("@")[2]
+        if "." not in host:
+            return None
+    else:
+        return None
     parts = [p for p in tail.split("/") if p]
     if len(parts) < 2:
         return None
@@ -1777,18 +1857,25 @@ def _run_code_scanner(spec: dict, root: str, report_path: str, workdir: str,
     container_spec = dict(spec, local_path="/scan/src")
     with open(spec_path, "w") as f:
         json.dump(container_spec, f)
+    container = "lc-code-scan-%s" % uuid.uuid4().hex[:12]
     cmd = [
         "docker", "run", "--rm",
-        # As the invoking user, so the report comes back readable. The container's own
-        # identity is irrelevant here — there is no sandbox boundary on a laptop — and a
-        # root-owned artifact in somebody's temporary directory is a nuisance at best.
-        "--user", "%d:%d" % (os.getuid(), os.getgid()),
+        # A name, so a scan that outruns --timeout can actually be stopped: killing the
+        # docker CLI leaves the container running, and the temporary directory it is
+        # writing into is about to be removed under it.
+        "--name", container,
         "-v", "%s:/scan" % workdir,
         "-v", "%s:/scan/src:ro" % root,
         "-e", "TRIVY_DB_REPOSITORY=%s" % db_repo,
         "-e", "TRIVY_JAVA_DB_REPOSITORY=%s" % java_db_repo,
         "-e", "HOME=/scan",
     ]
+    if hasattr(os, "getuid"):
+        # As the invoking user, so the report comes back readable. The container's own
+        # identity is irrelevant here — there is no sandbox boundary on a laptop — and a
+        # root-owned artifact in somebody's temporary directory is a nuisance at best.
+        # Absent on Windows, where the daemon does not map host uids anyway.
+        cmd += ["--user", "%d:%d" % (os.getuid(), os.getgid())]
     if checks_repo:
         cmd += ["-e", "TRIVY_CHECKS_BUNDLE_REPOSITORY=%s" % checks_repo]
     cmd += [
@@ -1796,16 +1883,27 @@ def _run_code_scanner(spec: dict, root: str, report_path: str, workdir: str,
         "--spec", "/scan/spec.json",
         "--out", "/scan/%s" % os.path.basename(report_path),
     ] + extra_args
-    _run(cmd, timeout_s)
+    _run(cmd, timeout_s, container=container)
 
 
-def _run(cmd: list[str], timeout_s: int, *, env: dict | None = None) -> None:
+def _run(cmd: list[str], timeout_s: int, *, env: dict | None = None,
+         container: str | None = None) -> None:
     try:
         proc = subprocess.run(cmd, timeout=timeout_s, check=False, env=env)
     except FileNotFoundError:
         raise click.ClickException(
             "%s is not installed or not on PATH" % cmd[0])
     except subprocess.TimeoutExpired:
+        if container:
+            # The timeout killed the docker CLI, not the container: the daemon keeps
+            # running it, and the workspace it is writing into is removed a moment from
+            # now. Stop it explicitly, best-effort — a failure to kill must not replace the
+            # timeout message with a docker one.
+            try:
+                subprocess.run(["docker", "kill", container], timeout=30,
+                               check=False, capture_output=True)
+            except (OSError, subprocess.SubprocessError):
+                pass
         raise click.ClickException(
             "the scan did not finish within %d seconds" % timeout_s)
     if proc.returncode != 0:

--- a/limacharlie/commands/cloudsec.py
+++ b/limacharlie/commands/cloudsec.py
@@ -52,6 +52,18 @@ from ..discovery import register_explain
 # it used precisely so that question has an answer.
 DEFAULT_CODE_SCANNER_IMAGE = "gcr.io/legion-212720/github.com/refractionpoint/lc-code-scanner:v0.4.0"
 
+# Where a LOCAL scan gets its vulnerability data.
+#
+# The image deliberately ships no defaults for these: inside the hosted sandbox the only
+# reachable source is our own mirror, and a default pointing anywhere else would work on a
+# developer's machine and then fail inside the sandbox — where the failure reads as "no
+# vulnerabilities found". A local scan is the other case, and it is the one these are for:
+# the machine has ordinary internet access, and the upstream public databases are what it
+# should use. Override with --db-repo / --java-db-repo for an air-gapped or rate-limited
+# network, which is exactly when a mirror of your own is worth having.
+DEFAULT_TRIVY_DB_REPO = "ghcr.io/aquasecurity/trivy-db:2"
+DEFAULT_TRIVY_JAVA_DB_REPO = "ghcr.io/aquasecurity/trivy-java-db:1"
+
 
 # ---------------------------------------------------------------------------
 # Explain texts
@@ -1592,9 +1604,17 @@ def code_ingest(ctx, repo, source, file_path, commit, ref, provider) -> None:
                    "on purpose — see the command help.")
 @click.option("--timeout", "timeout_s", default=1800, show_default=True,
               help="Seconds to allow the scan.")
+@click.option("--db-repo", "db_repo", default=DEFAULT_TRIVY_DB_REPO, show_default=True,
+              help="Vulnerability database to scan against.")
+@click.option("--java-db-repo", "java_db_repo", default=DEFAULT_TRIVY_JAVA_DB_REPO,
+              show_default=True, help="Java artifact index to resolve jars against.")
+@click.option("--checks-repo", "checks_repo", default=None,
+              help="Infrastructure-checks bundle. Omit to use the checks compiled into "
+                   "the scanner, which is what a local scan normally wants.")
 @pass_context
 def code_scan(ctx, path, repo, commit, do_ingest, image, binary,
-              output_path, scanners, timeout_s) -> None:
+              output_path, scanners, timeout_s, db_repo, java_db_repo,
+              checks_repo) -> None:
     """Scan a local checkout with the LimaCharlie code scanner.
 
     Runs the scanner over PATH (default: the current directory) and writes a
@@ -1639,7 +1659,11 @@ def code_scan(ctx, path, repo, commit, do_ingest, image, binary,
 
     wanted = [s.strip() for s in scanners.split(",") if s.strip()]
     with tempfile.TemporaryDirectory(prefix="lc-code-scan-") as workdir:
-        report_path = output_path or os.path.join(workdir, "report.json.gz")
+        # The report is always produced inside this private directory and copied out
+        # afterwards. Writing it straight to --output would mean mounting whatever
+        # directory the caller named into the container, which hands a container running
+        # third-party engines write access to a directory it has no business in.
+        report_path = os.path.join(workdir, "report.json.gz")
         spec = {
             "job_id": "cli-%s" % uuid.uuid4().hex[:12],
             # Carried for the agent's own logging only; the scan is local and the
@@ -1653,13 +1677,16 @@ def code_scan(ctx, path, repo, commit, do_ingest, image, binary,
                          ("sca", "secrets", "secrets_history", "iac", "sast", "licenses", "images")},
         }
         _run_code_scanner(spec, root, report_path, workdir,
-                          image=image, binary=binary, timeout_s=timeout_s)
+                          image=image, binary=binary, timeout_s=timeout_s,
+                          db_repo=db_repo, java_db_repo=java_db_repo,
+                          checks_repo=checks_repo)
         with open(report_path, "rb") as f:
             document = f.read()
 
-        result = {"report": output_path or None, "bytes": len(document),
-                  "repo": repo, "commit": commit}
+        result = {"bytes": len(document), "repo": repo, "commit": commit}
         if output_path:
+            with open(output_path, "wb") as f:
+                f.write(document)
             result["written"] = output_path
         if do_ingest:
             cs = _get_cloudsec(ctx)
@@ -1707,8 +1734,9 @@ def _git(root: str, *args: str) -> str | None:
 
 
 def _run_code_scanner(spec: dict, root: str, report_path: str, workdir: str,
-                      *, image: str | None, binary: str | None,
-                      timeout_s: int) -> None:
+                      *, image: str | None, binary: str | None, timeout_s: int,
+                      db_repo: str, java_db_repo: str,
+                      checks_repo: str | None) -> None:
     """Run the scanner over a local checkout, writing report_path.
 
     Two backends, one contract: the agent reads a spec and writes a gzipped
@@ -1717,34 +1745,63 @@ def _run_code_scanner(spec: dict, root: str, report_path: str, workdir: str,
     job that already has one should not pay for a pull.
     """
     spec_path = os.path.join(workdir, "spec.json")
+    # The scanner takes its data sources from the environment and refuses to start without
+    # them — which is the right behaviour for the sandbox and means a local run has to
+    # supply them.
+    env = dict(os.environ)
+    env["TRIVY_DB_REPOSITORY"] = db_repo
+    env["TRIVY_JAVA_DB_REPOSITORY"] = java_db_repo
+    extra_args: list[str] = []
+    if checks_repo:
+        env["TRIVY_CHECKS_BUNDLE_REPOSITORY"] = checks_repo
+    else:
+        # The checks compiled into the binary. A local scan has no mirror to point at, and
+        # the alternative — refusing to scan infrastructure files — would be a silent gap.
+        extra_args.append("--embedded-checks")
+
     if binary:
         with open(spec_path, "w") as f:
             json.dump(spec, f)
-        cmd = [binary, "--spec", spec_path, "--out", report_path]
-        _run(cmd, timeout_s)
+        cmd = [binary, "--spec", spec_path, "--out", report_path] + extra_args
+        _run(cmd, timeout_s, env=env)
         return
 
-    # In the container the checkout is mounted read-only at a fixed path, so
-    # the spec has to name THAT path rather than the host's.
+    # In the container the checkout is mounted read-only at a fixed path, so the spec has to
+    # name THAT path rather than the host's.
+    #
+    # The private working directory is mounted as the container's whole scratch volume
+    # (/scan), which is what the engines unpack databases and layers into. Mounting only an
+    # output directory looked tidier and does not work: the container runs as the invoking
+    # user (so the report comes back readable) and that user does not own the image's own
+    # /scan.
     container_spec = dict(spec, local_path="/scan/src")
     with open(spec_path, "w") as f:
         json.dump(container_spec, f)
-    out_dir = os.path.dirname(os.path.abspath(report_path)) or "."
     cmd = [
         "docker", "run", "--rm",
+        # As the invoking user, so the report comes back readable. The container's own
+        # identity is irrelevant here — there is no sandbox boundary on a laptop — and a
+        # root-owned artifact in somebody's temporary directory is a nuisance at best.
+        "--user", "%d:%d" % (os.getuid(), os.getgid()),
+        "-v", "%s:/scan" % workdir,
         "-v", "%s:/scan/src:ro" % root,
-        "-v", "%s:/scan/spec.json:ro" % spec_path,
-        "-v", "%s:/scan/out" % out_dir,
+        "-e", "TRIVY_DB_REPOSITORY=%s" % db_repo,
+        "-e", "TRIVY_JAVA_DB_REPOSITORY=%s" % java_db_repo,
+        "-e", "HOME=/scan",
+    ]
+    if checks_repo:
+        cmd += ["-e", "TRIVY_CHECKS_BUNDLE_REPOSITORY=%s" % checks_repo]
+    cmd += [
         image or DEFAULT_CODE_SCANNER_IMAGE,
         "--spec", "/scan/spec.json",
-        "--out", "/scan/out/%s" % os.path.basename(report_path),
-    ]
+        "--out", "/scan/%s" % os.path.basename(report_path),
+    ] + extra_args
     _run(cmd, timeout_s)
 
 
-def _run(cmd: list[str], timeout_s: int) -> None:
+def _run(cmd: list[str], timeout_s: int, *, env: dict | None = None) -> None:
     try:
-        proc = subprocess.run(cmd, timeout=timeout_s, check=False)
+        proc = subprocess.run(cmd, timeout=timeout_s, check=False, env=env)
     except FileNotFoundError:
         raise click.ClickException(
             "%s is not installed or not on PATH" % cmd[0])

--- a/limacharlie/sdk/cloudsec.py
+++ b/limacharlie/sdk/cloudsec.py
@@ -28,6 +28,7 @@ here are the pre-save credential preflight
 
 from __future__ import annotations
 
+import base64
 import json
 from typing import Any, TYPE_CHECKING
 from urllib.parse import quote as _quote
@@ -1278,6 +1279,71 @@ class CloudSec:
             return None
         with _urlopen(sbom["url"]) as body:
             return body.read()
+
+    def ingest_code_results(
+        self,
+        repo: str,
+        source: str,
+        document: bytes | str | dict[str, Any],
+        *,
+        commit: str | None = None,
+        ref: str | None = None,
+        provider: str | None = None,
+    ) -> dict[str, Any]:
+        """Push results your own pipeline produced for one repository.
+
+        The document is recorded as Cloud Security findings on that
+        repository, deduplicated against the hosted scan by IDENTITY — so
+        pushing something the hosted scanner also found updates it rather
+        than duplicating it, and re-pushing an identical document writes
+        nothing.
+
+        Args:
+            repo: the ``"<owner>/<name>"`` key :meth:`list_code_repos`
+                returns. It must already be in the org's collected
+                inventory and be selected by an enabled ``code_scanning``
+                policy — the same switch the hosted lane uses.
+            source: ``"sarif"``, ``"cyclonedx"`` or ``"report"`` (the
+                LimaCharlie scanner's own ``report/v1`` document, which is
+                loss-free and therefore dedupes exactly).
+            document: the document, as raw bytes (gzipped or not), a string,
+                or an already-parsed object.
+            commit: the revision the document describes. Recorded, not
+                verified, and worth sending: it is what tells somebody
+                reading a finding which checkout produced it.
+
+        Returns:
+            ``{"result": {...}}`` — what landed: ``findings``, the SoR
+            counters (``created``/``updated``/``deleted``/``unchanged``),
+            what the merge did (``enriched``/``carried_forward``/``closed``)
+            and ``notes``, the machine-readable list of things the FORMAT
+            could not carry. A ``notes`` entry is not an error; it is the
+            honest half of the answer, and ``secrets_not_ingestable`` in
+            particular means credential findings were deliberately dropped
+            (a pushed document cannot carry the keyed digest a secret is
+            identified by, and the plaintext is never accepted).
+
+        A pushed document can only ever close findings IT previously
+        reported. It can never close what the hosted scanner found.
+        """
+        body: dict[str, Any] = {"repo": repo, "source": source}
+        if isinstance(document, (bytes, bytearray)):
+            # Sent base64 rather than decoded here: the document may be a gzip
+            # stream (the scanner writes report.json.gz) and decoding it
+            # locally only to re-encode it as JSON would parse a multi-megabyte
+            # payload twice for nothing.
+            body["document_b64"] = base64.b64encode(bytes(document)).decode("ascii")
+        elif isinstance(document, str):
+            body["document_b64"] = base64.b64encode(document.encode("utf-8")).decode("ascii")
+        else:
+            body["document"] = document
+        if commit is not None:
+            body["commit"] = commit
+        if ref is not None:
+            body["ref"] = ref
+        if provider is not None:
+            body["provider"] = provider
+        return self._post("code/ingest", body)
 
     # ------------------------------------------------------------------
     # Overview / trends / chokepoints

--- a/tests/unit/test_cli_cloudsec.py
+++ b/tests/unit/test_cli_cloudsec.py
@@ -1,6 +1,7 @@
 """Tests for limacharlie cloudsec CLI commands."""
 
 import json
+import os
 
 from unittest.mock import patch, MagicMock
 
@@ -1528,6 +1529,76 @@ class TestCloudSecCode:
             assert result.exit_code != 0
             assert "--repo" in result.output
             inst.ingest_code_results.assert_not_called()
+
+    def test_code_scan_container_invocation(self, tmp_path, monkeypatch):
+        """The docker argv is the only genuinely fragile thing in this command — the
+        mounts, the identity it runs as, and the data sources the scanner refuses to
+        start without. It is asserted here because getting it wrong produces a scanner
+        that cannot run at all, which is what happened once already."""
+        from limacharlie.commands import cloudsec as cs_mod
+
+        captured = {}
+
+        def fake_run(cmd, timeout_s, *, env=None, container=None):
+            captured["cmd"] = cmd
+            captured["container"] = container
+            # Stand in for the scanner: the caller reads this file next.
+            out = cmd[cmd.index("--out") + 1]
+            host_out = os.path.join(
+                cmd[cmd.index("-v") + 1].split(":")[0], os.path.basename(out))
+            with open(host_out, "wb") as f:
+                f.write(b"REPORT")
+
+        monkeypatch.setattr(cs_mod, "_run", fake_run)
+        with _patches()[0], _patches()[1], _patches()[2] as cs_cls:
+            result, _ = _invoke(
+                ["cloudsec", "code", "scan", str(tmp_path), "--repo", "acme/api",
+                 "-o", str(tmp_path / "report.json.gz")],
+                cs_cls, {"result": {}})
+        assert result.exit_code == 0, result.output
+        cmd = captured["cmd"]
+        assert cmd[:3] == ["docker", "run", "--rm"]
+        joined = " ".join(cmd)
+        # The checkout is mounted READ-ONLY; the scratch volume is the private workdir.
+        assert "%s:/scan/src:ro" % str(tmp_path) in cmd
+        assert any(a.endswith(":/scan") for a in cmd)
+        # The scanner refuses to start without these, by design.
+        assert any(a.startswith("TRIVY_DB_REPOSITORY=") for a in cmd)
+        assert any(a.startswith("TRIVY_JAVA_DB_REPOSITORY=") for a in cmd)
+        # No checks mirror was given, so the compiled-in checks are used rather than
+        # silently skipping infrastructure files.
+        assert "--embedded-checks" in cmd
+        assert captured["container"] and "--name" in cmd
+        assert "--spec" in joined and "/scan/spec.json" in joined
+
+    def test_code_scan_refuses_scanners_it_cannot_run(self, tmp_path):
+        """An unknown scanner used to be dropped silently — a narrower scan reported as a
+        successful one. And `secrets` cannot work locally at all."""
+        for bad, expect in [("sca,iacc", "unknown scanner"),
+                            ("sca,secrets", "cannot run in a local scan")]:
+            with _patches()[0], _patches()[1], _patches()[2] as cs_cls:
+                result, _ = _invoke(
+                    ["cloudsec", "code", "scan", str(tmp_path), "--repo", "acme/api",
+                     "-o", str(tmp_path / "r.gz"), "--scanners", bad],
+                    cs_cls, {"result": {}})
+            assert result.exit_code != 0, bad
+            assert expect in result.output, result.output
+
+    def test_git_repo_key_refuses_a_remote_that_names_no_repository(self):
+        """A local remote yields a plausible, wrong key — exactly the guess --ingest
+        refuses to make from an absent one."""
+        from limacharlie.commands import cloudsec as cs_mod
+
+        cases = {
+            "https://github.com/acme/api.git": "acme/api",
+            "git@github.com:acme/api.git": "acme/api",
+            "/home/me/src/api": None,
+            "file:///home/me/src/api": None,
+            "../sibling/api": None,
+        }
+        for url, want in cases.items():
+            with patch.object(cs_mod, "_git", return_value=url):
+                assert cs_mod._git_repo_key("/anywhere") == want, url
 
     def test_code_repos_all_walks_the_cursor(self):
         """--all must use the iterator, not a single page.

--- a/tests/unit/test_cli_cloudsec.py
+++ b/tests/unit/test_cli_cloudsec.py
@@ -48,6 +48,7 @@ def _invoke(args, mock_cs_cls, return_value=None, stdin=None):
             "get_policy_vocabulary", "suggest_policy_values",
             "simulate_resource_match", "simulate_finding_match",
             "list_code_repos", "get_code_status", "get_code_sbom",
+            "ingest_code_results",
         ]
     })
     # CSV exports return raw text, not a JSON-renderable object.
@@ -1461,7 +1462,7 @@ class TestCloudSecCode:
         runner = CliRunner()
         result = runner.invoke(cli, ["cloudsec", "code", "--help"])
         assert result.exit_code == 0
-        for cmd in ["repos", "status", "sbom"]:
+        for cmd in ["repos", "status", "sbom", "ingest", "scan"]:
             assert cmd in result.output
 
     def test_code_repos(self):
@@ -1486,6 +1487,47 @@ class TestCloudSecCode:
                 cs_cls, {"repos": []})
             assert result.exit_code == 0
             assert inst.list_code_repos.call_args.kwargs["has_findings"] is False
+
+    def test_code_ingest_reads_the_file_and_pushes_it(self, tmp_path):
+        doc = tmp_path / "trivy.sarif"
+        doc.write_bytes(b'{"version":"2.1.0","runs":[]}')
+        with _patches()[0], _patches()[1], _patches()[2] as cs_cls:
+            result, inst = _invoke(
+                ["cloudsec", "code", "ingest", "--repo", "acme/api",
+                 "--source", "sarif", "-f", str(doc), "--commit", "c0ffee"],
+                cs_cls, {"result": {}})
+            assert result.exit_code == 0, result.output
+            inst.ingest_code_results.assert_called_once()
+            args, kwargs = inst.ingest_code_results.call_args
+            assert args[0] == "acme/api"
+            assert args[1] == "sarif"
+            assert args[2] == b'{"version":"2.1.0","runs":[]}'
+            assert kwargs["commit"] == "c0ffee"
+
+    def test_code_scan_refuses_to_do_nothing(self, tmp_path):
+        """Without --ingest and without -o the report would be written into a
+        temporary directory and deleted — a command that appears to succeed and
+        leaves nothing behind. It must say so instead."""
+        with _patches()[0], _patches()[1], _patches()[2] as cs_cls:
+            with patch("limacharlie.commands.cloudsec._run_code_scanner"):
+                result, inst = _invoke(
+                    ["cloudsec", "code", "scan", str(tmp_path), "--repo", "acme/api"],
+                    cs_cls, {"result": {}})
+            assert result.exit_code != 0
+            assert "nothing to do with the report" in result.output
+            inst.ingest_code_results.assert_not_called()
+
+    def test_code_scan_will_not_guess_the_repository(self, tmp_path):
+        """--ingest against a checkout whose origin names no repository must
+        refuse: which repository a finding belongs to is an identity, and a
+        guessed one attaches somebody's findings to the wrong node."""
+        with _patches()[0], _patches()[1], _patches()[2] as cs_cls:
+            result, inst = _invoke(
+                ["cloudsec", "code", "scan", str(tmp_path), "--ingest"],
+                cs_cls, {"result": {}})
+            assert result.exit_code != 0
+            assert "--repo" in result.output
+            inst.ingest_code_results.assert_not_called()
 
     def test_code_repos_all_walks_the_cursor(self):
         """--all must use the iterator, not a single page.

--- a/tests/unit/test_sdk_cloudsec.py
+++ b/tests/unit/test_sdk_cloudsec.py
@@ -1,5 +1,6 @@
 """Tests for limacharlie.sdk.cloudsec module."""
 
+import base64
 import json
 
 from unittest.mock import MagicMock
@@ -949,6 +950,42 @@ class TestCodeLane:
         cs.get_code_sbom("acme/api", provider="github")
         _, qp = _get_call(mock_org)
         assert qp == [("provider", "github")]
+
+    def test_ingest_code_results_sends_bytes_as_base64(self, cs, mock_org):
+        """A document read from a file is sent base64, NOT decoded and re-encoded.
+
+        The documents this takes are files — the scanner writes report.json.gz —
+        so decoding a gzip stream locally only to re-serialize it as JSON would
+        parse a multi-megabyte payload twice, and could not represent a
+        compressed one at all.
+        """
+        mock_org.client.request.return_value = {"result": {}}
+        cs.ingest_code_results("acme/api", "report", b"\x1f\x8bnot-really-gzip",
+                               commit="c0ffee")
+        url, body = _post_call(mock_org)
+        assert url == f"cloudsec/{OID}/code/ingest"
+        assert body["repo"] == "acme/api"
+        assert body["source"] == "report"
+        assert body["commit"] == "c0ffee"
+        assert base64.b64decode(body["document_b64"]) == b"\x1f\x8bnot-really-gzip"
+        assert "document" not in body
+
+    def test_ingest_code_results_sends_an_object_as_an_object(self, cs, mock_org):
+        """An already-parsed document goes in `document`: re-encoding it to base64
+        would make the gateway's JSON body opaque for no gain."""
+        mock_org.client.request.return_value = {"result": {}}
+        cs.ingest_code_results("acme/api", "sarif", {"version": "2.1.0", "runs": []})
+        _, body = _post_call(mock_org)
+        assert body["document"] == {"version": "2.1.0", "runs": []}
+        assert "document_b64" not in body
+
+    def test_ingest_code_results_omits_what_was_not_given(self, cs, mock_org):
+        """An absent commit must not become an empty one: '' is a value, and a
+        finding stamped with a blank revision is worse than one with none."""
+        mock_org.client.request.return_value = {"result": {}}
+        cs.ingest_code_results("acme/api", "cyclonedx", "{}")
+        _, body = _post_call(mock_org)
+        assert "commit" not in body and "ref" not in body and "provider" not in body
 
     def test_download_code_sbom_returns_none_when_absent(self, cs, mock_org):
         """No SBOM yet is a normal answer, not an exception."""


### PR DESCRIPTION
Roadmap 15 **P2.2**, the CLI/SDK half.

- **`limacharlie cloudsec code ingest --repo <owner/name> --source sarif|cyclonedx|report -f <file>`** — push a document your own pipeline produced. Findings dedupe against the hosted scan by identity; re-pushing an identical document writes nothing.
- **`limacharlie cloudsec code scan [PATH] [--ingest]`** — run the LimaCharlie code scanner over a local checkout (container by default, `--binary` for an already-installed agent), producing a `report/v1` document and optionally pushing it. The report format is loss-free, so a scan from a laptop lands on exactly the rows a hosted scan of the same repository would write.
- **SDK**: `CloudSec.ingest_code_results(repo, source, document, ...)`.

Two decisions worth flagging in review:

**Secret scanning is off by default in `code scan`.** A secret's identity in this pipeline is a digest keyed by a deployment-side salt the CLI does not have, so locally-found credentials would not dedupe against the hosted scan's — and the ingest refuses them for the same reason. Turning it on locally would produce findings that churn.

**The command refuses to do nothing.** `code scan` with neither `--ingest` nor `-o` would write its report into a temporary directory and delete it; it now says so *before* spending minutes scanning. Likewise `--ingest` will not guess the repository from a directory name — which repository a finding belongs to is an identity.

`pytest tests/unit` green (3805 passed).