### PR TITLE
cloudsec: fix inventory scope and use account_empty

### DIFF
--- a/limacharlie/commands/cloudsec.py
+++ b/limacharlie/commands/cloudsec.py
@@ -1120,7 +1120,7 @@ def _finding_filter_options(f):
 def _inventory_filter_options(f):
     """The inventory filter selectors (shared by list/export)."""
     f = click.option(
-        "--unscoped-account", "unscoped_account", is_flag=True, default=False,
+        "--account-empty", "account_empty", is_flag=True, default=False,
         help="Select only resources that have no cloud account.",
     )(f)
     f = click.option(
@@ -1147,21 +1147,22 @@ def _inventory_filter_options(f):
     return f
 
 
-def _inventory_account_unscoped(account: str | None, all_accounts: bool,
-                                unscoped_account: bool) -> bool | None:
+def _inventory_account_empty(account: str | None, all_accounts: bool,
+                             account_empty: bool) -> bool | None:
     """Translate CLI account scope flags to the API's accountless-bucket selector.
 
     Inventory is estate-wide when no account selector is sent. Historically the CLI
-    implemented ``--all-accounts`` by sending ``account_unscoped=true``; that parameter
-    actually means account == '' and silently hid every cloud-account resource. Keep the
-    old flag as a compatibility no-op and expose the real accountless selection explicitly.
+    implemented ``--all-accounts`` by sending the deprecated
+    ``account_unscoped=true`` selector; that parameter actually means account == '' and
+    silently hid every cloud-account resource. Keep the old flag as a compatibility no-op
+    and expose the real account-empty selection with an unambiguous name.
     """
-    selected = int(bool(account)) + int(all_accounts) + int(unscoped_account)
+    selected = int(bool(account)) + int(all_accounts) + int(account_empty)
     if selected > 1:
         raise click.UsageError(
-            "--account, --all-accounts, and --unscoped-account are mutually exclusive."
+            "--account, --all-accounts, and --account-empty are mutually exclusive."
         )
-    return True if unscoped_account else None
+    return True if account_empty else None
 
 
 def _identity_filter_options(f):
@@ -2396,7 +2397,7 @@ def inventory_group() -> None:
 @_paging_options
 @pass_context
 def inventory_list(ctx, resource_type, provider, account, region, q,
-                   all_accounts, unscoped_account, cursor, limit) -> None:
+                   all_accounts, account_empty, cursor, limit) -> None:
     """List the cloud resource inventory.
 
     \b
@@ -2405,14 +2406,14 @@ def inventory_list(ctx, resource_type, provider, account, region, q,
       limacharlie cloudsec inventory list --provider okta
       limacharlie cloudsec inventory list -q prod --limit 50
       limacharlie cloudsec inventory list --all-accounts
-      limacharlie cloudsec inventory list --unscoped-account
+      limacharlie cloudsec inventory list --account-empty
     """
     cs = _get_cloudsec(ctx)
     _output(ctx, cs.list_inventory(
         resource_type=resource_type, provider=provider, account=account,
         region=region, q=q,
-        account_unscoped=_inventory_account_unscoped(
-            account, all_accounts, unscoped_account),
+        account_empty=_inventory_account_empty(
+            account, all_accounts, account_empty),
         cursor=cursor, limit=limit,
     ))
 
@@ -3129,7 +3130,7 @@ def export_findings(ctx, severities, finding_classes, statuses, accounts, repos,
 @_export_output_option
 @pass_context
 def export_inventory(ctx, resource_type, provider, account, region, q,
-                     all_accounts, unscoped_account, output_path) -> None:
+                     all_accounts, account_empty, output_path) -> None:
     """Export the (filtered) cloud resource inventory as CSV.
 
     \b
@@ -3141,8 +3142,8 @@ def export_inventory(ctx, resource_type, provider, account, region, q,
     _emit_csv(ctx, cs.export_inventory_csv(
         resource_type=resource_type, provider=provider, account=account,
         region=region, q=q,
-        account_unscoped=_inventory_account_unscoped(
-            account, all_accounts, unscoped_account),
+        account_empty=_inventory_account_empty(
+            account, all_accounts, account_empty),
     ), output_path)
 
 

--- a/limacharlie/commands/cloudsec.py
+++ b/limacharlie/commands/cloudsec.py
@@ -1121,7 +1121,7 @@ def _inventory_filter_options(f):
     """The inventory filter selectors (shared by list/export)."""
     f = click.option(
         "--unscoped-account", "unscoped_account", is_flag=True, default=False,
-        help="Select only resources that have no cloud account (the '~' bucket).",
+        help="Select only resources that have no cloud account.",
     )(f)
     f = click.option(
         "--all-accounts", "all_accounts", is_flag=True, default=False,

--- a/limacharlie/commands/cloudsec.py
+++ b/limacharlie/commands/cloudsec.py
@@ -1120,9 +1120,13 @@ def _finding_filter_options(f):
 def _inventory_filter_options(f):
     """The inventory filter selectors (shared by list/export)."""
     f = click.option(
+        "--unscoped-account", "unscoped_account", is_flag=True, default=False,
+        help="Select only resources that have no cloud account (the '~' bucket).",
+    )(f)
+    f = click.option(
         "--all-accounts", "all_accounts", is_flag=True, default=False,
-        help="Escape hatch: drop the per-account scoping and span the "
-             "whole estate (the account-scoped default holds otherwise).",
+        help="Span the whole estate. This is already the default and the flag is "
+             "retained for compatibility.",
     )(f)
     f = click.option(
         "-q", "--search", "q", default=None, help="Substring search.",
@@ -1141,6 +1145,23 @@ def _inventory_filter_options(f):
         "--type", "resource_type", default=None, help="Filter by resource type.",
     )(f)
     return f
+
+
+def _inventory_account_unscoped(account: str | None, all_accounts: bool,
+                                unscoped_account: bool) -> bool | None:
+    """Translate CLI account scope flags to the API's accountless-bucket selector.
+
+    Inventory is estate-wide when no account selector is sent. Historically the CLI
+    implemented ``--all-accounts`` by sending ``account_unscoped=true``; that parameter
+    actually means account == '' and silently hid every cloud-account resource. Keep the
+    old flag as a compatibility no-op and expose the real accountless selection explicitly.
+    """
+    selected = int(bool(account)) + int(all_accounts) + int(unscoped_account)
+    if selected > 1:
+        raise click.UsageError(
+            "--account, --all-accounts, and --unscoped-account are mutually exclusive."
+        )
+    return True if unscoped_account else None
 
 
 def _identity_filter_options(f):
@@ -2375,7 +2396,7 @@ def inventory_group() -> None:
 @_paging_options
 @pass_context
 def inventory_list(ctx, resource_type, provider, account, region, q,
-                   all_accounts, cursor, limit) -> None:
+                   all_accounts, unscoped_account, cursor, limit) -> None:
     """List the cloud resource inventory.
 
     \b
@@ -2384,11 +2405,14 @@ def inventory_list(ctx, resource_type, provider, account, region, q,
       limacharlie cloudsec inventory list --provider okta
       limacharlie cloudsec inventory list -q prod --limit 50
       limacharlie cloudsec inventory list --all-accounts
+      limacharlie cloudsec inventory list --unscoped-account
     """
     cs = _get_cloudsec(ctx)
     _output(ctx, cs.list_inventory(
         resource_type=resource_type, provider=provider, account=account,
-        region=region, q=q, account_unscoped=all_accounts or None,
+        region=region, q=q,
+        account_unscoped=_inventory_account_unscoped(
+            account, all_accounts, unscoped_account),
         cursor=cursor, limit=limit,
     ))
 
@@ -3105,7 +3129,7 @@ def export_findings(ctx, severities, finding_classes, statuses, accounts, repos,
 @_export_output_option
 @pass_context
 def export_inventory(ctx, resource_type, provider, account, region, q,
-                     all_accounts, output_path) -> None:
+                     all_accounts, unscoped_account, output_path) -> None:
     """Export the (filtered) cloud resource inventory as CSV.
 
     \b
@@ -3116,7 +3140,9 @@ def export_inventory(ctx, resource_type, provider, account, region, q,
     cs = _get_cloudsec(ctx)
     _emit_csv(ctx, cs.export_inventory_csv(
         resource_type=resource_type, provider=provider, account=account,
-        region=region, q=q, account_unscoped=all_accounts or None,
+        region=region, q=q,
+        account_unscoped=_inventory_account_unscoped(
+            account, all_accounts, unscoped_account),
     ), output_path)
 
 

--- a/limacharlie/sdk/cloudsec.py
+++ b/limacharlie/sdk/cloudsec.py
@@ -778,8 +778,8 @@ class CloudSec:
             account, region: Scalar filters.
             q: Substring search.
             account_unscoped: When ``True``, select only resources whose
-                account is empty (the accountless ``~`` bucket). Omit both
-                this and ``account`` to span the whole estate. The gateway
+                account is empty. Omit both this and ``account`` to span the
+                whole estate. The gateway
                 ignores a ``False`` value.
             cursor, limit: Keyset pagination.
 

--- a/limacharlie/sdk/cloudsec.py
+++ b/limacharlie/sdk/cloudsec.py
@@ -777,10 +777,10 @@ class CloudSec:
                 ``aws``, ``okta``, ``google_workspace``).
             account, region: Scalar filters.
             q: Substring search.
-            account_unscoped: Escape hatch — when ``True`` the walk drops
-                the per-account scoping and spans the whole estate. Only
-                forwarded when set (the account-scoped default holds
-                otherwise); the gateway ignores a ``False`` value.
+            account_unscoped: When ``True``, select only resources whose
+                account is empty (the accountless ``~`` bucket). Omit both
+                this and ``account`` to span the whole estate. The gateway
+                ignores a ``False`` value.
             cursor, limit: Keyset pagination.
 
         Returns:

--- a/limacharlie/sdk/cloudsec.py
+++ b/limacharlie/sdk/cloudsec.py
@@ -87,6 +87,28 @@ def _query_pairs(**params: Any) -> list[tuple[str, str]]:
     return pairs
 
 
+def _inventory_account_selector(
+    account_empty: bool | None,
+    account_unscoped: bool | None,
+) -> dict[str, bool | None]:
+    """Return one inventory account-empty query selector.
+
+    ``account_unscoped`` is the deprecated API name. Preserve it on the wire for
+    callers that still use that argument, while new callers use the unambiguous
+    ``account_empty`` name. Sending conflicting aliases is almost certainly a caller
+    bug and must not silently choose one.
+    """
+    if account_empty is not None and account_unscoped is not None:
+        if bool(account_empty) != bool(account_unscoped):
+            raise ValueError(
+                "account_empty and account_unscoped cannot have different values"
+            )
+        return {"account_empty": account_empty or None}
+    if account_empty is not None:
+        return {"account_empty": account_empty or None}
+    return {"account_unscoped": account_unscoped or None}
+
+
 def _finding_query_pairs(
     *,
     severity: list[str] | None = None,
@@ -765,6 +787,7 @@ class CloudSec:
         account: str | None = None,
         region: str | None = None,
         q: str | None = None,
+        account_empty: bool | None = None,
         account_unscoped: bool | None = None,
         cursor: str | None = None,
         limit: int | None = None,
@@ -777,19 +800,20 @@ class CloudSec:
                 ``aws``, ``okta``, ``google_workspace``).
             account, region: Scalar filters.
             q: Substring search.
-            account_unscoped: When ``True``, select only resources whose
-                account is empty. Omit both this and ``account`` to span the
-                whole estate. The gateway
-                ignores a ``False`` value.
+            account_empty: When ``True``, select only resources whose account
+                is empty. Omit this and ``account`` to span the whole estate.
+            account_unscoped: Deprecated alias for ``account_empty``. It is
+                retained for compatibility with older gateways and callers.
             cursor, limit: Keyset pagination.
 
         Returns:
             ``{"resources": [...], "next_cursor": str}``.
         """
+        selector = _inventory_account_selector(account_empty, account_unscoped)
         return self._get("inventory", _query_pairs(
             type=resource_type, provider=provider, account=account,
             region=region, q=q,
-            account_unscoped=account_unscoped or None,
+            **selector,
             cursor=cursor, limit=limit,
         ))
 
@@ -1821,6 +1845,7 @@ class CloudSec:
         account: str | None = None,
         region: str | None = None,
         q: str | None = None,
+        account_empty: bool | None = None,
         account_unscoped: bool | None = None,
     ) -> str:
         """Export the (filtered) cloud resource inventory as CSV text.
@@ -1832,10 +1857,11 @@ class CloudSec:
         Returns:
             The CSV document as a string.
         """
+        selector = _inventory_account_selector(account_empty, account_unscoped)
         pairs = _query_pairs(
             type=resource_type, provider=provider, account=account,
             region=region, q=q,
-            account_unscoped=account_unscoped or None,
+            **selector,
         )
         pairs.append(("format", "csv"))
         return self._get("inventory", pairs, raw_response=True)

--- a/tests/unit/test_cli_cloudsec.py
+++ b/tests/unit/test_cli_cloudsec.py
@@ -943,6 +943,20 @@ class TestInventoryAllAccounts:
             assert result.exit_code == 0, result.output
             inst.list_inventory.assert_called_once_with(
                 resource_type=None, provider=None, account=None,
+                region=None, q=None, account_unscoped=None,
+                cursor=None, limit=None,
+            )
+
+    def test_list_unscoped_account_flag(self):
+        p1, p2, p3 = _patches()
+        with p1, p2, p3 as cls:
+            result, inst = _invoke(
+                ["cloudsec", "inventory", "list", "--unscoped-account"], cls,
+                return_value={"resources": []},
+            )
+            assert result.exit_code == 0, result.output
+            inst.list_inventory.assert_called_once_with(
+                resource_type=None, provider=None, account=None,
                 region=None, q=None, account_unscoped=True,
                 cursor=None, limit=None,
             )
@@ -968,8 +982,31 @@ class TestInventoryAllAccounts:
             assert result.exit_code == 0, result.output
             inst.export_inventory_csv.assert_called_once_with(
                 resource_type=None, provider=None, account=None,
+                region=None, q=None, account_unscoped=None,
+            )
+
+    def test_export_unscoped_account_flag(self):
+        p1, p2, p3 = _patches()
+        with p1, p2, p3 as cls:
+            result, inst = _invoke(
+                ["cloudsec", "export", "inventory", "--unscoped-account"], cls,
+            )
+            assert result.exit_code == 0, result.output
+            inst.export_inventory_csv.assert_called_once_with(
+                resource_type=None, provider=None, account=None,
                 region=None, q=None, account_unscoped=True,
             )
+
+    def test_account_scope_flags_are_mutually_exclusive(self):
+        runner = CliRunner()
+        for args in [
+            ["--account", "project-1", "--all-accounts"],
+            ["--account", "project-1", "--unscoped-account"],
+            ["--all-accounts", "--unscoped-account"],
+        ]:
+            result = runner.invoke(cli, ["cloudsec", "inventory", "list", *args])
+            assert result.exit_code != 0
+            assert "mutually exclusive" in result.output
 
 
 class TestPolicy:

--- a/tests/unit/test_cli_cloudsec.py
+++ b/tests/unit/test_cli_cloudsec.py
@@ -810,7 +810,7 @@ class TestInventoryProvider:
             assert result.exit_code == 0, result.output
             inst.list_inventory.assert_called_once_with(
                 resource_type=None, provider="okta", account=None,
-                region=None, q=None, account_unscoped=None,
+                region=None, q=None, account_empty=None,
                 cursor=None, limit=None,
             )
 
@@ -857,7 +857,7 @@ class TestExport:
             assert result.exit_code == 0, result.output
             inst.export_inventory_csv.assert_called_once_with(
                 resource_type="Bucket", provider="gcp", account=None,
-                region=None, q=None, account_unscoped=None,
+                region=None, q=None, account_empty=None,
             )
 
     def test_export_compliance(self):
@@ -943,25 +943,25 @@ class TestInventoryAllAccounts:
             assert result.exit_code == 0, result.output
             inst.list_inventory.assert_called_once_with(
                 resource_type=None, provider=None, account=None,
-                region=None, q=None, account_unscoped=None,
+                region=None, q=None, account_empty=None,
                 cursor=None, limit=None,
             )
 
-    def test_list_unscoped_account_flag(self):
+    def test_list_account_empty_flag(self):
         p1, p2, p3 = _patches()
         with p1, p2, p3 as cls:
             result, inst = _invoke(
-                ["cloudsec", "inventory", "list", "--unscoped-account"], cls,
+                ["cloudsec", "inventory", "list", "--account-empty"], cls,
                 return_value={"resources": []},
             )
             assert result.exit_code == 0, result.output
             inst.list_inventory.assert_called_once_with(
                 resource_type=None, provider=None, account=None,
-                region=None, q=None, account_unscoped=True,
+                region=None, q=None, account_empty=True,
                 cursor=None, limit=None,
             )
 
-    def test_list_default_omits_account_unscoped(self):
+    def test_list_default_omits_account_empty(self):
         p1, p2, p3 = _patches()
         with p1, p2, p3 as cls:
             result, inst = _invoke(
@@ -970,8 +970,8 @@ class TestInventoryAllAccounts:
             )
             assert result.exit_code == 0, result.output
             _, kwargs = inst.list_inventory.call_args
-            # The default must not forward a falsey account_unscoped.
-            assert kwargs["account_unscoped"] is None
+            # The default must not forward a falsey account_empty.
+            assert kwargs["account_empty"] is None
 
     def test_export_all_accounts_flag(self):
         p1, p2, p3 = _patches()
@@ -982,27 +982,27 @@ class TestInventoryAllAccounts:
             assert result.exit_code == 0, result.output
             inst.export_inventory_csv.assert_called_once_with(
                 resource_type=None, provider=None, account=None,
-                region=None, q=None, account_unscoped=None,
+                region=None, q=None, account_empty=None,
             )
 
-    def test_export_unscoped_account_flag(self):
+    def test_export_account_empty_flag(self):
         p1, p2, p3 = _patches()
         with p1, p2, p3 as cls:
             result, inst = _invoke(
-                ["cloudsec", "export", "inventory", "--unscoped-account"], cls,
+                ["cloudsec", "export", "inventory", "--account-empty"], cls,
             )
             assert result.exit_code == 0, result.output
             inst.export_inventory_csv.assert_called_once_with(
                 resource_type=None, provider=None, account=None,
-                region=None, q=None, account_unscoped=True,
+                region=None, q=None, account_empty=True,
             )
 
     def test_account_scope_flags_are_mutually_exclusive(self):
         runner = CliRunner()
         for args in [
             ["--account", "project-1", "--all-accounts"],
-            ["--account", "project-1", "--unscoped-account"],
-            ["--all-accounts", "--unscoped-account"],
+            ["--account", "project-1", "--account-empty"],
+            ["--all-accounts", "--account-empty"],
         ]:
             result = runner.invoke(cli, ["cloudsec", "inventory", "list", *args])
             assert result.exit_code != 0

--- a/tests/unit/test_sdk_cloudsec.py
+++ b/tests/unit/test_sdk_cloudsec.py
@@ -624,7 +624,7 @@ class TestInventoryAccountUnscoped:
         assert qp == [("account_unscoped", "true")]
 
     def test_list_inventory_false_is_omitted(self, cs, mock_org):
-        # The account-scoped default must not forward a falsey value.
+        # The estate-wide default must not accidentally select the accountless bucket.
         mock_org.client.request.return_value = {"resources": []}
         cs.list_inventory(account_unscoped=False)
         _, qp = _get_call(mock_org)

--- a/tests/unit/test_sdk_cloudsec.py
+++ b/tests/unit/test_sdk_cloudsec.py
@@ -581,12 +581,12 @@ class TestCsvExports:
         assert json.loads(kwargs["raw_body"]) == {"named": "public_data_stores"}
         assert kwargs["raw_response"] is True
 
-    def test_export_inventory_csv_all_accounts(self, cs, mock_org):
+    def test_export_inventory_csv_account_empty(self, cs, mock_org):
         mock_org.client.request.return_value = "urn\n"
-        cs.export_inventory_csv(provider="gcp", account_unscoped=True)
+        cs.export_inventory_csv(provider="gcp", account_empty=True)
         _, kwargs = mock_org.client.request.call_args
         assert kwargs["query_params"] == [
-            ("provider", "gcp"), ("account_unscoped", "true"), ("format", "csv"),
+            ("provider", "gcp"), ("account_empty", "true"), ("format", "csv"),
         ]
 
 
@@ -615,20 +615,30 @@ class TestIdentityGet:
         assert qp == [("urn", "lcrn:sa")]
 
 
-class TestInventoryAccountUnscoped:
-    def test_list_inventory_all_accounts(self, cs, mock_org):
+class TestInventoryAccountEmpty:
+    def test_list_inventory_account_empty(self, cs, mock_org):
         mock_org.client.request.return_value = {"resources": []}
-        cs.list_inventory(account_unscoped=True)
+        cs.list_inventory(account_empty=True)
         url, qp = _get_call(mock_org)
         assert url == f"cloudsec/{OID}/inventory"
+        assert qp == [("account_empty", "true")]
+
+    def test_deprecated_alias_is_preserved_on_wire(self, cs, mock_org):
+        mock_org.client.request.return_value = {"resources": []}
+        cs.list_inventory(account_unscoped=True)
+        _, qp = _get_call(mock_org)
         assert qp == [("account_unscoped", "true")]
 
     def test_list_inventory_false_is_omitted(self, cs, mock_org):
         # The estate-wide default must not accidentally select the accountless bucket.
         mock_org.client.request.return_value = {"resources": []}
-        cs.list_inventory(account_unscoped=False)
+        cs.list_inventory(account_empty=False)
         _, qp = _get_call(mock_org)
         assert qp is None
+
+    def test_conflicting_aliases_are_rejected(self, cs):
+        with pytest.raises(ValueError, match="cannot have different values"):
+            cs.list_inventory(account_empty=True, account_unscoped=False)
 
 
 class TestPolicyAuthoring:


### PR DESCRIPTION
## Summary

- make --all-accounts honor its documented estate-wide meaning
- add unambiguous --account-empty for resources without a cloud account
- add canonical account_empty SDK arguments
- retain account_unscoped as a deprecated SDK compatibility alias
- reject conflicting scope selectors and conflicting SDK aliases

## Validation

- affected Python unit suite: 238 passed
- prior full local suite: 3802 passed, 19 skipped
- live white-sands check: --all-accounts returns all 14 AzureRoleAssignment rows