### PR TITLE
cloudsec: limacharlie cloudsec code autofix <finding_id>

### DIFF
--- a/limacharlie/commands/cloudsec.py
+++ b/limacharlie/commands/cloudsec.py
@@ -1589,6 +1589,58 @@ def code_rescan(ctx, repo, ref, provider) -> None:
     """
     cs = _get_cloudsec(ctx)
     _output(ctx, cs.rescan_code_repo(repo, ref=ref, provider=provider))
+
+
+@code_group.command("autofix")
+@click.argument("finding_id")
+@click.option("--repo", default=None,
+              help="Narrow the search to one repository. A HINT, not an "
+                   "authorization — the finding id is what is acted on — but "
+                   "worth passing: without it the backend searches the "
+                   "in-scope repositories.")
+@click.option("--provider", default=None,
+              help="Source-control provider the repository belongs to "
+                   "(default github).")
+@pass_context
+def code_autofix(ctx, finding_id, repo, provider) -> None:
+    """Open a pull request fixing a dependency finding.
+
+    FINDING_ID is the id of an open dependency (SCA) finding, as 'cloudsec
+    findings' returns it.
+
+    The finding id is the only input that decides anything: the backend
+    resolves it against the dependency rows ITS OWN scan produced and raises
+    that package to that advisory's fixed version. There is deliberately no
+    way to name a package or a version here.
+
+    It ACCEPTS and returns — cloning the repository in a sandbox, editing the
+    manifest and opening the pull request takes minutes. THE PULL REQUEST IS
+    THE RESULT; this response is only that the request was queued.
+
+    'accepted' does NOT mean a pull request exists. Each of these is a quiet
+    no-op: an org with no Code Actions App configured, or one whose App
+    lacks 'Contents: Read and write' (the write App is separate and opt-in —
+    the read-only connection App is never used to write); a finding whose
+    package is flagged malicious, where the fix is removal and credential
+    rotation rather than an upgrade; a finding with no published fixed
+    version; an ecosystem other than npm, pip, go or maven; a repository
+    outside the code_scanning policy scope or over the free-tier quota; a
+    package that already has an AutoFix pull request open; and a connection
+    at its daily AutoFix limit.
+
+    For npm and go the LOCKFILE IS NOT REGENERATED — the scanning sandbox
+    has no package-registry access by design — and the pull request says so
+    prominently and names the command to run. pip (requirements.txt) and
+    maven have no lockfile, so those changes are complete.
+
+    \b
+    Examples:
+      limacharlie cloudsec code autofix fnd_2290bab86c1b4d0374d1e2666f64aeca
+      limacharlie cloudsec code autofix fnd_2290... --repo refractionPOINT/lc-appsec-fixtures
+    """
+    cs = _get_cloudsec(ctx)
+    _output(ctx, cs.autofix_code_finding(finding_id, repo=repo, provider=provider))
+
 @code_group.command("ingest")
 @click.option("--repo", required=True,
               help="Repository key '<owner>/<name>' as 'code repos' returns it.")

--- a/limacharlie/sdk/cloudsec.py
+++ b/limacharlie/sdk/cloudsec.py
@@ -1325,6 +1325,64 @@ class CloudSec:
         if provider:
             body["provider"] = provider
         return self._post("code/scan", body)
+    def autofix_code_finding(
+        self,
+        finding_id: str,
+        *,
+        repo: str | None = None,
+        provider: str | None = None,
+    ) -> dict[str, Any]:
+        """Open a pull request raising the vulnerable dependency a finding is about.
+
+        The finding id is the ONLY input that decides anything. The backend
+        resolves it against the dependency rows its own scan produced and
+        raises that package to that advisory's fixed version, so a fix can
+        never be requested for a package or a version the organization's own
+        scan did not find.
+
+        Args:
+            finding_id: the id of an open dependency (SCA) finding, as
+                returned by :meth:`list_findings`.
+            repo: optional — narrows the search to one repository. It is a
+                hint, not an authorization: the finding id is what is acted
+                on.
+            provider: the source-control provider; defaults to ``github``
+                server-side.
+
+        Returns:
+            ``{"accepted": bool, "finding_id": str, "repo": str,
+            "provider": str, "debounce_seconds": int}``.
+
+        Note:
+            ``accepted`` does not mean a pull request exists. The request is
+            acknowledged immediately and handed to the collector replica
+            holding that connection, which clones the repository in a
+            sandbox, edits the manifest and opens the pull request — that
+            pull request is where the result appears. Each of these is a
+            quiet no-op from here: an organization with no Code Actions App
+            configured (the write App is separate and opt-in — the read-only
+            connection App is never used to write) or one whose App lacks
+            *Contents: Read and write*; a finding whose package is flagged
+            malicious (the remediation is removal and credential rotation,
+            not an upgrade) or for which no fixed version has been
+            published; an ecosystem other than npm, pip, go or maven; a
+            repository outside the ``code_scanning`` policy scope or over the
+            free-tier quota; a package that already has an AutoFix pull
+            request open; and a connection at its daily AutoFix limit.
+
+            For **npm** and **go** the lockfile is not regenerated — the
+            scanning sandbox has no package-registry access by design — and
+            the pull request says so prominently and names the command to
+            run. For **pip** (``requirements.txt``) and **maven** there is no
+            lockfile, so the change is complete.
+        """
+        body: dict[str, Any] = {"finding_id": finding_id}
+        if repo:
+            body["repo"] = repo
+        if provider:
+            body["provider"] = provider
+        return self._post("code/autofix", body)
+
     def ingest_code_results(
         self,
         repo: str,

--- a/tests/unit/test_cli_cloudsec.py
+++ b/tests/unit/test_cli_cloudsec.py
@@ -49,7 +49,7 @@ def _invoke(args, mock_cs_cls, return_value=None, stdin=None):
             "get_policy_vocabulary", "suggest_policy_values",
             "simulate_resource_match", "simulate_finding_match",
             "list_code_repos", "get_code_status", "get_code_sbom",
-            "rescan_code_repo",
+            "rescan_code_repo", "autofix_code_finding",
             "ingest_code_results",
         ]
     })
@@ -1674,6 +1674,31 @@ class TestCloudSecCode:
             assert result.exit_code == 0
             inst.rescan_code_repo.assert_called_once_with(
                 "lc-appsec-fixtures", ref=None, provider=None)
+
+    def test_code_autofix_takes_the_finding_positionally(self):
+        """'autofix <finding_id>' — the finding is the subject.
+
+        And there is no --package/--version option, on purpose: the backend
+        resolves the id against its own scan's rows, so naming a package here
+        would be the one way to request a fix the scan never found.
+        """
+        with _patches()[0], _patches()[1], _patches()[2] as cs_cls:
+            result, inst = _invoke(
+                ["cloudsec", "code", "autofix", "fnd_" + "a" * 32],
+                cs_cls, {"accepted": True, "debounce_seconds": 10})
+            assert result.exit_code == 0
+            inst.autofix_code_finding.assert_called_once_with(
+                "fnd_" + "a" * 32, repo=None, provider=None)
+
+    def test_code_autofix_forwards_the_repository_hint(self):
+        with _patches()[0], _patches()[1], _patches()[2] as cs_cls:
+            result, inst = _invoke(
+                ["cloudsec", "code", "autofix", "fnd_" + "b" * 32,
+                 "--repo", "acme/api"],
+                cs_cls, {"accepted": True})
+            assert result.exit_code == 0
+            inst.autofix_code_finding.assert_called_once_with(
+                "fnd_" + "b" * 32, repo="acme/api", provider=None)
 
     def test_finding_list_forwards_repo(self):
         with _patches()[0], _patches()[1], _patches()[2] as cs_cls:

--- a/tests/unit/test_sdk_cloudsec.py
+++ b/tests/unit/test_sdk_cloudsec.py
@@ -975,6 +975,33 @@ class TestCodeLane:
         cs.rescan_code_repo("api")
         _, body = _post_call(mock_org)
         assert body == {"repo": "api", "source": "manual"}
+    def test_autofix_code_finding_posts_only_the_finding_id(self, cs, mock_org):
+        """The finding id is the ONLY input that decides anything.
+
+        There is deliberately no package or version parameter: the backend
+        resolves the id against the dependency rows its own scan produced, so
+        a fix can never be requested for a package or a version the org's own
+        scan did not find. A body that could carry them would be the way past
+        that.
+        """
+        mock_org.client.request.return_value = {"accepted": True}
+        cs.autofix_code_finding("fnd_" + "a" * 32)
+        url, body = _post_call(mock_org)
+        assert url == f"cloudsec/{OID}/code/autofix"
+        assert body == {"finding_id": "fnd_" + "a" * 32}
+
+    def test_autofix_code_finding_forwards_the_repository_hint(self, cs, mock_org):
+        mock_org.client.request.return_value = {"accepted": True}
+        cs.autofix_code_finding("fnd_" + "b" * 32,
+                                repo="refractionPOINT/lc-appsec-fixtures",
+                                provider="github")
+        _, body = _post_call(mock_org)
+        assert body == {
+            "finding_id": "fnd_" + "b" * 32,
+            "repo": "refractionPOINT/lc-appsec-fixtures",
+            "provider": "github",
+        }
+
     def test_ingest_code_results_sends_bytes_as_base64(self, cs, mock_org):
         """A document read from a file is sent base64, NOT decoded and re-encoded.
 


### PR DESCRIPTION
The CLI and SDK door onto dependency AutoFix: open a pull request raising the vulnerable
dependency a finding is about.

```
limacharlie cloudsec code autofix fnd_2290bab86c1b4d0374d1e2666f64aeca
limacharlie cloudsec code autofix fnd_2290... --repo refractionPOINT/lc-appsec-fixtures
```

## The finding id is the only input that decides anything

There is deliberately no `--package` and no `--version`. The backend resolves the id against
the dependency rows **its own scan** produced and raises that package to that advisory's
fixed version, so a fix can never be requested for a package or a version the organization's
own scan did not find. `--repo` is a search hint, not an authorization.

## What `accepted` does not mean

It posts to `POST /v1/cloudsec/{oid}/code/autofix`, which ACCEPTS and returns — cloning the
repository in a sandbox, editing the manifest and opening the pull request takes minutes.
**The pull request is the result**; the response is only that the request was queued. The
help says so, and names every quiet no-op, because each of them would otherwise read as
success: no Code Actions App configured (the write App is separate and opt-in — the
read-only connection App is never used to write) or one lacking *Contents: Read and write*;
a **malicious** package, where the remediation is removal and credential rotation rather
than an upgrade; a finding with no published fixed version; an ecosystem other than npm,
pip, go or maven; a repository outside the `code_scanning` policy scope or over the
free-tier quota; a package that already has an AutoFix pull request open; and a connection
at its daily AutoFix limit.

It also says the thing a user would otherwise discover by merging: **for npm and go the
lockfile is not regenerated** — the scanning sandbox has no package-registry access by
design — and the pull request itself carries the command to run. pip
(`requirements.txt`) and maven have no lockfile, so those changes are complete.

## Tests

Four new: the SDK posts only the finding id (and the shape of the body is the assertion —
one that could carry a package would be the way past the resolution), the repository hint is
forwarded, and the CLI takes the finding positionally with no package/version option.
`3816 passed, 6 skipped` on the full unit suite.

Public repo — **not merging**; this is for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)