### PR TITLE
cloudsec: --source on the findings worklist (hosted vs pushed)

### DIFF
--- a/limacharlie/commands/cloudsec.py
+++ b/limacharlie/commands/cloudsec.py
@@ -1088,6 +1088,20 @@ def _finding_filter_options(f):
         help="Only findings on (non-)reachable resources.",
     )(f)
     f = click.option(
+        "--source", "source", default=None,
+        type=click.Choice(["hosted", "ingest", "other", "none", "both"]),
+        help="Filter by WHICH SCANNER found it (the AppSec code lane's "
+             "producer): 'hosted' = the scan LimaCharlie ran; 'ingest' = a "
+             "document your own pipeline pushed ('cloudsec code ingest', or "
+             "'cloudsec code scan --ingest'); 'other' = a producer that is "
+             "neither, today the source control's own detectors; 'none' = no "
+             "code provenance at all, which on a cloud estate is nearly every "
+             "finding. 'both' (the default) applies no filter. Not a list — "
+             "'both' is what a multi-value selection would mean. The server "
+             "applies it inside the paged query, so 'finding facets' counts "
+             "under it describe the same set the list returns.",
+    )(f)
+    f = click.option(
         "--repo", "repos", multiple=True,
         help="Filter to findings about a source repository, keyed "
              "'<owner>/<name>' as 'cloudsec code repos' returns it; "
@@ -2007,8 +2021,8 @@ def finding_group() -> None:
 @_paging_options
 @pass_context
 def finding_list(ctx, severities, finding_classes, statuses, accounts, repos,
-                 owners, unassigned, sla_states, reachable, kev, q, sort,
-                 order, cursor, limit) -> None:
+                 source, owners, unassigned, sla_states, reachable, kev, q,
+                 sort, order, cursor, limit) -> None:
     """List the merged, risk-ranked cloud-security findings.
 
     \b
@@ -2027,6 +2041,7 @@ def finding_list(ctx, severities, finding_classes, statuses, accounts, repos,
         status=list(statuses) or None,
         account=list(accounts) or None,
         repo=list(repos) or None,
+        source=source,
         owner=_selector_with_empty(owners, unassigned),
         sla=list(sla_states) or None,
         reachable=reachable,
@@ -2050,7 +2065,7 @@ def finding_list(ctx, severities, finding_classes, statuses, accounts, repos,
                    "pin can still be dropped.")
 @pass_context
 def finding_facets(ctx, severities, finding_classes, statuses, accounts, repos,
-                   owners, unassigned, sla_states, reachable, kev, q,
+                   source, owners, unassigned, sla_states, reachable, kev, q,
                    owner_pins) -> None:
     """Cross-filtered facet counts for the findings worklist.
 
@@ -2066,6 +2081,7 @@ def finding_facets(ctx, severities, finding_classes, statuses, accounts, repos,
         status=list(statuses) or None,
         account=list(accounts) or None,
         repo=list(repos) or None,
+        source=source,
         owner=_selector_with_empty(owners, unassigned),
         owner_pin=list(owner_pins) or None,
         sla=list(sla_states) or None,
@@ -2086,8 +2102,8 @@ def finding_facets(ctx, severities, finding_classes, statuses, accounts, repos,
                    "rollup is not paginated; 'distinct' reports the tail.")
 @pass_context
 def finding_causes(ctx, severities, finding_classes, statuses, accounts, repos,
-                   owners, unassigned, sla_states, reachable, kev, q, cause,
-                   limit) -> None:
+                   source, owners, unassigned, sla_states, reachable, kev, q,
+                   cause, limit) -> None:
     """Findings grouped by CAUSE: one edit that closes N findings.
 
     \b
@@ -2103,6 +2119,7 @@ def finding_causes(ctx, severities, finding_classes, statuses, accounts, repos,
         status=list(statuses) or None,
         account=list(accounts) or None,
         repo=list(repos) or None,
+        source=source,
         owner=_selector_with_empty(owners, unassigned),
         sla=list(sla_states) or None,
         reachable=reachable,
@@ -3073,8 +3090,8 @@ def export_group() -> None:
 @_export_output_option
 @pass_context
 def export_findings(ctx, severities, finding_classes, statuses, accounts, repos,
-                    owners, unassigned, sla_states, reachable, kev, q, sort,
-                    order, output_path) -> None:
+                    source, owners, unassigned, sla_states, reachable, kev, q,
+                    sort, order, output_path) -> None:
     """Export the (filtered) findings worklist as CSV.
 
     \b
@@ -3090,6 +3107,7 @@ def export_findings(ctx, severities, finding_classes, statuses, accounts, repos,
         status=list(statuses) or None,
         account=list(accounts) or None,
         repo=list(repos) or None,
+        source=source,
         owner=_selector_with_empty(owners, unassigned),
         sla=list(sla_states) or None,
         reachable=reachable,

--- a/limacharlie/commands/cloudsec.py
+++ b/limacharlie/commands/cloudsec.py
@@ -1099,7 +1099,10 @@ def _finding_filter_options(f):
              "finding. 'both' (the default) applies no filter. Not a list — "
              "'both' is what a multi-value selection would mean. The server "
              "applies it inside the paged query, so 'finding facets' counts "
-             "under it describe the same set the list returns.",
+             "under it describe the same set the list returns; the 'source' "
+             "facet's values sum to its total on an UNFILTERED read (like "
+             "every dimension it excludes its own filter, while the total "
+             "applies it).",
     )(f)
     f = click.option(
         "--repo", "repos", multiple=True,

--- a/limacharlie/sdk/cloudsec.py
+++ b/limacharlie/sdk/cloudsec.py
@@ -341,8 +341,10 @@ class CloudSec:
 
                 It is applied INSIDE the server's keyset query, so a page
                 and a count under it describe the same set. An unrecognised
-                value matches nothing and returns an empty page rather than
-                silently widening the read.
+                value is REJECTED by the server with an error naming it,
+                never quietly ignored: this selector is a scalar, so a
+                dropped value and an absent one are the same thing on the
+                wire, and absent means unconstrained.
             reachable: Only findings on (non-)reachable resources.
             kev: Only findings with (without) a KEV vulnerability.
             q: Substring search.
@@ -427,14 +429,24 @@ class CloudSec:
 
                 It is applied INSIDE the server's keyset query, so a page
                 and a count under it describe the same set. An unrecognised
-                value matches nothing and returns an empty page rather than
-                silently widening the read.
+                value is REJECTED by the server with an error naming it,
+                never quietly ignored: this selector is a scalar, so a
+                dropped value and an absent one are the same thing on the
+                wire, and absent means unconstrained.
 
                 The ``source`` facet is the one dimension here whose values
                 SUM EXACTLY TO ``total`` — every key is always present,
                 zeroes included — which is what lets a hosted-vs-pushed
                 split be quoted as a share of the estate rather than of one
-                page.
+                page. That holds only when ``source`` is NOT itself
+                filtered: like every dimension it is counted with its own
+                filter excluded while ``total`` applies it, so under
+                ``source="hosted"`` the map still sums to the unfiltered
+                population. Compute a share on an unfiltered read.
+
+                The key is ABSENT if the server has the facet turned off.
+                That never means zero — read it with ``.get("source")`` and
+                render nothing rather than a 0% split.
 
         Returns:
             ``{"facets": {..., "owner": {"": 12, "alice@corp.com": 3},

--- a/limacharlie/sdk/cloudsec.py
+++ b/limacharlie/sdk/cloudsec.py
@@ -97,6 +97,7 @@ def _finding_query_pairs(
     owner_pin: list[str] | None = None,
     sla: list[str] | None = None,
     repo: list[str] | None = None,
+    source: str | None = None,
     reachable: bool | None = None,
     kev: bool | None = None,
     q: str | None = None,
@@ -115,11 +116,16 @@ def _finding_query_pairs(
     ``repo`` is deliberately NOT like that. A finding with no repository is
     every cloud finding in the estate, which is not a bucket anyone selects,
     so an empty value there matches nothing rather than meaning "unscoped".
+
+    ``source`` is a SCALAR, not a list, because the vocabulary it mirrors is
+    the one-word answer ``list_code_repos`` gives per repository — and
+    ``"both"``, the value that would otherwise want a list, already means
+    "no constraint".
     """
     return _query_pairs(
         severity=severity, finding_class=finding_class, status=status,
         account=account, owner=owner, owner_pin=owner_pin, sla=sla,
-        repo=repo, reachable=reachable, kev=kev, q=q,
+        repo=repo, source=source, reachable=reachable, kev=kev, q=q,
         sort=sort, order=order, cursor=cursor, limit=limit,
     )
 
@@ -275,6 +281,7 @@ class CloudSec:
         owner: list[str] | None = None,
         sla: list[str] | None = None,
         repo: list[str] | None = None,
+        source: str | None = None,
         reachable: bool | None = None,
         kev: bool | None = None,
         q: str | None = None,
@@ -323,6 +330,19 @@ class CloudSec:
                 selector; cloud findings have no repository, so any repo
                 filter excludes them. An unknown repository honestly
                 returns nothing rather than widening the read.
+            source: The code lane's PRODUCER filter — which scanner found
+                the finding. ``"hosted"`` is the scan LimaCharlie ran,
+                ``"ingest"`` a document your own pipeline pushed (SARIF,
+                CycloneDX, or a local ``cloudsec code scan``), ``"other"``
+                a producer that is neither — today the source control's own
+                detectors — and ``"none"`` a finding with no code
+                provenance at all, which on a cloud estate is nearly every
+                row. ``"both"`` (and ``None``) apply no constraint.
+
+                It is applied INSIDE the server's keyset query, so a page
+                and a count under it describe the same set. An unrecognised
+                value matches nothing and returns an empty page rather than
+                silently widening the read.
             reachable: Only findings on (non-)reachable resources.
             kev: Only findings with (without) a KEV vulnerability.
             q: Substring search.
@@ -341,7 +361,7 @@ class CloudSec:
         return self._get("findings", _finding_query_pairs(
             severity=severity, finding_class=finding_class, status=status,
             account=account, owner=owner, sla=sla, repo=repo,
-            reachable=reachable, kev=kev, q=q,
+            source=source, reachable=reachable, kev=kev, q=q,
             sort=sort, order=order, cursor=cursor, limit=limit,
         ))
 
@@ -356,6 +376,7 @@ class CloudSec:
         owner_pin: list[str] | None = None,
         sla: list[str] | None = None,
         repo: list[str] | None = None,
+        source: str | None = None,
         reachable: bool | None = None,
         kev: bool | None = None,
         q: str | None = None,
@@ -395,6 +416,25 @@ class CloudSec:
                 is capped at the top 200 by count, with any actively
                 selected repository pinned into it; ``repo_truncated``
                 reports whether any were dropped.
+            source: The code lane's PRODUCER filter — which scanner found
+                the finding. ``"hosted"`` is the scan LimaCharlie ran,
+                ``"ingest"`` a document your own pipeline pushed (SARIF,
+                CycloneDX, or a local ``cloudsec code scan``), ``"other"``
+                a producer that is neither — today the source control's own
+                detectors — and ``"none"`` a finding with no code
+                provenance at all, which on a cloud estate is nearly every
+                row. ``"both"`` (and ``None``) apply no constraint.
+
+                It is applied INSIDE the server's keyset query, so a page
+                and a count under it describe the same set. An unrecognised
+                value matches nothing and returns an empty page rather than
+                silently widening the read.
+
+                The ``source`` facet is the one dimension here whose values
+                SUM EXACTLY TO ``total`` — every key is always present,
+                zeroes included — which is what lets a hosted-vs-pushed
+                split be quoted as a share of the estate rather than of one
+                page.
 
         Returns:
             ``{"facets": {..., "owner": {"": 12, "alice@corp.com": 3},
@@ -404,7 +444,7 @@ class CloudSec:
         return self._get("findings/facets", _finding_query_pairs(
             severity=severity, finding_class=finding_class, status=status,
             account=account, owner=owner, owner_pin=owner_pin, sla=sla,
-            repo=repo, reachable=reachable, kev=kev, q=q,
+            repo=repo, source=source, reachable=reachable, kev=kev, q=q,
         ))
 
     def list_finding_causes(
@@ -418,6 +458,7 @@ class CloudSec:
         owner: list[str] | None = None,
         sla: list[str] | None = None,
         repo: list[str] | None = None,
+        source: str | None = None,
         reachable: bool | None = None,
         kev: bool | None = None,
         q: str | None = None,
@@ -475,7 +516,7 @@ class CloudSec:
         pairs = _finding_query_pairs(
             severity=severity, finding_class=finding_class, status=status,
             account=account, owner=owner, sla=sla, repo=repo,
-            reachable=reachable, kev=kev, q=q,
+            source=source, reachable=reachable, kev=kev, q=q,
             limit=limit,
         )
         _add_scalar(pairs, "cause", cause)
@@ -1786,6 +1827,7 @@ class CloudSec:
         owner: list[str] | None = None,
         sla: list[str] | None = None,
         repo: list[str] | None = None,
+        source: str | None = None,
         reachable: bool | None = None,
         kev: bool | None = None,
         q: str | None = None,
@@ -1807,7 +1849,7 @@ class CloudSec:
         pairs = _finding_query_pairs(
             severity=severity, finding_class=finding_class, status=status,
             account=account, owner=owner, sla=sla, repo=repo,
-            reachable=reachable, kev=kev, q=q,
+            source=source, reachable=reachable, kev=kev, q=q,
             sort=sort, order=order,
         )
         pairs.append(("format", "csv"))

--- a/tests/unit/test_cli_cloudsec.py
+++ b/tests/unit/test_cli_cloudsec.py
@@ -252,6 +252,51 @@ class TestTopLevel:
 
 
 class TestFindingCommands:
+    def test_source_selector_forwards_on_list_and_facets(self):
+        """--source reaches BOTH routes, because a rail whose counts are
+        filtered differently from the list beside it is worse than no rail.
+        """
+        for argv, method in [
+            (["cloudsec", "finding", "list", "--source", "hosted"], "list_findings"),
+            (["cloudsec", "finding", "facets", "--source", "ingest"], "get_finding_facets"),
+        ]:
+            p1, p2, p3 = _patches()
+            with p1, p2, p3 as cls:
+                result, inst = _invoke(argv, cls, return_value={"findings": []})
+                assert result.exit_code == 0, result.output
+                kwargs = getattr(inst, method).call_args.kwargs
+                assert kwargs["source"] == argv[-1], f"{method} got {kwargs['source']!r}"
+
+    def test_source_omitted_is_unconstrained(self):
+        """No --source must send None, not a value the backend would read as
+        an unrecognised producer and match nothing against.
+        """
+        p1, p2, p3 = _patches()
+        with p1, p2, p3 as cls:
+            result, inst = _invoke(
+                ["cloudsec", "finding", "list"], cls, return_value={"findings": []},
+            )
+            assert result.exit_code == 0, result.output
+            assert inst.list_findings.call_args.kwargs["source"] is None
+
+    def test_source_rejects_a_value_outside_the_vocabulary(self):
+        """The vocabulary is CLOSED and the failure is local.
+
+        The gateway forwards an unknown value verbatim on purpose (so it can
+        never widen the read), which means a typo would come back as an empty
+        worklist after a round trip. Click can tell the caller what the four
+        words are before that happens, so it does.
+        """
+        p1, p2, p3 = _patches()
+        with p1, p2, p3 as cls:
+            result, inst = _invoke(
+                ["cloudsec", "finding", "list", "--source", "hosetd"], cls,
+                return_value={"findings": []},
+            )
+            assert result.exit_code != 0
+            assert "hosetd" in result.output
+            inst.list_findings.assert_not_called()
+
     def test_list_repeatable_filters(self):
         p1, p2, p3 = _patches()
         with p1, p2, p3 as cls:
@@ -273,6 +318,7 @@ class TestFindingCommands:
                 status=None,
                 account=None,
                 repo=None,
+                source=None,
                 owner=None,
                 sla=None,
                 reachable=True,
@@ -833,8 +879,8 @@ class TestExport:
             assert result.output == "col_a,col_b\n1,2\n"
             inst.export_findings_csv.assert_called_once_with(
                 severity=["CRITICAL"], finding_class=None, status=["open"],
-                account=None, repo=None, owner=None, sla=None, reachable=None,
-                kev=None, q=None, sort=None, order=None,
+                account=None, repo=None, source=None, owner=None, sla=None,
+                reachable=None, kev=None, q=None, sort=None, order=None,
             )
 
     def test_export_findings_to_file(self, tmp_path):
@@ -1218,6 +1264,7 @@ class TestFindingCauses:
                 status=None,
                 account=None,
                 repo=None,
+                source=None,
                 owner=None,
                 sla=None,
                 reachable=None,

--- a/tests/unit/test_sdk_cloudsec.py
+++ b/tests/unit/test_sdk_cloudsec.py
@@ -100,6 +100,44 @@ class TestFindings:
         assert url == f"cloudsec/{OID}/findings/facets"
         assert qp == [("severity", "LOW"), ("kev", "true")]
 
+    def test_source_selector_reaches_every_findings_route(self, cs, mock_org):
+        """The producer selector rides the SHARED query builder.
+
+        All four findings routes take it, which is the point: a page, its
+        facet counts, the shared-fix rollup and the CSV export are the same
+        filtered set or none of them can be compared to each other.
+        """
+        for call, route in [
+            (lambda: cs.list_findings(source="hosted"), f"cloudsec/{OID}/findings"),
+            (lambda: cs.get_finding_facets(source="hosted"), f"cloudsec/{OID}/findings/facets"),
+            (lambda: cs.list_finding_causes(source="hosted"), f"cloudsec/{OID}/findings/causes"),
+        ]:
+            mock_org.client.request.return_value = {}
+            call()
+            url, qp = _get_call(mock_org)
+            assert url == route
+            assert ("source", "hosted") in qp, f"{route} dropped the selector"
+
+    def test_source_is_a_scalar_and_absent_by_default(self, cs, mock_org):
+        """Omitted means UNCONSTRAINED and must add no query pair at all.
+
+        A `source=` on the wire with an empty value would be an unrecognised
+        producer at the backend, which matches nothing — so an unfiltered
+        call would come back empty.
+        """
+        mock_org.client.request.return_value = {"findings": []}
+        cs.list_findings()
+        _, qp = _get_call(mock_org)
+        assert qp is None
+
+        mock_org.client.request.return_value = {"findings": []}
+        cs.list_findings(source="both")
+        _, qp = _get_call(mock_org)
+        assert qp == [("source", "both")], (
+            "'both' travels to the server, which is what treats it as "
+            "unconstrained — the CLI must not decide that locally"
+        )
+
     def test_get_finding(self, cs, mock_org):
         mock_org.client.request.return_value = {"finding": {}}
         cs.get_finding("fnd_abc")


### PR DESCRIPTION
## What

`--source` on `cloudsec finding list`, `cloudsec finding facets`, `cloudsec finding causes` and `cloudsec export findings`, plus the matching `source=` kwarg on `list_findings` / `get_finding_facets` / `list_finding_causes` / `export_findings_csv`.

The AppSec code lane has two producers — the scan LimaCharlie runs, and the documents a pipeline pushes through `cloudsec code ingest` / `cloudsec code scan --ingest` — and no way to ask which one found a finding.

| value | means |
|---|---|
| `hosted` | the scan LimaCharlie ran |
| `ingest` | a document your own pipeline pushed (SARIF, CycloneDX, or a local scan) |
| `other` | a producer that is neither — today the source control's own detectors |
| `none` | no code provenance at all, which on a cloud estate is nearly every finding |
| `both` (default) | no filter |

It is **server-side**: the gateway forwards it and the backend applies it inside the keyset query, so `finding facets` returns a `source` map whose values sum exactly to `total`. Folding a page client-side would have made every count a count of one page.

## Two choices worth reviewing

**It rides the shared `_finding_filter_options` decorator**, so all four commands take it and are the same filtered set. A rail whose counts are filtered differently from the list beside it is worse than no rail.

**It is a `click.Choice`, even though the gateway forwards unknown values verbatim.** The server has to — dropping the only value of a one-value selection would widen the read to the whole estate under an active-looking chip — but the CLI can name the four words *before* the round trip, instead of returning a mystifying empty worklist for a typo. `test_source_rejects_a_value_outside_the_vocabulary` pins that the SDK is never called in that case.

It is a scalar, not repeatable: `both` is what a multi-value selection would mean, and it is the default.

## Tests

SDK: the selector reaches all three JSON routes (a page, its facet counts and the shared-fix rollup have to be the same filtered set or none can be compared to the others); omitted adds **no query pair at all** (an empty `source=` on the wire is an unrecognised producer and would match nothing); `both` travels rather than being resolved locally, because only one place should know what it means.

CLI: forwards on list and facets, omitted sends `None`, an out-of-vocabulary value fails locally.

Three existing exact-kwargs assertions updated for the new parameter. Full suite: 3817 passed, 6 skipped.

## Depends on

legion_graph #146 (the selector + facet) and lc_api-go #900 (the gateway forwards the param). Harmless before they deploy — an older backend ignores an unknown query key.

Requires review — public repo, not to be merged by an agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)