### PR TITLE
cloudsec: limacharlie cloudsec code rescan <repo> — trigger one repository's scan (P2.1)

### DIFF
--- a/limacharlie/commands/cloudsec.py
+++ b/limacharlie/commands/cloudsec.py
@@ -1514,6 +1514,44 @@ def code_sbom(ctx, repo, provider, output_path) -> None:
     _output(ctx, {"repo": repo, "written": output_path, "size_bytes": len(body)})
 
 
+@code_group.command("rescan")
+@click.argument("repo")
+@click.option("--ref", default=None,
+              help="The git ref a push landed on (refs/heads/main). Optional "
+                   "— the lane scans the default branch either way, and a ref "
+                   "naming another branch is declined because scanning again "
+                   "would re-report the same commit.")
+@click.option("--provider", default=None,
+              help="Source-control provider the repository belongs to "
+                   "(default github).")
+@pass_context
+def code_rescan(ctx, repo, ref, provider) -> None:
+    """Rescan ONE repository now instead of waiting for its schedule.
+
+    REPO is '<owner>/<name>', the bare repository name, or its urn.
+
+    This is the manual door onto the trigger a push webhook takes. It
+    ACCEPTS and returns — the scan runs for minutes in a sandbox — and it is
+    debounced per repository ('debounce_seconds' in the response: a burst
+    collapses into one scan).
+
+    'accepted' does NOT mean a scan will run. Each of these is a quiet
+    no-op: a repository outside the org's code_scanning policy scope, one
+    over the free-tier quota or the per-connection daily cap, one in a
+    failure backoff, or a connection whose collection is paused right then.
+    Read the outcome per repository with 'cloudsec code repos', not from
+    this response and not from 'cloudsec code status' — that row is the
+    estate pass's, and a one-repository run deliberately does not touch it.
+
+    \b
+    Examples:
+      limacharlie cloudsec code rescan refractionPOINT/lc-appsec-fixtures
+      limacharlie cloudsec code rescan api --ref refs/heads/main
+    """
+    cs = _get_cloudsec(ctx)
+    _output(ctx, cs.rescan_code_repo(repo, ref=ref, provider=provider))
+
+
 # ---------------------------------------------------------------------------
 # fleet subgroup (multi-org)
 # ---------------------------------------------------------------------------

--- a/limacharlie/sdk/cloudsec.py
+++ b/limacharlie/sdk/cloudsec.py
@@ -1279,6 +1279,52 @@ class CloudSec:
         with _urlopen(sbom["url"]) as body:
             return body.read()
 
+    def rescan_code_repo(
+        self,
+        repo: str,
+        *,
+        ref: str | None = None,
+        provider: str | None = None,
+        source: str | None = None,
+    ) -> dict[str, Any]:
+        """Ask the code lane to rescan ONE repository now.
+
+        This is the manual door onto the same trigger a push webhook takes.
+        It does not wait for the scan, and it is not a promise that one will
+        run: the response means the trigger was ACCEPTED.
+
+        Args:
+            repo: The repository — ``"<owner>/<name>"``, its bare name, or
+                its canonical urn.
+            ref: The git ref a push landed on
+                (``"refs/heads/main"``). Optional; the lane scans the
+                default branch either way, and a ref naming a branch other
+                than the one the last scan cloned is declined.
+            provider: The source-control provider the repository belongs to;
+                defaults to ``github`` server-side.
+            source: A short token recording who asked, for the host's log
+                line and the mark it persists. Defaults to ``manual``.
+
+        Returns:
+            ``{"accepted": bool, "repo": str, "provider": str,
+            "debounce_seconds": int}``. ``debounce_seconds`` is the window a
+            burst of triggers for one repository collapses into.
+
+        Note:
+            Several outcomes are a quiet no-op from here: a repository
+            outside the org's ``code_scanning`` policy scope, one over the
+            free-tier quota or the per-connection daily cap, one in a failure
+            backoff, or a connection whose collection is paused at that
+            instant. The result is visible per repository on
+            :meth:`list_code_repos`, not on this response.
+        """
+        body: dict[str, Any] = {"repo": repo, "source": source or "manual"}
+        if ref:
+            body["ref"] = ref
+        if provider:
+            body["provider"] = provider
+        return self._post("code/scan", body)
+
     # ------------------------------------------------------------------
     # Overview / trends / chokepoints
     # ------------------------------------------------------------------

--- a/tests/unit/test_cli_cloudsec.py
+++ b/tests/unit/test_cli_cloudsec.py
@@ -48,6 +48,7 @@ def _invoke(args, mock_cs_cls, return_value=None, stdin=None):
             "get_policy_vocabulary", "suggest_policy_values",
             "simulate_resource_match", "simulate_finding_match",
             "list_code_repos", "get_code_status", "get_code_sbom",
+            "rescan_code_repo",
         ]
     })
     # CSV exports return raw text, not a JSON-renderable object.
@@ -1535,6 +1536,31 @@ class TestCloudSecCode:
                 assert "sbom_not_generated_yet" in result.output
                 import os
                 assert not os.path.exists("out.gz")
+
+    def test_code_rescan_forwards_the_repository_and_ref(self):
+        with _patches()[0], _patches()[1], _patches()[2] as cs_cls:
+            result, inst = _invoke(
+                ["cloudsec", "code", "rescan", "acme/api",
+                 "--ref", "refs/heads/main"],
+                cs_cls, {"accepted": True, "debounce_seconds": 600})
+            assert result.exit_code == 0
+            inst.rescan_code_repo.assert_called_once_with(
+                "acme/api", ref="refs/heads/main", provider=None)
+
+    def test_code_rescan_takes_the_repository_positionally(self):
+        """'rescan <repo>' — the repository is the subject, not an option.
+
+        The sibling 'code scan <path>' takes a filesystem path positionally
+        for the same reason; keeping the two shapes apart is what stops
+        'code rescan' from reading like a local scan of a directory.
+        """
+        with _patches()[0], _patches()[1], _patches()[2] as cs_cls:
+            result, inst = _invoke(
+                ["cloudsec", "code", "rescan", "lc-appsec-fixtures"],
+                cs_cls, {"accepted": True})
+            assert result.exit_code == 0
+            inst.rescan_code_repo.assert_called_once_with(
+                "lc-appsec-fixtures", ref=None, provider=None)
 
     def test_finding_list_forwards_repo(self):
         with _patches()[0], _patches()[1], _patches()[2] as cs_cls:

--- a/tests/unit/test_sdk_cloudsec.py
+++ b/tests/unit/test_sdk_cloudsec.py
@@ -950,6 +950,31 @@ class TestCodeLane:
         _, qp = _get_call(mock_org)
         assert qp == [("provider", "github")]
 
+    def test_rescan_code_repo_posts_the_trigger(self, cs, mock_org):
+        mock_org.client.request.return_value = {"accepted": True}
+        cs.rescan_code_repo("refractionPOINT/lc-appsec-fixtures",
+                            ref="refs/heads/main", provider="github")
+        url, body = _post_call(mock_org)
+        assert url == f"cloudsec/{OID}/code/scan"
+        assert body == {
+            "repo": "refractionPOINT/lc-appsec-fixtures",
+            "source": "manual",
+            "ref": "refs/heads/main",
+            "provider": "github",
+        }
+
+    def test_rescan_code_repo_omits_optionals(self, cs, mock_org):
+        """An empty ref must not reach the wire.
+
+        The host declines a ref that names a branch other than the one the
+        last scan cloned, and an empty string is not 'unspecified' to a
+        gateway that bounds every non-empty field it forwards.
+        """
+        mock_org.client.request.return_value = {"accepted": True}
+        cs.rescan_code_repo("api")
+        _, body = _post_call(mock_org)
+        assert body == {"repo": "api", "source": "manual"}
+
     def test_download_code_sbom_returns_none_when_absent(self, cs, mock_org):
         """No SBOM yet is a normal answer, not an exception."""
         mock_org.client.request.return_value = {


### PR DESCRIPTION
The manual door onto the push-triggered rescan the code lane grew in roadmap 15 P2.1. `limacharlie cloudsec code rescan <repo> [--ref] [--provider]` posts to the public `POST /v1/cloudsec/{oid}/code/scan` route, which **accepts** the trigger and returns — the scan itself runs for minutes inside a sandbox Job on the collector replica holding that connection, debounced per repository.

### Why the help text is this long

`accepted: true` is not a promise that a scan will run, and every one of these is a quiet no-op a caller would otherwise read as success:

- the repository is outside the org's `code_scanning` policy scope;
- it is over the free-tier repository quota or the per-connection daily cap;
- it is inside a failure backoff (the trigger is recorded and the next pass retries it);
- `--ref` names a branch other than the one the last scan cloned — the lane scans the default branch, so scanning again would re-report the same commit;
- the connection's collection is paused or failing over at that instant, and the normal schedule is the backstop.

So the help says where the outcome actually is: `limacharlie cloudsec code repos`. Not `code status` — that row is the estate pass's, and a one-repository run deliberately does not write it.

### Detail

An empty `--ref` does not reach the wire. The gateway bounds every non-empty field it forwards and `""` is not "unspecified" to it.

### Naming

`code rescan <repo>` is deliberately distinct from the sibling `code scan <path>` (#337, local scanning): one names a repository the platform already knows, the other a directory on your laptop. Both take their subject positionally.

### Tests

`tests/unit/test_sdk_cloudsec.py` (the POST body, and that an absent ref is omitted) and `tests/unit/test_cli_cloudsec.py` (the forwarding, and the positional subject). Full unit suite green: 224 passed in the two cloudsec files, 1054 in the lazy-loading regression file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)