### PR TITLE
mailsec: full CLI and SDK coverage of the Email Security API

### DIFF
--- a/limacharlie/cli.py
+++ b/limacharlie/cli.py
@@ -152,6 +152,7 @@ _COMMAND_MODULE_MAP: dict[str, tuple[str, str]] = {
     "logging": ("logging_cmd", "group"),
     "lookup": ("lookup", "group"),
     "note": ("note", "group"),
+    "mailsec": ("mailsec", "group"),
     "org": ("org", "group"),
     "output": ("output_cmd", "group"),
     "payload": ("payload", "group"),

--- a/limacharlie/commands/mailsec.py
+++ b/limacharlie/commands/mailsec.py
@@ -560,8 +560,10 @@ def message_get(ctx, msg_uuid) -> None:
 @click.argument("msg_uuid")
 @click.option("--justification", required=True,
               help="Why you are downloading this person's mail. Written to the access audit.")
-@click.option("--output", "out_path", default=None, type=click.Path(dir_okay=False),
-              help="Write the bytes here instead of to stdout.")
+@click.option("--out-file", "out_path", default=None, type=click.Path(dir_okay=False),
+              help="Write the raw bytes to this path instead of to stdout. Deliberately NOT "
+                   "--output: that is the global format option, and a command-level --output "
+                   "would shadow it so that `--output yaml` silently wrote a file named 'yaml'.")
 @pass_context
 def message_eml(ctx, msg_uuid, justification, out_path) -> None:
     """Download the original bytes of a message (audited).

--- a/limacharlie/commands/mailsec.py
+++ b/limacharlie/commands/mailsec.py
@@ -1,0 +1,920 @@
+"""Email Security (mailsec) commands for LimaCharlie CLI v2.
+
+Commands for the ``/mailsec`` API surface: the coverage screen, the message
+index and its drawer, the justified raw-EML download, campaigns and
+campaign-wide sweeps, sender profiles, the action audit trail, the
+abuse-mailbox report queue, standalone EML analysis, retro-hunts, custom-rule
+validation and backtest, the connection preflight, and the served onboarding
+guide.
+
+Four permissions rather than the usual get/set pair, because mailsec asks to be
+trusted with four different things:
+
+  mailsec.get      read the product's own view (queue, drawer, campaigns,
+                   senders, audit trail)
+  mailsec.set      change detection behaviour and triage state
+  mailsec.act      remediate live mail at the provider
+  mailsec.get.eml  take the original bytes of somebody's mail out of the
+                   building; requires a logged justification
+
+Every command requires the org to be subscribed to the ``ext-email-security``
+extension:
+
+  limacharlie extension subscribe --name ext-email-security
+
+Provider connections and policy are hive records — manage them with the hive
+commands (``limacharlie hive list --hive-name mailsec_provider``, same for
+``mailsec_policy`` and ``dr-mail``). The connection operations here are the
+post-save preflight (``mailsec connection test``) and the served setup guide
+(``mailsec onboarding``).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import click
+
+from ..cli import pass_context
+from ..client import Client
+from ..sdk.organization import Organization
+from ..sdk.mailsec import Mailsec
+from ..output import format_output, detect_output_format
+from ..discovery import register_explain
+
+
+# ---------------------------------------------------------------------------
+# Explain texts
+# ---------------------------------------------------------------------------
+
+_EXPLAIN_COVERAGE = """\
+Coverage and volume for the org: how many mailboxes are protected,
+which are not and why, and what was analysed over the window.
+
+The mailboxes that are NOT protected are the point. A mailbox we
+cannot subscribe is reported as visibly broken rather than omitted,
+so the number is a coverage statement an admin can act on instead of
+a count of whatever happened to work.
+
+Examples:
+  limacharlie mailsec coverage
+  limacharlie mailsec coverage --window-days 30
+"""
+
+_EXPLAIN_MESSAGE_LIST = """\
+The message index — the triage queue. Repeatable filters OR within a
+key and AND across keys.
+
+--user-reported is worth knowing about: a human taking the trouble to
+report a message is the strongest signal this product gets, and it
+outranks whatever the scorer decided.
+
+Examples:
+  limacharlie mailsec message list --verdict suspicious --verdict malicious
+  limacharlie mailsec message list --mailbox cfo@corp.example --since 2026-08-01
+  limacharlie mailsec message list --user-reported
+  limacharlie mailsec message list --link-domain evil.example
+"""
+
+_EXPLAIN_MESSAGE_GET = """\
+One message: the index row plus the re-parsed MDM (the drawer).
+
+The MDM is re-parsed from the stored raw copy rather than read from
+the index, and the response says which path produced it. Enrichments
+are deliberately absent rather than recomputed — they were resolved
+against sender profiles as they existed at ingest, and synthesising
+today's values would show you a reputation the verdict was never
+based on.
+
+An unknown id returns a null message, not an error: the index has a
+35-day TTL, so a miss is normal.
+
+Examples:
+  limacharlie mailsec message get 0057db2b-3a06-5aab-b3be-c1e6c15dcf10
+"""
+
+_EXPLAIN_MESSAGE_EML = """\
+Download the original RFC822 bytes of a message.
+
+This is a different privilege from opening the drawer (mailsec.get.eml,
+not mailsec.get) because it takes a person's actual mail out of the
+building. --justification is REQUIRED and is written to the access
+audit with your identity: there is no way to fetch these bytes without
+leaving a record of why.
+
+Examples:
+  limacharlie mailsec message eml 0057db2b-... --justification "INC-4471 credential harvest"
+"""
+
+_EXPLAIN_MESSAGE_SIMILAR = """\
+Messages clustered with this one — "who else got this", answered from
+a single message.
+
+Examples:
+  limacharlie mailsec message similar 0057db2b-...
+"""
+
+_EXPLAIN_MESSAGE_ACTION = """\
+Remediate one message at the provider. Requires mailsec.act.
+
+Executed by the collector holding the org's lease — the single choke
+point where alert_only/enforce is applied and the audit row written.
+Idempotent per (message, action).
+
+Watch for result=alert_only: it means the action was DECIDED and
+deliberately not performed because the org is not in enforce mode.
+That is a success reported honestly, not a failure.
+
+Examples:
+  limacharlie mailsec message action 0057db2b-... --action quarantine_message --reason "confirmed phish"
+  limacharlie mailsec message action 0057db2b-... --action restore_message
+"""
+
+_EXPLAIN_CAMPAIGN_LIST = """\
+Campaigns: one attack triaged once, rather than once per mailbox.
+
+Examples:
+  limacharlie mailsec campaign list --min-members 3
+  limacharlie mailsec campaign list --verdict malicious
+"""
+
+_EXPLAIN_CAMPAIGN_GET = """\
+One campaign with its aggregates and the cluster keys that grouped it.
+
+Examples:
+  limacharlie mailsec campaign get ec7e273b-ea9d-51e1-bdd8-9c18829d2071
+"""
+
+_EXPLAIN_CAMPAIGN_ACTION = """\
+Sweep an action across every member of a campaign. Requires mailsec.act.
+
+PREVIEWS BY DEFAULT. --confirm <campaign_id> is what turns the preview
+into an execution, which is the right default for an operation whose
+blast radius is every mailbox that received the attack.
+
+Examples:
+  limacharlie mailsec campaign action ec7e273b-... --action quarantine_message
+  limacharlie mailsec campaign action ec7e273b-... --action quarantine_message --confirm ec7e273b-...
+"""
+
+_EXPLAIN_SENDER_GET = """\
+A sender's history with this org: prevalence, first seen, and how much
+of their mail has been flagged.
+
+The key is an address or a domain, optionally prefixed to disambiguate.
+
+Examples:
+  limacharlie mailsec sender get cfo@corp.example
+  limacharlie mailsec sender get domain:corp.example
+"""
+
+_EXPLAIN_ACTION_GET = """\
+One record from the action audit trail: what was decided, by whom, why,
+and what the provider actually did.
+
+Examples:
+  limacharlie mailsec action get <action_id>
+"""
+
+_EXPLAIN_ANALYZE = """\
+Parse and score an EML without ingesting it. Nothing is persisted and
+no mailbox is touched.
+
+Examples:
+  limacharlie mailsec analyze --file suspect.eml
+  limacharlie mailsec analyze --file suspect.eml --org-domain corp.example
+"""
+
+_EXPLAIN_REPORT_LIST = """\
+The abuse-mailbox report queue: what the org's own people reported.
+
+--oldest-first is what makes this an SLA surface. "The oldest thing
+nobody has looked at" is the question a queue exists to answer, and it
+is not answerable from a newest-first page.
+
+Each report carries original_found. A report whose original was never
+indexed is a real state — the message predates the connection, or
+landed in a mailbox outside scope — and it is shown as a gap rather
+than as a blank field that reads like a bug.
+
+Examples:
+  limacharlie mailsec report list --status open --oldest-first
+  limacharlie mailsec report list --status resolved
+"""
+
+_EXPLAIN_REPORT_GET = """\
+One report: who reported it, the message they reported, and the
+original it refers to once located across the tenant's mailboxes.
+
+Examples:
+  limacharlie mailsec report get dfed9d76ce5ee1096852ea563f5cce23
+"""
+
+_EXPLAIN_REPORT_RESOLVE = """\
+Close a report with a disposition. Requires mailsec.set.
+
+'unknown' is deliberately not resolvable by a human: as the outcome of
+someone closing a report it means "I looked and decided nothing", which
+is indistinguishable in the SLA numbers from never having looked.
+
+Resolving twice succeeds and reports already_resolved — two analysts
+clicking at once is ordinary, and the second must not get an error for
+an outcome that already holds.
+
+Examples:
+  limacharlie mailsec report resolve <report_id> --disposition true_positive
+"""
+
+_EXPLAIN_HUNT_CREATE = """\
+Start a retro-hunt over message history.
+
+Examples:
+  limacharlie mailsec hunt create --detect-file detect.json --since 2026-07-01
+  limacharlie mailsec hunt create --lcql "..." --dry-run
+"""
+
+_EXPLAIN_HUNT_GET = """\
+A hunt's status and results.
+
+Examples:
+  limacharlie mailsec hunt get <hunt_id>
+"""
+
+_EXPLAIN_HUNT_REMEDIATE = """\
+Bulk-remediate a hunt's results. Requires mailsec.act.
+
+Previews by default; --confirm executes, exactly like a campaign sweep.
+
+Examples:
+  limacharlie mailsec hunt remediate <hunt_id> --action quarantine_message
+  limacharlie mailsec hunt remediate <hunt_id> --action quarantine_message --confirm <hunt_id>
+"""
+
+_EXPLAIN_RULE_VALIDATE = """\
+Check a candidate detection rule without saving it.
+
+Runs the SAME validation the dr-mail hive applies on save, so a rule
+this accepts is a rule that will save. An invalid rule comes back as a
+successful response with valid=false and the reason — that is the
+answer to the question, not a failure to answer it.
+
+Tenant rule ids must start with 'custom-'.
+
+Examples:
+  limacharlie mailsec rule validate --file rule.json
+  limacharlie mailsec rule validate --file rule.json --rule-id custom-lookalike
+"""
+
+_EXPLAIN_RULE_BACKTEST = """\
+Replay a candidate rule over recent mail and report what it would have
+matched, so its precision is known before it is enabled.
+
+Bounded to the window this product retains rather than the full-history
+retro-hunt; every response says so in coverage_note and counts what it
+could NOT examine (skipped_no_raw, skipped_unparse, truncated). A
+precision figure whose denominator silently shrank is a number that
+looks like a measurement and is not one.
+
+precision is null - not 0 - when nothing it matched has an analyst
+disposition yet. Zero would read as "everything it matched was wrong"
+and would have you discard a good rule.
+
+Examples:
+  limacharlie mailsec rule backtest --file rule.json
+  limacharlie mailsec rule backtest --file rule.json --since 2026-08-01
+"""
+
+_EXPLAIN_CONNECTION_TEST = """\
+Exercise a saved provider connection end to end.
+
+Takes the RECORD NAME of a mailsec_provider hive record, never a
+credential: the credential stays in the secret hive and is resolved
+server-side. Reports what the connection can actually do, including the
+per-connection capabilities that depend on which scopes the customer's
+admin granted.
+
+Examples:
+  limacharlie mailsec connection test gws-exp
+"""
+
+_EXPLAIN_ONBOARDING = """\
+The setup guide for connecting a mail provider, with this org's own
+values already substituted in.
+
+Served by the backend rather than written into the docs so the
+identifiers you must paste - the service account, the topic, the
+subscription - are the real ones for this deployment rather than
+placeholders you have to translate.
+
+Examples:
+  limacharlie mailsec onboarding --provider gworkspace
+  limacharlie mailsec onboarding --provider m365
+"""
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _output(ctx: click.Context, data: Any) -> None:
+    fmt = ctx.obj.output_format or detect_output_format()
+    if not ctx.obj.quiet:
+        click.echo(format_output(data, fmt))
+
+
+def _get_mailsec(ctx: click.Context) -> Mailsec:
+    client = Client(
+        oid=ctx.obj.oid,
+        environment=ctx.obj.environment,
+        print_debug_fn=ctx.obj.debug_fn,
+        debug_full_response=ctx.obj.debug_full,
+        debug_curl=ctx.obj.debug_curl,
+        debug_verbose=ctx.obj.debug_verbose,
+    )
+    org = Organization(client)
+    return Mailsec(org)
+
+
+def _load_json_file(path: str, param_hint: str) -> Any:
+    """Read a JSON document from a file, with a usage error rather than a
+    traceback when it is not JSON."""
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except OSError as e:
+        raise click.BadParameter(f"cannot read {path}: {e}", param_hint=param_hint)
+    except json.JSONDecodeError as e:
+        raise click.BadParameter(f"{path} is not valid JSON: {e}", param_hint=param_hint)
+
+
+def _tri_state(flag: bool, no_flag: bool, name: str) -> bool | None:
+    """Resolve a --x / --no-x pair into a tri-state.
+
+    Neither flag means UNCONSTRAINED, which is not the same as False. The API
+    is tri-state throughout and collapsing the two here would silently narrow
+    every unfiltered read.
+    """
+    if flag and no_flag:
+        raise click.BadParameter(f"--{name} and --no-{name} are mutually exclusive")
+    if flag:
+        return True
+    if no_flag:
+        return False
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Groups
+# ---------------------------------------------------------------------------
+
+@click.group(name="mailsec")
+def group() -> None:
+    """Email Security: mail ingest, verdicts, campaigns, remediation.
+
+    \b
+    Requires the ext-email-security extension:
+      limacharlie extension subscribe --name ext-email-security
+
+    \b
+      coverage            Mailbox coverage and analysed volume
+      message ...         The triage queue, drawer, raw EML, similar, actions
+      campaign ...        Campaigns and campaign-wide sweeps
+      sender get          A sender's history with this org
+      action get          One record from the action audit trail
+      analyze             Parse and score an EML without ingesting it
+      report ...          Abuse-mailbox report queue (list, get, resolve)
+      hunt ...            Retro-hunts (create, get, remediate)
+      rule ...            Custom rule validation and backtest
+      connection test     Provider connection preflight
+      onboarding          Provider setup guide, with your values filled in
+    """
+
+
+@group.group("message")
+def message_group() -> None:
+    """The message index, drawer, raw EML, similar mail, and actions."""
+
+
+@group.group("campaign")
+def campaign_group() -> None:
+    """Campaigns and campaign-wide sweeps."""
+
+
+@group.group("sender")
+def sender_group() -> None:
+    """Sender profiles."""
+
+
+@group.group("action")
+def action_group() -> None:
+    """The action audit trail."""
+
+
+@group.group("report")
+def report_group() -> None:
+    """The abuse-mailbox report queue."""
+
+
+@group.group("hunt")
+def hunt_group() -> None:
+    """Retro-hunts over message history."""
+
+
+@group.group("rule")
+def rule_group() -> None:
+    """Custom detection rules: validate and backtest."""
+
+
+@group.group("connection")
+def connection_group() -> None:
+    """Provider connections."""
+
+
+# ---------------------------------------------------------------------------
+# Top-level
+# ---------------------------------------------------------------------------
+
+@group.command("coverage")
+@click.option("--window-days", default=None, type=int, help="Days of volume to summarise.")
+@pass_context
+def coverage(ctx, window_days) -> None:
+    """Mailbox coverage and analysed volume.
+
+    \b
+    Example:
+      limacharlie mailsec coverage --window-days 30
+    """
+    _output(ctx, _get_mailsec(ctx).get_coverage(window_days=window_days))
+
+
+@group.command("analyze")
+@click.option("--file", "eml_file", required=True, type=click.Path(exists=True, dir_okay=False),
+              help="Path to the .eml to analyse.")
+@click.option("--org-domain", "org_domains", multiple=True,
+              help="One of your org's domains (repeatable); makes direction and impersonation computable.")
+@click.option("--direction", default=None, help="Override the computed direction.")
+@pass_context
+def analyze(ctx, eml_file, org_domains, direction) -> None:
+    """Parse and score an EML without ingesting it.
+
+    \b
+    Example:
+      limacharlie mailsec analyze --file suspect.eml --org-domain corp.example
+    """
+    import base64
+
+    with open(eml_file, "rb") as f:
+        raw = f.read()
+    # Sent base64 rather than as text: an EML is bytes, and a raw 8-bit body or
+    # a stray CR would not survive a JSON string round trip intact.
+    ms = _get_mailsec(ctx)
+    _output(ctx, ms.analyze(
+        eml_b64=base64.b64encode(raw).decode("ascii"),
+        org_domains=list(org_domains) or None,
+        direction=direction,
+    ))
+
+
+@group.command("onboarding")
+@click.option("--provider", default=None, type=click.Choice(["m365", "gworkspace"]),
+              help="Which provider's guide to fetch.")
+@pass_context
+def onboarding(ctx, provider) -> None:
+    """Provider setup guide, with this org's own values filled in.
+
+    \b
+    Example:
+      limacharlie mailsec onboarding --provider gworkspace
+    """
+    _output(ctx, _get_mailsec(ctx).get_onboarding(provider=provider))
+
+
+# ---------------------------------------------------------------------------
+# Messages
+# ---------------------------------------------------------------------------
+
+@message_group.command("list")
+@click.option("--verdict", multiple=True, help="malicious|suspicious|graymail|benign|unknown (repeatable).")
+@click.option("--mailbox", default=None, help="Protected mailbox address (exact).")
+@click.option("--sender-email", default=None, help="Sender address (exact).")
+@click.option("--sender-domain", default=None, help="Sender registrable root domain.")
+@click.option("--campaign-id", default=None, help="Only members of this campaign.")
+@click.option("--state", multiple=True, help="Message state (repeatable).")
+@click.option("--direction", multiple=True, help="inbound|outbound|internal (repeatable).")
+@click.option("--user-reported", is_flag=True, default=False, help="Only mail a person reported.")
+@click.option("--no-user-reported", is_flag=True, default=False, help="Only mail nobody reported.")
+@click.option("--min-score", default=None, type=int, help="Only messages at or above this score.")
+@click.option("--link-domain", default=None, help="IOC pivot: who else got mail linking here.")
+@click.option("--attachment-sha256", default=None, help="IOC pivot: who else got this file.")
+@click.option("--since", default=None, help="Lower time bound (RFC3339 or unix seconds).")
+@click.option("--until", default=None, help="Upper time bound.")
+@click.option("--cursor", default=None, help="Keyset token from a previous page.")
+@click.option("--limit", default=None, type=int, help="Page size.")
+@pass_context
+def message_list(ctx, verdict, mailbox, sender_email, sender_domain, campaign_id, state,
+                 direction, user_reported, no_user_reported, min_score, link_domain,
+                 attachment_sha256, since, until, cursor, limit) -> None:
+    """The message index — the triage queue.
+
+    \b
+    Examples:
+      limacharlie mailsec message list --verdict suspicious
+      limacharlie mailsec message list --user-reported
+      limacharlie mailsec message list --link-domain evil.example
+    """
+    ms = _get_mailsec(ctx)
+    _output(ctx, ms.list_messages(
+        verdict=list(verdict) or None,
+        mailbox=mailbox,
+        sender_email=sender_email,
+        sender_domain=sender_domain,
+        campaign_id=campaign_id,
+        state=list(state) or None,
+        direction=list(direction) or None,
+        user_reported=_tri_state(user_reported, no_user_reported, "user-reported"),
+        min_score=min_score,
+        link_domain=link_domain,
+        attachment_sha256=attachment_sha256,
+        since=since,
+        until=until,
+        cursor=cursor,
+        limit=limit,
+    ))
+
+
+@message_group.command("get")
+@click.argument("msg_uuid")
+@pass_context
+def message_get(ctx, msg_uuid) -> None:
+    """One message: the index row plus the re-parsed MDM.
+
+    \b
+    Example:
+      limacharlie mailsec message get 0057db2b-3a06-5aab-b3be-c1e6c15dcf10
+    """
+    _output(ctx, _get_mailsec(ctx).get_message(msg_uuid))
+
+
+@message_group.command("eml")
+@click.argument("msg_uuid")
+@click.option("--justification", required=True,
+              help="Why you are downloading this person's mail. Written to the access audit.")
+@click.option("--output", "out_path", default=None, type=click.Path(dir_okay=False),
+              help="Write the bytes here instead of to stdout.")
+@pass_context
+def message_eml(ctx, msg_uuid, justification, out_path) -> None:
+    """Download the original bytes of a message (audited).
+
+    \b
+    Example:
+      limacharlie mailsec message eml 0057db2b-... --justification "INC-4471"
+    """
+    ms = _get_mailsec(ctx)
+    data = ms.get_message_eml(msg_uuid, justification)
+    if out_path:
+        payload = data if isinstance(data, (bytes, bytearray)) else str(data).encode()
+        with open(out_path, "wb") as f:
+            f.write(payload)
+        if not ctx.obj.quiet:
+            click.echo(f"wrote {len(payload)} bytes to {out_path}")
+        return
+    _output(ctx, data)
+
+
+@message_group.command("similar")
+@click.argument("msg_uuid")
+@click.option("--cursor", default=None, help="Keyset token from a previous page.")
+@click.option("--limit", default=None, type=int, help="Page size.")
+@pass_context
+def message_similar(ctx, msg_uuid, cursor, limit) -> None:
+    """Messages clustered with this one — who else got it.
+
+    \b
+    Example:
+      limacharlie mailsec message similar 0057db2b-...
+    """
+    _output(ctx, _get_mailsec(ctx).list_similar_messages(msg_uuid, cursor=cursor, limit=limit))
+
+
+@message_group.command("action")
+@click.argument("msg_uuid")
+@click.option("--action", "action_name", required=True,
+              help="quarantine_message|trash_message|restore_message|apply_banner|remove_banner")
+@click.option("--reason", default=None, help="Recorded on the audit row.")
+@click.option("--attempt", default=None, help="Caller-supplied idempotency token.")
+@click.option("--banner", default=None, help="Banner HTML, for the banner actions.")
+@pass_context
+def message_action(ctx, msg_uuid, action_name, reason, attempt, banner) -> None:
+    """Remediate one message at the provider (mailsec.act).
+
+    \b
+    Example:
+      limacharlie mailsec message action 0057db2b-... --action quarantine_message --reason "phish"
+    """
+    ms = _get_mailsec(ctx)
+    _output(ctx, ms.act_on_message(
+        msg_uuid, action_name, reason=reason, attempt=attempt, banner=banner,
+    ))
+
+
+# ---------------------------------------------------------------------------
+# Campaigns
+# ---------------------------------------------------------------------------
+
+@campaign_group.command("list")
+@click.option("--state", multiple=True, help="Campaign state (repeatable).")
+@click.option("--verdict", multiple=True, help="Campaign verdict (repeatable).")
+@click.option("--min-members", default=None, type=int, help="Only campaigns with at least this many members.")
+@click.option("--since", default=None, help="Lower time bound.")
+@click.option("--until", default=None, help="Upper time bound.")
+@click.option("--cursor", default=None, help="Keyset token from a previous page.")
+@click.option("--limit", default=None, type=int, help="Page size.")
+@pass_context
+def campaign_list(ctx, state, verdict, min_members, since, until, cursor, limit) -> None:
+    """Campaigns: one attack triaged once, not once per mailbox.
+
+    \b
+    Example:
+      limacharlie mailsec campaign list --min-members 3
+    """
+    ms = _get_mailsec(ctx)
+    _output(ctx, ms.list_campaigns(
+        state=list(state) or None,
+        verdict=list(verdict) or None,
+        min_members=min_members,
+        since=since, until=until, cursor=cursor, limit=limit,
+    ))
+
+
+@campaign_group.command("get")
+@click.argument("campaign_id")
+@pass_context
+def campaign_get(ctx, campaign_id) -> None:
+    """One campaign with its aggregates and cluster keys.
+
+    \b
+    Example:
+      limacharlie mailsec campaign get ec7e273b-...
+    """
+    _output(ctx, _get_mailsec(ctx).get_campaign(campaign_id))
+
+
+@campaign_group.command("action")
+@click.argument("campaign_id")
+@click.option("--action", "action_name", required=True, help="The typed action to sweep.")
+@click.option("--confirm", default=None,
+              help="Pass the campaign id to EXECUTE. Omit to preview — previewing is the default.")
+@click.option("--reason", default=None, help="Recorded on every resulting audit row.")
+@pass_context
+def campaign_action(ctx, campaign_id, action_name, confirm, reason) -> None:
+    """Sweep an action across a whole campaign (mailsec.act).
+
+    \b
+    Previews unless --confirm is given.
+
+    \b
+    Example:
+      limacharlie mailsec campaign action ec7e273b-... --action quarantine_message --confirm ec7e273b-...
+    """
+    ms = _get_mailsec(ctx)
+    _output(ctx, ms.act_on_campaign(campaign_id, action_name, confirm=confirm, reason=reason))
+
+
+# ---------------------------------------------------------------------------
+# Senders, audit
+# ---------------------------------------------------------------------------
+
+@sender_group.command("get")
+@click.argument("key")
+@pass_context
+def sender_get(ctx, key) -> None:
+    """A sender's history with this org.
+
+    \b
+    Example:
+      limacharlie mailsec sender get cfo@corp.example
+    """
+    _output(ctx, _get_mailsec(ctx).get_sender_profile(key))
+
+
+@action_group.command("get")
+@click.argument("action_id")
+@pass_context
+def action_get(ctx, action_id) -> None:
+    """One record from the action audit trail.
+
+    \b
+    Example:
+      limacharlie mailsec action get <action_id>
+    """
+    _output(ctx, _get_mailsec(ctx).get_action(action_id))
+
+
+# ---------------------------------------------------------------------------
+# Reports
+# ---------------------------------------------------------------------------
+
+@report_group.command("list")
+@click.option("--status", multiple=True, help="open|triaging|resolved (repeatable).")
+@click.option("--oldest-first", is_flag=True, default=False,
+              help="Order by age — the SLA view: the oldest thing nobody has looked at.")
+@click.option("--cursor", default=None, help="Keyset token from a previous page.")
+@click.option("--limit", default=None, type=int, help="Page size.")
+@pass_context
+def report_list(ctx, status, oldest_first, cursor, limit) -> None:
+    """The abuse-mailbox report queue.
+
+    \b
+    Example:
+      limacharlie mailsec report list --status open --oldest-first
+    """
+    ms = _get_mailsec(ctx)
+    _output(ctx, ms.list_reports(
+        status=list(status) or None,
+        # Only forwarded when set, so absent keeps the newest-first default
+        # every other list in this API uses.
+        oldest_first=True if oldest_first else None,
+        cursor=cursor, limit=limit,
+    ))
+
+
+@report_group.command("get")
+@click.argument("report_id")
+@pass_context
+def report_get(ctx, report_id) -> None:
+    """One report and the original it refers to.
+
+    \b
+    Example:
+      limacharlie mailsec report get dfed9d76ce5ee1096852ea563f5cce23
+    """
+    _output(ctx, _get_mailsec(ctx).get_report(report_id))
+
+
+@report_group.command("resolve")
+@click.argument("report_id")
+@click.option("--disposition", required=True,
+              type=click.Choice(["true_positive", "false_positive", "benign"]),
+              help="What was decided. 'unknown' is deliberately not offered.")
+@pass_context
+def report_resolve(ctx, report_id, disposition) -> None:
+    """Close a report with a disposition (mailsec.set).
+
+    \b
+    Example:
+      limacharlie mailsec report resolve <report_id> --disposition true_positive
+    """
+    _output(ctx, _get_mailsec(ctx).resolve_report(report_id, disposition))
+
+
+# ---------------------------------------------------------------------------
+# Hunts
+# ---------------------------------------------------------------------------
+
+@hunt_group.command("create")
+@click.option("--detect-file", default=None, type=click.Path(exists=True, dir_okay=False),
+              help="JSON file holding a D&R detect block.")
+@click.option("--lcql", default=None, help="An LCQL query, as an alternative to --detect-file.")
+@click.option("--since", default=None, help="Lower time bound.")
+@click.option("--until", default=None, help="Upper time bound.")
+@click.option("--dry-run", is_flag=True, default=False, help="Estimate cost and matches without running.")
+@pass_context
+def hunt_create(ctx, detect_file, lcql, since, until, dry_run) -> None:
+    """Start a retro-hunt over message history.
+
+    \b
+    Example:
+      limacharlie mailsec hunt create --detect-file detect.json --since 2026-07-01
+    """
+    if not detect_file and not lcql:
+        raise click.UsageError("a hunt needs something to match: pass --detect-file or --lcql")
+    detect = _load_json_file(detect_file, "--detect-file") if detect_file else None
+    ms = _get_mailsec(ctx)
+    _output(ctx, ms.create_hunt(
+        detect=detect, lcql=lcql, since=since, until=until,
+        dry_run=True if dry_run else None,
+    ))
+
+
+@hunt_group.command("get")
+@click.argument("hunt_id")
+@pass_context
+def hunt_get(ctx, hunt_id) -> None:
+    """A hunt's status and results.
+
+    \b
+    Example:
+      limacharlie mailsec hunt get <hunt_id>
+    """
+    _output(ctx, _get_mailsec(ctx).get_hunt(hunt_id))
+
+
+@hunt_group.command("remediate")
+@click.argument("hunt_id")
+@click.option("--action", "action_name", required=True, help="The typed action to apply to the results.")
+@click.option("--confirm", default=None, help="Pass the hunt id to EXECUTE. Omit to preview.")
+@click.option("--reason", default=None, help="Recorded on every resulting audit row.")
+@pass_context
+def hunt_remediate(ctx, hunt_id, action_name, confirm, reason) -> None:
+    """Bulk-remediate a hunt's results (mailsec.act).
+
+    \b
+    Previews unless --confirm is given.
+
+    \b
+    Example:
+      limacharlie mailsec hunt remediate <hunt_id> --action quarantine_message --confirm <hunt_id>
+    """
+    ms = _get_mailsec(ctx)
+    _output(ctx, ms.remediate_hunt(hunt_id, action_name, confirm=confirm, reason=reason))
+
+
+# ---------------------------------------------------------------------------
+# Rules
+# ---------------------------------------------------------------------------
+
+@rule_group.command("validate")
+@click.option("--file", "rule_file", required=True, type=click.Path(exists=True, dir_okay=False),
+              help="JSON file holding the candidate rule body.")
+@click.option("--rule-id", default=None, help="Rule id; tenant ids must start with 'custom-'.")
+@pass_context
+def rule_validate(ctx, rule_file, rule_id) -> None:
+    """Check a candidate rule without saving it.
+
+    \b
+    Runs the same validation the dr-mail hive applies on save.
+
+    \b
+    Example:
+      limacharlie mailsec rule validate --file rule.json --rule-id custom-lookalike
+    """
+    rule = _load_json_file(rule_file, "--file")
+    _output(ctx, _get_mailsec(ctx).validate_rule(rule, rule_id=rule_id))
+
+
+@rule_group.command("backtest")
+@click.option("--file", "rule_file", required=True, type=click.Path(exists=True, dir_okay=False),
+              help="JSON file holding the candidate rule body.")
+@click.option("--rule-id", default=None, help="Rule id; tenant ids must start with 'custom-'.")
+@click.option("--since", default=None, help="Lower time bound.")
+@click.option("--until", default=None, help="Upper time bound.")
+@pass_context
+def rule_backtest(ctx, rule_file, rule_id, since, until) -> None:
+    """Replay a candidate rule over recent mail and report its precision.
+
+    \b
+    Example:
+      limacharlie mailsec rule backtest --file rule.json --since 2026-08-01
+    """
+    rule = _load_json_file(rule_file, "--file")
+    ms = _get_mailsec(ctx)
+    _output(ctx, ms.backtest_rule(rule, rule_id=rule_id, since=since, until=until))
+
+
+# ---------------------------------------------------------------------------
+# Connections
+# ---------------------------------------------------------------------------
+
+@connection_group.command("test")
+@click.argument("record")
+@pass_context
+def connection_test(ctx, record) -> None:
+    """Exercise a saved provider connection end to end.
+
+    \b
+    Takes the mailsec_provider RECORD NAME, never a credential.
+
+    \b
+    Example:
+      limacharlie mailsec connection test gws-exp
+    """
+    _output(ctx, _get_mailsec(ctx).test_connection(record))
+
+
+# ---------------------------------------------------------------------------
+# Explain registration
+# ---------------------------------------------------------------------------
+
+register_explain("mailsec.coverage", _EXPLAIN_COVERAGE)
+register_explain("mailsec.analyze", _EXPLAIN_ANALYZE)
+register_explain("mailsec.onboarding", _EXPLAIN_ONBOARDING)
+register_explain("mailsec.message.list", _EXPLAIN_MESSAGE_LIST)
+register_explain("mailsec.message.get", _EXPLAIN_MESSAGE_GET)
+register_explain("mailsec.message.eml", _EXPLAIN_MESSAGE_EML)
+register_explain("mailsec.message.similar", _EXPLAIN_MESSAGE_SIMILAR)
+register_explain("mailsec.message.action", _EXPLAIN_MESSAGE_ACTION)
+register_explain("mailsec.campaign.list", _EXPLAIN_CAMPAIGN_LIST)
+register_explain("mailsec.campaign.get", _EXPLAIN_CAMPAIGN_GET)
+register_explain("mailsec.campaign.action", _EXPLAIN_CAMPAIGN_ACTION)
+register_explain("mailsec.sender.get", _EXPLAIN_SENDER_GET)
+register_explain("mailsec.action.get", _EXPLAIN_ACTION_GET)
+register_explain("mailsec.report.list", _EXPLAIN_REPORT_LIST)
+register_explain("mailsec.report.get", _EXPLAIN_REPORT_GET)
+register_explain("mailsec.report.resolve", _EXPLAIN_REPORT_RESOLVE)
+register_explain("mailsec.hunt.create", _EXPLAIN_HUNT_CREATE)
+register_explain("mailsec.hunt.get", _EXPLAIN_HUNT_GET)
+register_explain("mailsec.hunt.remediate", _EXPLAIN_HUNT_REMEDIATE)
+register_explain("mailsec.rule.validate", _EXPLAIN_RULE_VALIDATE)
+register_explain("mailsec.rule.backtest", _EXPLAIN_RULE_BACKTEST)
+register_explain("mailsec.connection.test", _EXPLAIN_CONNECTION_TEST)

--- a/limacharlie/sdk/mailsec.py
+++ b/limacharlie/sdk/mailsec.py
@@ -42,9 +42,23 @@ from __future__ import annotations
 
 import json
 from typing import Any, TYPE_CHECKING
+from urllib.parse import quote as _quote
 
 if TYPE_CHECKING:
     from .organization import Organization
+
+
+def _seg(value: str) -> str:
+    """Escape one caller-supplied path segment.
+
+    `safe=""` so a slash is escaped too. Most of these ids are UUIDs the server
+    minted and are harmless either way, but two are arbitrary user input: the
+    sender key is an address or domain a person types, and the connection record
+    is a hive record name. An unescaped slash in either silently addresses a
+    DIFFERENT route rather than failing, which is the shape that turns a typo
+    into a request nobody intended.
+    """
+    return _quote(str(value), safe="")
 
 
 def _add_pairs(
@@ -227,7 +241,7 @@ class Mailsec:
         An unknown id returns ``{"message": None}`` rather than an error: the
         index has a 35-day TTL, so a miss is a normal outcome.
         """
-        return self._get(f"messages/{msg_uuid}")
+        return self._get(f"messages/{_seg(msg_uuid)}")
 
     def get_message_eml(self, msg_uuid: str, justification: str) -> Any:
         """The original RFC822 bytes of a message.
@@ -248,7 +262,7 @@ class Mailsec:
                 "and an unexplained one is not auditable"
             )
         return self._get(
-            f"messages/{msg_uuid}/eml",
+            f"messages/{_seg(msg_uuid)}/eml",
             [("justification", justification)],
         )
 
@@ -264,7 +278,7 @@ class Mailsec:
         pairs: list[tuple[str, str]] = []
         _add_scalar(pairs, "cursor", cursor)
         _add_scalar(pairs, "limit", limit)
-        return self._get(f"messages/{msg_uuid}/similar", pairs)
+        return self._get(f"messages/{_seg(msg_uuid)}/similar", pairs)
 
     def act_on_message(
         self,
@@ -300,7 +314,7 @@ class Mailsec:
         for key, val in (("reason", reason), ("attempt", attempt), ("banner", banner)):
             if val is not None:
                 body[key] = val
-        return self._post(f"messages/{msg_uuid}/actions", body)
+        return self._post(f"messages/{_seg(msg_uuid)}/actions", body)
 
     # ------------------------------------------------------------------
     # Campaigns
@@ -333,7 +347,7 @@ class Mailsec:
 
     def get_campaign(self, campaign_id: str) -> dict[str, Any]:
         """One campaign with its aggregates and cluster keys."""
-        return self._get(f"campaigns/{campaign_id}")
+        return self._get(f"campaigns/{_seg(campaign_id)}")
 
     def act_on_campaign(
         self,
@@ -366,7 +380,7 @@ class Mailsec:
         for key, val in (("confirm", confirm), ("reason", reason), ("actor", actor)):
             if val is not None:
                 body[key] = val
-        return self._post(f"campaigns/{campaign_id}/actions", body)
+        return self._post(f"campaigns/{_seg(campaign_id)}/actions", body)
 
     # ------------------------------------------------------------------
     # Senders and the audit trail
@@ -381,12 +395,12 @@ class Mailsec:
                 (``corp.example``), optionally prefixed ``email:`` /
                 ``domain:`` to disambiguate.
         """
-        return self._get(f"senders/{key}")
+        return self._get(f"senders/{_seg(key)}")
 
     def get_action(self, action_id: str) -> dict[str, Any]:
         """One record from the action audit trail: what was decided, by whom,
         why, and what the provider actually did."""
-        return self._get(f"actions/{action_id}")
+        return self._get(f"actions/{_seg(action_id)}")
 
     # ------------------------------------------------------------------
     # Standalone analysis
@@ -475,7 +489,7 @@ class Mailsec:
         An unknown id returns ``{"report": None}``, matching the message
         drawer, so a client branches on null rather than on a status code.
         """
-        return self._get(f"reports/{report_id}")
+        return self._get(f"reports/{_seg(report_id)}")
 
     def resolve_report(self, report_id: str, disposition: str) -> dict[str, Any]:
         """Close a report with a disposition. Requires ``mailsec.set``.
@@ -496,7 +510,7 @@ class Mailsec:
             and the second must not get a failure for an outcome that already
             holds.
         """
-        return self._post(f"reports/{report_id}/resolve", {"disposition": disposition})
+        return self._post(f"reports/{_seg(report_id)}/resolve", {"disposition": disposition})
 
     # ------------------------------------------------------------------
     # Hunts
@@ -534,7 +548,7 @@ class Mailsec:
 
     def get_hunt(self, hunt_id: str) -> dict[str, Any]:
         """A hunt's status and results."""
-        return self._get(f"hunts/{hunt_id}")
+        return self._get(f"hunts/{_seg(hunt_id)}")
 
     def remediate_hunt(
         self,
@@ -553,7 +567,7 @@ class Mailsec:
         for key, val in (("confirm", confirm), ("reason", reason)):
             if val is not None:
                 body[key] = val
-        return self._post(f"hunts/{hunt_id}/remediate", body)
+        return self._post(f"hunts/{_seg(hunt_id)}/remediate", body)
 
     # ------------------------------------------------------------------
     # Custom rules
@@ -627,7 +641,7 @@ class Mailsec:
         per-connection capabilities that depend on which scopes the customer's
         admin granted.
         """
-        return self._post(f"connections/{record}/test", {})
+        return self._post(f"connections/{_seg(record)}/test", {})
 
     def get_onboarding(self, *, provider: str | None = None) -> dict[str, Any]:
         """The setup guide for connecting a mail provider, with this org's own

--- a/limacharlie/sdk/mailsec.py
+++ b/limacharlie/sdk/mailsec.py
@@ -1,0 +1,643 @@
+"""Email Security (mailsec) SDK for LimaCharlie v2.
+
+Wraps the ``/mailsec/{oid}/...`` REST routes served by the API gateway: the
+coverage screen, the message index and its drawer, the justified raw-EML
+download, campaigns, sender profiles, the action audit trail, the
+abuse-mailbox report queue, standalone EML analysis, retro-hunts, custom-rule
+validation and backtest, the provider connection preflight, and the served
+onboarding guide.
+
+Permissions, which are four rather than the usual get/set pair because mailsec
+asks to be trusted with four different things:
+
+- ``mailsec.get``     read the product's own view: the queue, the drawer,
+                      campaigns, sender profiles, the audit trail
+- ``mailsec.set``     change detection behaviour and triage state
+- ``mailsec.act``     remediate live mail at the provider
+- ``mailsec.get.eml`` take the original bytes of somebody's mail out of the
+                      building; requires a logged justification
+
+Every route additionally requires the org to be subscribed to the
+``ext-email-security`` extension (403 otherwise)::
+
+    limacharlie extension subscribe --name ext-email-security
+
+Provider connections and policy are hive records — manage them with the hive
+commands (``limacharlie hive list --hive-name mailsec_provider``, same for
+``mailsec_policy`` and ``dr-mail``). The one connection operation here is the
+post-save credential preflight (:meth:`Mailsec.test_connection`).
+
+Two conventions inherited from the API contract that callers must not
+"helpfully" work around:
+
+- **Cursors are opaque and are passed back verbatim.** They encode which index
+  the walk is pinned to, and they are bound to the filter set they were minted
+  under; changing a filter mid-walk is an error rather than a page that
+  silently means something else.
+- **Booleans are tri-state.** Leaving one unset means the dimension is
+  unconstrained, which is NOT the same as sending ``False``.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .organization import Organization
+
+
+def _add_pairs(
+    pairs: list[tuple[str, str]],
+    key: str,
+    values: list[str] | tuple[str, ...] | None,
+) -> None:
+    """Append one ``(key, value)`` pair per value (repeatable query param)."""
+    if not values:
+        return
+    for v in values:
+        pairs.append((key, str(v)))
+
+
+def _add_scalar(pairs: list[tuple[str, str]], key: str, value: Any) -> None:
+    """Append a scalar param, skipping ``None`` so absent stays absent.
+
+    ``False`` is forwarded, ``None`` is not: that is the whole tri-state
+    contract, and collapsing them would turn "unconstrained" into "must be
+    false" on every boolean the API has.
+    """
+    if value is None:
+        return
+    if isinstance(value, bool):
+        pairs.append((key, "true" if value else "false"))
+    else:
+        pairs.append((key, str(value)))
+
+
+class Mailsec:
+    """Email Security client for LimaCharlie."""
+
+    def __init__(self, org: Organization) -> None:
+        self._org = org
+
+    @property
+    def oid(self) -> str:
+        return self._org.oid
+
+    # ------------------------------------------------------------------
+    # Low-level helpers
+    # ------------------------------------------------------------------
+
+    def _get(
+        self,
+        path: str,
+        query_params: list[tuple[str, str]] | None = None,
+        *,
+        raw_response: bool = False,
+    ) -> Any:
+        return self._org.client.request(
+            "GET",
+            f"mailsec/{self.oid}/{path}",
+            query_params=query_params or None,
+            raw_response=raw_response,
+        )
+
+    def _post(
+        self,
+        path: str,
+        body: dict[str, Any],
+        query_params: list[tuple[str, str]] | None = None,
+        *,
+        raw_response: bool = False,
+    ) -> Any:
+        return self._org.client.request(
+            "POST",
+            f"mailsec/{self.oid}/{path}",
+            query_params=query_params or None,
+            raw_body=json.dumps(body).encode(),
+            content_type="application/json",
+            raw_response=raw_response,
+        )
+
+    # ------------------------------------------------------------------
+    # Coverage
+    # ------------------------------------------------------------------
+
+    def get_coverage(self, *, window_days: int | None = None) -> dict[str, Any]:
+        """Coverage and volume for the org: mailboxes protected vs not, and
+        what was analysed over the window.
+
+        Args:
+            window_days: Days of volume to summarise (server default applies
+                when omitted).
+
+        Returns:
+            The coverage summary, including the mailbox states that are NOT
+            protected — a mailbox we cannot subscribe is reported as broken
+            rather than omitted, so the number is a coverage statement rather
+            than a count of what happened to work.
+        """
+        pairs: list[tuple[str, str]] = []
+        _add_scalar(pairs, "window_days", window_days)
+        return self._get("coverage", pairs)
+
+    # ------------------------------------------------------------------
+    # Messages
+    # ------------------------------------------------------------------
+
+    def list_messages(
+        self,
+        *,
+        verdict: list[str] | None = None,
+        mailbox: str | None = None,
+        sender_email: str | None = None,
+        sender_domain: str | None = None,
+        campaign_id: str | None = None,
+        state: list[str] | None = None,
+        direction: list[str] | None = None,
+        user_reported: bool | None = None,
+        min_score: int | None = None,
+        link_domain: str | None = None,
+        attachment_sha256: str | None = None,
+        since: str | None = None,
+        until: str | None = None,
+        cursor: str | None = None,
+        limit: int | None = None,
+    ) -> dict[str, Any]:
+        """The message index: the triage queue.
+
+        Repeatable filters OR within a key and AND across keys.
+
+        Args:
+            verdict: ``malicious``, ``suspicious``, ``graymail``, ``benign``,
+                ``unknown`` (repeatable).
+            mailbox: Protected mailbox address (exact).
+            sender_email: Envelope/header sender address (exact).
+            sender_domain: Sender registrable root domain.
+            campaign_id: Only members of one campaign.
+            state: Message lifecycle state (repeatable).
+            direction: ``inbound``, ``outbound``, ``internal`` (repeatable).
+            user_reported: Tri-state. ``True`` only reported mail, ``False``
+                only unreported, ``None`` (default) either. A human reporting
+                a message is the strongest signal the product gets, so this
+                is worth filtering on directly.
+            min_score: Only messages at or above this score.
+            link_domain: IOC pivot — who else received mail linking here.
+            attachment_sha256: IOC pivot — who else received this file.
+            since: Lower time bound (RFC3339 or unix seconds).
+            until: Upper time bound (RFC3339 or unix seconds).
+            cursor: Opaque keyset token from a previous page.
+            limit: Page size (server clamps).
+
+        Returns:
+            ``{"messages": [...], "next_cursor": str}``. An empty
+            ``next_cursor`` means the last page.
+        """
+        pairs: list[tuple[str, str]] = []
+        _add_pairs(pairs, "verdict", verdict)
+        _add_pairs(pairs, "state", state)
+        _add_pairs(pairs, "direction", direction)
+        for key, val in (
+            ("mailbox", mailbox),
+            ("sender_email", sender_email),
+            ("sender_domain", sender_domain),
+            ("campaign_id", campaign_id),
+            ("min_score", min_score),
+            ("link_domain", link_domain),
+            ("attachment_sha256", attachment_sha256),
+            ("since", since),
+            ("until", until),
+            ("cursor", cursor),
+            ("limit", limit),
+            ("user_reported", user_reported),
+        ):
+            _add_scalar(pairs, key, val)
+        return self._get("messages", pairs)
+
+    def get_message(self, msg_uuid: str) -> dict[str, Any]:
+        """One message: the index row plus the re-parsed MDM (the drawer).
+
+        The MDM is not stored in Spanner — the index row is a summary and the
+        raw bytes live in object storage — so the drawer re-parses the stored
+        EML and says which path produced it (``mdm_source``). Enrichments are
+        deliberately ABSENT rather than recomputed: they were resolved against
+        sender profiles as they existed at ingest, and synthesising today's
+        values would show a reputation the verdict was never based on.
+
+        An unknown id returns ``{"message": None}`` rather than an error: the
+        index has a 35-day TTL, so a miss is a normal outcome.
+        """
+        return self._get(f"messages/{msg_uuid}")
+
+    def get_message_eml(self, msg_uuid: str, justification: str) -> Any:
+        """The original RFC822 bytes of a message.
+
+        Requires ``mailsec.get.eml`` — a different privilege from opening the
+        drawer, because this takes a person's actual mail out of the building.
+        The justification is REQUIRED and is written to the access audit with
+        the caller's identity; there is no way to fetch these bytes without
+        leaving a record of why.
+
+        Args:
+            msg_uuid: The message.
+            justification: Why the download is happening. Stored verbatim.
+        """
+        if not justification or not justification.strip():
+            raise ValueError(
+                "a justification is required to download raw mail: the access is audited, "
+                "and an unexplained one is not auditable"
+            )
+        return self._get(
+            f"messages/{msg_uuid}/eml",
+            [("justification", justification)],
+        )
+
+    def list_similar_messages(
+        self,
+        msg_uuid: str,
+        *,
+        cursor: str | None = None,
+        limit: int | None = None,
+    ) -> dict[str, Any]:
+        """Messages clustered with this one — the campaign view from a single
+        message, which is how "who else got this" is answered."""
+        pairs: list[tuple[str, str]] = []
+        _add_scalar(pairs, "cursor", cursor)
+        _add_scalar(pairs, "limit", limit)
+        return self._get(f"messages/{msg_uuid}/similar", pairs)
+
+    def act_on_message(
+        self,
+        msg_uuid: str,
+        action: str,
+        *,
+        reason: str | None = None,
+        attempt: str | None = None,
+        banner: str | None = None,
+    ) -> dict[str, Any]:
+        """Remediate one message at the provider. Requires ``mailsec.act``.
+
+        Executed by the collector that holds the org's lease — the single
+        choke point where the org's alert_only/enforce mode is applied and the
+        audit row is written. Idempotent per (message, action).
+
+        Args:
+            msg_uuid: The message to act on.
+            action: ``quarantine_message``, ``trash_message``,
+                ``restore_message``, ``apply_banner``, ``remove_banner``.
+            reason: Free-text justification recorded on the audit row.
+            attempt: Caller-supplied idempotency token.
+            banner: Banner HTML, for the banner actions.
+
+        Returns:
+            The action record, including ``result`` — note ``alert_only``,
+            which means the action was DECIDED and deliberately not performed
+            because the org is not in enforce mode. That is a success, not a
+            failure, and it is reported as its own result rather than as
+            ``ok``.
+        """
+        body: dict[str, Any] = {"action": action}
+        for key, val in (("reason", reason), ("attempt", attempt), ("banner", banner)):
+            if val is not None:
+                body[key] = val
+        return self._post(f"messages/{msg_uuid}/actions", body)
+
+    # ------------------------------------------------------------------
+    # Campaigns
+    # ------------------------------------------------------------------
+
+    def list_campaigns(
+        self,
+        *,
+        state: list[str] | None = None,
+        verdict: list[str] | None = None,
+        min_members: int | None = None,
+        since: str | None = None,
+        until: str | None = None,
+        cursor: str | None = None,
+        limit: int | None = None,
+    ) -> dict[str, Any]:
+        """Campaigns: one attack, triaged once, rather than once per mailbox."""
+        pairs: list[tuple[str, str]] = []
+        _add_pairs(pairs, "state", state)
+        _add_pairs(pairs, "verdict", verdict)
+        for key, val in (
+            ("min_members", min_members),
+            ("since", since),
+            ("until", until),
+            ("cursor", cursor),
+            ("limit", limit),
+        ):
+            _add_scalar(pairs, key, val)
+        return self._get("campaigns", pairs)
+
+    def get_campaign(self, campaign_id: str) -> dict[str, Any]:
+        """One campaign with its aggregates and cluster keys."""
+        return self._get(f"campaigns/{campaign_id}")
+
+    def act_on_campaign(
+        self,
+        campaign_id: str,
+        action: str,
+        *,
+        confirm: str | None = None,
+        reason: str | None = None,
+        actor: str | None = None,
+    ) -> dict[str, Any]:
+        """Sweep an action across every member of a campaign.
+
+        Requires ``mailsec.act``.
+
+        ``confirm`` is what turns a PREVIEW into an EXECUTION. Without it the
+        call reports what it would do and changes nothing — which is the right
+        default for an operation whose blast radius is "every mailbox that got
+        this attack".
+
+        Args:
+            campaign_id: The campaign to sweep.
+            action: The typed action, as for :meth:`act_on_message`.
+            confirm: Pass the campaign id to execute. Omit to preview.
+            reason: Recorded on every resulting audit row.
+            actor: Ignored if supplied — the gateway stamps the acting
+                identity from the authenticated claims, so an audit trail's
+                subject can never be chosen by its subject.
+        """
+        body: dict[str, Any] = {"action": action}
+        for key, val in (("confirm", confirm), ("reason", reason), ("actor", actor)):
+            if val is not None:
+                body[key] = val
+        return self._post(f"campaigns/{campaign_id}/actions", body)
+
+    # ------------------------------------------------------------------
+    # Senders and the audit trail
+    # ------------------------------------------------------------------
+
+    def get_sender_profile(self, key: str) -> dict[str, Any]:
+        """A sender's history with this org: prevalence, first seen, how much
+        of their mail has been flagged.
+
+        Args:
+            key: An address (``cfo@corp.example``) or a domain
+                (``corp.example``), optionally prefixed ``email:`` /
+                ``domain:`` to disambiguate.
+        """
+        return self._get(f"senders/{key}")
+
+    def get_action(self, action_id: str) -> dict[str, Any]:
+        """One record from the action audit trail: what was decided, by whom,
+        why, and what the provider actually did."""
+        return self._get(f"actions/{action_id}")
+
+    # ------------------------------------------------------------------
+    # Standalone analysis
+    # ------------------------------------------------------------------
+
+    def analyze(
+        self,
+        *,
+        eml: str | None = None,
+        eml_b64: str | None = None,
+        org_domains: list[str] | None = None,
+        direction: str | None = None,
+    ) -> dict[str, Any]:
+        """Parse and score an EML without ingesting it.
+
+        Nothing is persisted and no mailbox is touched — this is the "what
+        would you say about this file" path, served by the stateless api-mode
+        actor rather than by the collector.
+
+        Args:
+            eml: Raw RFC822 text.
+            eml_b64: The same bytes base64-encoded, for content that does not
+                survive a text field.
+            org_domains: The org's own domains, which is what makes direction
+                and impersonation computable.
+            direction: Override the computed direction.
+        """
+        if not eml and not eml_b64:
+            raise ValueError("analyze needs the message: pass eml or eml_b64")
+        body: dict[str, Any] = {}
+        for key, val in (
+            ("eml", eml),
+            ("eml_b64", eml_b64),
+            ("org_domains", org_domains),
+            ("direction", direction),
+        ):
+            if val is not None:
+                body[key] = val
+        return self._post("analyze", body)
+
+    # ------------------------------------------------------------------
+    # Abuse-mailbox report queue
+    # ------------------------------------------------------------------
+
+    def list_reports(
+        self,
+        *,
+        status: list[str] | None = None,
+        oldest_first: bool | None = None,
+        cursor: str | None = None,
+        limit: int | None = None,
+    ) -> dict[str, Any]:
+        """The user-report queue: what the org's own people reported.
+
+        Args:
+            status: ``open``, ``triaging``, ``resolved`` (repeatable).
+            oldest_first: Order by AGE rather than recency. This is what makes
+                the queue an SLA surface — "the oldest thing nobody has looked
+                at" is the question a queue exists to answer, and it is not
+                answerable from a newest-first page.
+            cursor: Opaque keyset token.
+            limit: Page size.
+
+        Returns:
+            ``{"reports": [...], "next_cursor": str}``. Each report carries
+            ``original_found``, which is explicit rather than inferred from an
+            empty id: a report whose original was never indexed is a real
+            state (the message predates the connection, or landed outside
+            scope) and the queue shows it as a gap rather than as a blank
+            field that reads like a loading bug.
+        """
+        pairs: list[tuple[str, str]] = []
+        _add_pairs(pairs, "status", status)
+        for key, val in (
+            ("oldest_first", oldest_first),
+            ("cursor", cursor),
+            ("limit", limit),
+        ):
+            _add_scalar(pairs, key, val)
+        return self._get("reports", pairs)
+
+    def get_report(self, report_id: str) -> dict[str, Any]:
+        """One report: who reported it, the message they reported, and the
+        original it refers to once located across the tenant's mailboxes.
+
+        An unknown id returns ``{"report": None}``, matching the message
+        drawer, so a client branches on null rather than on a status code.
+        """
+        return self._get(f"reports/{report_id}")
+
+    def resolve_report(self, report_id: str, disposition: str) -> dict[str, Any]:
+        """Close a report with a disposition. Requires ``mailsec.set``.
+
+        Args:
+            report_id: The report.
+            disposition: ``true_positive`` (it was malicious),
+                ``false_positive`` (we flagged it and it was fine), or
+                ``benign`` (it was never a threat). ``unknown`` is a real
+                stored value but is NOT resolvable by a human: as the outcome
+                of someone closing a report it means "I looked and decided
+                nothing", which is indistinguishable in the SLA numbers from
+                never having looked.
+
+        Returns:
+            The updated report plus ``already_resolved``. Resolving twice
+            succeeds and says so — two analysts clicking at once is ordinary,
+            and the second must not get a failure for an outcome that already
+            holds.
+        """
+        return self._post(f"reports/{report_id}/resolve", {"disposition": disposition})
+
+    # ------------------------------------------------------------------
+    # Hunts
+    # ------------------------------------------------------------------
+
+    def create_hunt(
+        self,
+        *,
+        detect: dict[str, Any] | None = None,
+        lcql: str | None = None,
+        since: str | None = None,
+        until: str | None = None,
+        dry_run: bool | None = None,
+    ) -> dict[str, Any]:
+        """Start a retro-hunt over message history.
+
+        Args:
+            detect: A D&R detect block to match.
+            lcql: An LCQL query, as an alternative to ``detect``.
+            since: Lower time bound.
+            until: Upper time bound.
+            dry_run: Estimate cost and match count without running.
+        """
+        body: dict[str, Any] = {}
+        for key, val in (
+            ("detect", detect),
+            ("lcql", lcql),
+            ("since", since),
+            ("until", until),
+            ("dry_run", dry_run),
+        ):
+            if val is not None:
+                body[key] = val
+        return self._post("hunts", body)
+
+    def get_hunt(self, hunt_id: str) -> dict[str, Any]:
+        """A hunt's status and results."""
+        return self._get(f"hunts/{hunt_id}")
+
+    def remediate_hunt(
+        self,
+        hunt_id: str,
+        action: str,
+        *,
+        confirm: str | None = None,
+        reason: str | None = None,
+    ) -> dict[str, Any]:
+        """Bulk-remediate a hunt's results. Requires ``mailsec.act``.
+
+        Like a campaign sweep, ``confirm`` is what turns a preview into an
+        execution.
+        """
+        body: dict[str, Any] = {"action": action}
+        for key, val in (("confirm", confirm), ("reason", reason)):
+            if val is not None:
+                body[key] = val
+        return self._post(f"hunts/{hunt_id}/remediate", body)
+
+    # ------------------------------------------------------------------
+    # Custom rules
+    # ------------------------------------------------------------------
+
+    def validate_rule(
+        self,
+        rule: dict[str, Any],
+        *,
+        rule_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Check a candidate rule without saving it.
+
+        Runs the SAME validation the ``dr-mail`` hive applies on save, so a
+        rule this accepts is a rule that will save. An invalid rule is a
+        successful response carrying ``valid: false`` and the reason — it is
+        the ANSWER to the question, not a failure to answer it.
+
+        Args:
+            rule: The rule body (``name``, ``fp_notes``, ``phase``,
+                ``weight``, ``detect``, ...).
+            rule_id: The rule id. Tenant rule ids must start with
+                ``custom-``; omitting it validates against a placeholder in
+                that namespace so an unnamed draft is not refused for a name
+                it was never asked for.
+        """
+        body: dict[str, Any] = {"rule": rule}
+        if rule_id is not None:
+            body["rule_id"] = rule_id
+        return self._post("rules/validate", body)
+
+    def backtest_rule(
+        self,
+        rule: dict[str, Any],
+        *,
+        rule_id: str | None = None,
+        since: str | None = None,
+        until: str | None = None,
+    ) -> dict[str, Any]:
+        """Replay a candidate rule over recent mail and report what it would
+        have matched.
+
+        Bounded to the window this product retains rather than the
+        full-history retro-hunt, and every response says so in
+        ``coverage_note``. It also counts what it could NOT examine
+        (``skipped_no_raw``, ``skipped_unparse``, ``truncated``), because a
+        precision figure whose denominator silently shrank is a number that
+        looks like a measurement and is not one.
+
+        ``precision`` is ``None`` — not ``0`` — when nothing it matched has an
+        analyst disposition yet. Zero would read as "everything it matched was
+        wrong" and would have an author discard a good rule.
+        """
+        body: dict[str, Any] = {"rule": rule}
+        for key, val in (("rule_id", rule_id), ("since", since), ("until", until)):
+            if val is not None:
+                body[key] = val
+        return self._post("rules/backtest", body)
+
+    # ------------------------------------------------------------------
+    # Connections and onboarding
+    # ------------------------------------------------------------------
+
+    def test_connection(self, record: str) -> dict[str, Any]:
+        """Exercise a saved provider connection end to end.
+
+        Takes the RECORD NAME of a ``mailsec_provider`` hive record, never a
+        credential: the credential stays in the secret hive and is resolved
+        server-side by the pod that owns the connection. Reports what the
+        connection can actually do — directory access, mail read, and the
+        per-connection capabilities that depend on which scopes the customer's
+        admin granted.
+        """
+        return self._post(f"connections/{record}/test", {})
+
+    def get_onboarding(self, *, provider: str | None = None) -> dict[str, Any]:
+        """The setup guide for connecting a mail provider, with this org's own
+        values already substituted in.
+
+        Served by the backend rather than written into the docs or the web app
+        so that the identifiers a customer must paste — the service account,
+        the topic, the subscription — are the real ones for this deployment
+        rather than placeholders a reader has to translate.
+        """
+        pairs: list[tuple[str, str]] = []
+        _add_scalar(pairs, "provider", provider)
+        return self._get("onboarding", pairs)

--- a/tests/unit/test_cli_lazy_loading_regression.py
+++ b/tests/unit/test_cli_lazy_loading_regression.py
@@ -50,7 +50,7 @@ EXPECTED_TOP_LEVEL_COMMANDS = frozenset({
     "detection", "download", "dr", "endpoint-policy", "event", "exfil",
     "extension", "external-adapter", "feedback", "fp", "group", "help", "hive",
     "ingestion-key", "installation-key", "integrity", "ioc", "job", "logging",
-    "lookup", "note", "org", "output", "payload", "playbook", "replay",
+    "lookup", "mailsec", "note", "org", "output", "payload", "playbook", "replay",
     "schema", "search", "secret", "sensor", "sop", "spotcheck", "stream",
     "sync", "tag", "task", "user", "usp", "vulnerability", "yara",
 })
@@ -94,6 +94,7 @@ EXPECTED_MODULE_MAP = {
     "ioc": ("group", "ioc"),
     "job": ("group", "job"),
     "logging_cmd": ("group", "logging"),
+    "mailsec": ("group", "mailsec"),
     "lookup": ("group", "lookup"),
     "note": ("group", "note"),
     "org": ("group", "org"),
@@ -190,6 +191,10 @@ EXPECTED_SUBCOMMANDS: dict[str, frozenset[str]] = {
     "ioc": frozenset({"batch-enrich", "batch-search", "enrich", "hosts", "search"}),
     "job": frozenset({"delete", "get", "list", "wait"}),
     "logging": frozenset({"create", "delete", "get", "list"}),
+    "mailsec": frozenset({
+        "coverage", "analyze", "onboarding", "message", "campaign", "sender",
+        "action", "report", "hunt", "rule", "connection",
+    }),
     "lookup": frozenset({"delete", "disable", "enable", "get", "list", "set", "tag"}),
     "note": frozenset({"delete", "disable", "enable", "get", "list", "set", "tag"}),
     "org": frozenset({

--- a/tests/unit/test_sdk_mailsec.py
+++ b/tests/unit/test_sdk_mailsec.py
@@ -183,6 +183,40 @@ class TestRules:
         assert body["since"] == "2026-08-01"
 
 
+class TestPathSegmentsAreEscaped:
+    """A caller-supplied id must not be able to change which route is addressed.
+
+    Most of these are server-minted UUIDs, but the sender key is an address or
+    domain a person types and the connection record is a hive record name. An
+    unescaped slash in either silently addresses a DIFFERENT route rather than
+    failing — a typo becoming a request nobody intended.
+    """
+
+    def test_a_slash_in_a_sender_key_cannot_change_the_route(self, ms, mock_org):
+        ms.get_sender_profile("evil/../../admin")
+        url, _ = _get_call(mock_org)
+        assert url == f"mailsec/{OID}/senders/evil%2F..%2F..%2Fadmin"
+        assert url.count("/") == 3, f"the key escaped its segment: {url}"
+
+    def test_a_slash_in_a_connection_record_cannot_change_the_route(self, ms, mock_org):
+        ms.test_connection("a/b")
+        url, _ = _post_call(mock_org)
+        assert url == f"mailsec/{OID}/connections/a%2Fb/test"
+
+    def test_ordinary_ids_are_unharmed(self, ms, mock_org):
+        ms.get_message("0057db2b-3a06-5aab-b3be-c1e6c15dcf10")
+        url, _ = _get_call(mock_org)
+        assert url == f"mailsec/{OID}/messages/0057db2b-3a06-5aab-b3be-c1e6c15dcf10"
+
+    def test_an_email_sender_key_survives_readably(self, ms, mock_org):
+        """@ and . are escaped but the request still resolves; the point is that
+        the segment cannot BREAK OUT, not that it stays pretty."""
+        ms.get_sender_profile("cfo@corp.example")
+        url, _ = _get_call(mock_org)
+        assert url.startswith(f"mailsec/{OID}/senders/")
+        assert "/" not in url[len(f"mailsec/{OID}/senders/"):]
+
+
 class TestRouteCoverage:
     """Every gateway route has an SDK method.
 

--- a/tests/unit/test_sdk_mailsec.py
+++ b/tests/unit/test_sdk_mailsec.py
@@ -1,0 +1,225 @@
+"""Tests for limacharlie.sdk.mailsec module."""
+
+import json
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from limacharlie.sdk.mailsec import Mailsec
+
+
+OID = "11111111-2222-3333-4444-555555555555"
+
+
+@pytest.fixture
+def mock_org():
+    org = MagicMock()
+    org.oid = OID
+    org.client = MagicMock()
+    return org
+
+
+@pytest.fixture
+def ms(mock_org):
+    return Mailsec(mock_org)
+
+
+def _get_call(mock_org):
+    """Pull (url, query_pairs) out of a mocked GET client.request call."""
+    args, kwargs = mock_org.client.request.call_args
+    assert args[0] == "GET"
+    return args[1], kwargs.get("query_params")
+
+
+def _post_call(mock_org):
+    """Pull (url, decoded_json_body) out of a mocked POST client.request call."""
+    args, kwargs = mock_org.client.request.call_args
+    assert args[0] == "POST"
+    assert kwargs["content_type"] == "application/json"
+    return args[1], json.loads(kwargs["raw_body"])
+
+
+class TestBasics:
+    def test_oid_property(self, ms):
+        assert ms.oid == OID
+
+    def test_get_omits_empty_query(self, ms, mock_org):
+        mock_org.client.request.return_value = {"messages": []}
+        ms.list_messages()
+        url, qp = _get_call(mock_org)
+        assert url == f"mailsec/{OID}/messages"
+        assert qp is None
+
+
+class TestTriStateBooleans:
+    """The API is tri-state throughout: absent means unconstrained, which is
+    NOT the same as false. Collapsing the two silently narrows every
+    unfiltered read, and the narrowing is invisible because a smaller result
+    set looks like a correct one."""
+
+    def test_absent_user_reported_sends_nothing(self, ms, mock_org):
+        ms.list_messages()
+        _, qp = _get_call(mock_org)
+        assert qp is None
+
+    def test_false_is_forwarded_not_dropped(self, ms, mock_org):
+        ms.list_messages(user_reported=False)
+        _, qp = _get_call(mock_org)
+        assert ("user_reported", "false") in qp
+
+    def test_true_is_forwarded(self, ms, mock_org):
+        ms.list_messages(user_reported=True)
+        _, qp = _get_call(mock_org)
+        assert ("user_reported", "true") in qp
+
+
+class TestRepeatableFilters:
+    def test_verdict_repeats_one_pair_per_value(self, ms, mock_org):
+        ms.list_messages(verdict=["malicious", "suspicious"])
+        _, qp = _get_call(mock_org)
+        assert ("verdict", "malicious") in qp
+        assert ("verdict", "suspicious") in qp
+
+    def test_mixed_filters_all_present(self, ms, mock_org):
+        ms.list_messages(
+            verdict=["malicious"],
+            mailbox="cfo@corp.example",
+            link_domain="evil.example",
+            limit=50,
+        )
+        _, qp = _get_call(mock_org)
+        assert ("verdict", "malicious") in qp
+        assert ("mailbox", "cfo@corp.example") in qp
+        assert ("link_domain", "evil.example") in qp
+        assert ("limit", "50") in qp
+
+
+class TestEMLRequiresJustification:
+    """The EML download is a separate privilege because it takes a person's
+    actual mail out of the building, and the justification is what makes the
+    access auditable. Refusing an empty one client-side keeps a caller from
+    discovering the requirement as a server error after the fact."""
+
+    def test_missing_justification_refused(self, ms):
+        with pytest.raises(ValueError, match="justification"):
+            ms.get_message_eml("msg-1", "")
+
+    def test_whitespace_justification_refused(self, ms):
+        with pytest.raises(ValueError, match="justification"):
+            ms.get_message_eml("msg-1", "   ")
+
+    def test_justification_is_forwarded(self, ms, mock_org):
+        ms.get_message_eml("msg-1", "INC-4471")
+        url, qp = _get_call(mock_org)
+        assert url == f"mailsec/{OID}/messages/msg-1/eml"
+        assert ("justification", "INC-4471") in qp
+
+
+class TestActions:
+    def test_message_action_body(self, ms, mock_org):
+        ms.act_on_message("msg-1", "quarantine_message", reason="phish")
+        url, body = _post_call(mock_org)
+        assert url == f"mailsec/{OID}/messages/msg-1/actions"
+        assert body == {"action": "quarantine_message", "reason": "phish"}
+
+    def test_campaign_action_previews_without_confirm(self, ms, mock_org):
+        """confirm is what turns a preview into an execution. Its absence must
+        reach the server as an absence, not as an empty string that could be
+        read as a confirmation."""
+        ms.act_on_campaign("cmp-1", "quarantine_message")
+        _, body = _post_call(mock_org)
+        assert "confirm" not in body
+
+    def test_campaign_action_confirm_is_forwarded(self, ms, mock_org):
+        ms.act_on_campaign("cmp-1", "quarantine_message", confirm="cmp-1")
+        _, body = _post_call(mock_org)
+        assert body["confirm"] == "cmp-1"
+
+
+class TestAnalyze:
+    def test_analyze_needs_content(self, ms):
+        with pytest.raises(ValueError, match="eml"):
+            ms.analyze()
+
+    def test_analyze_forwards_b64_and_domains(self, ms, mock_org):
+        ms.analyze(eml_b64="QUJD", org_domains=["corp.example"])
+        url, body = _post_call(mock_org)
+        assert url == f"mailsec/{OID}/analyze"
+        assert body["eml_b64"] == "QUJD"
+        assert body["org_domains"] == ["corp.example"]
+
+
+class TestReports:
+    def test_oldest_first_is_the_sla_ordering(self, ms, mock_org):
+        ms.list_reports(oldest_first=True)
+        _, qp = _get_call(mock_org)
+        assert ("oldest_first", "true") in qp
+
+    def test_status_repeats(self, ms, mock_org):
+        ms.list_reports(status=["open", "triaging"])
+        _, qp = _get_call(mock_org)
+        assert ("status", "open") in qp
+        assert ("status", "triaging") in qp
+
+    def test_resolve_sends_disposition(self, ms, mock_org):
+        ms.resolve_report("rep-1", "true_positive")
+        url, body = _post_call(mock_org)
+        assert url == f"mailsec/{OID}/reports/rep-1/resolve"
+        assert body == {"disposition": "true_positive"}
+
+
+class TestRules:
+    def test_validate_body(self, ms, mock_org):
+        ms.validate_rule({"phase": "pre_verdict"}, rule_id="custom-x")
+        url, body = _post_call(mock_org)
+        assert url == f"mailsec/{OID}/rules/validate"
+        assert body == {"rule": {"phase": "pre_verdict"}, "rule_id": "custom-x"}
+
+    def test_backtest_window_forwarded(self, ms, mock_org):
+        ms.backtest_rule({"phase": "pre_verdict"}, since="2026-08-01")
+        url, body = _post_call(mock_org)
+        assert url == f"mailsec/{OID}/rules/backtest"
+        assert body["since"] == "2026-08-01"
+
+
+class TestRouteCoverage:
+    """Every gateway route has an SDK method.
+
+    The gateway is the contract; a route with no SDK method is a capability
+    the CLI silently does not have, and nobody notices until someone needs it.
+    """
+
+    def test_every_route_has_a_method(self, ms, mock_org):
+        calls = [
+            (lambda: ms.get_coverage(), "GET", f"mailsec/{OID}/coverage"),
+            (lambda: ms.list_messages(), "GET", f"mailsec/{OID}/messages"),
+            (lambda: ms.get_message("m"), "GET", f"mailsec/{OID}/messages/m"),
+            (lambda: ms.get_message_eml("m", "why"), "GET", f"mailsec/{OID}/messages/m/eml"),
+            (lambda: ms.list_similar_messages("m"), "GET", f"mailsec/{OID}/messages/m/similar"),
+            (lambda: ms.list_campaigns(), "GET", f"mailsec/{OID}/campaigns"),
+            (lambda: ms.get_campaign("c"), "GET", f"mailsec/{OID}/campaigns/c"),
+            (lambda: ms.get_sender_profile("s"), "GET", f"mailsec/{OID}/senders/s"),
+            (lambda: ms.get_action("a"), "GET", f"mailsec/{OID}/actions/a"),
+            (lambda: ms.list_reports(), "GET", f"mailsec/{OID}/reports"),
+            (lambda: ms.get_report("r"), "GET", f"mailsec/{OID}/reports/r"),
+            (lambda: ms.get_hunt("h"), "GET", f"mailsec/{OID}/hunts/h"),
+            (lambda: ms.get_onboarding(), "GET", f"mailsec/{OID}/onboarding"),
+            (lambda: ms.analyze(eml="x"), "POST", f"mailsec/{OID}/analyze"),
+            (lambda: ms.act_on_message("m", "a"), "POST", f"mailsec/{OID}/messages/m/actions"),
+            (lambda: ms.act_on_campaign("c", "a"), "POST", f"mailsec/{OID}/campaigns/c/actions"),
+            (lambda: ms.resolve_report("r", "benign"), "POST", f"mailsec/{OID}/reports/r/resolve"),
+            (lambda: ms.create_hunt(lcql="q"), "POST", f"mailsec/{OID}/hunts"),
+            (lambda: ms.remediate_hunt("h", "a"), "POST", f"mailsec/{OID}/hunts/h/remediate"),
+            (lambda: ms.validate_rule({}), "POST", f"mailsec/{OID}/rules/validate"),
+            (lambda: ms.backtest_rule({}), "POST", f"mailsec/{OID}/rules/backtest"),
+            (lambda: ms.test_connection("rec"), "POST", f"mailsec/{OID}/connections/rec/test"),
+        ]
+        # 22 gateway routes, 22 SDK methods.
+        assert len(calls) == 22
+        for fn, method, expected_url in calls:
+            mock_org.client.request.reset_mock()
+            fn()
+            args, _ = mock_org.client.request.call_args
+            assert args[0] == method, f"{expected_url}: wrong HTTP method"
+            assert args[1] == expected_url


### PR DESCRIPTION
Adds `limacharlie mailsec ...` over **all 22** `/mailsec/{oid}/*` gateway routes: coverage, the message index and drawer, the justified raw-EML download, similar-message pivots, per-message and campaign-wide actions, campaigns, sender profiles, the action audit trail, standalone EML analysis, the abuse-mailbox report queue, retro-hunts, custom-rule validation and backtest, the connection preflight, and the served onboarding guide.

Noun-verb groups (`message get`, `report resolve`, `rule backtest`) matching the cloudsec surface, with an `--explain` entry per command.

## Three contracts the wrapper preserves rather than smooths over

Each is a place where being "helpful" would quietly change what the caller asked for:

- **Booleans are tri-state.** Absent means *unconstrained*; it is not `False`. `--user-reported` / `--no-user-reported` resolves to `None` when neither is given. Collapsing the two would narrow every unfiltered read **invisibly**, because a smaller result set looks exactly like a correct one.
- **Cursors are opaque** and passed back verbatim — they encode which index the walk is pinned to and are bound to the filter set that minted them.
- **`confirm` is absent, not empty.** Campaign sweeps and hunt remediation preview by default; omitting `--confirm` must reach the server as an absence rather than an empty string that could read as a confirmation.

The EML download refuses an empty justification client-side — the justification is what makes the access auditable, and discovering that requirement as a server error after the fact is a worse way to learn it.

## Verification

- 21 SDK tests, including a **route-coverage table** asserting all 22 routes have a method with the right verb and URL. A route with no SDK method is a capability the CLI silently lacks until someone needs it.
- The three CLI inventory guards (command count, expected commands, module map) updated to include mailsec — which is what those guards are for.
- **Verified against a stashed baseline:** the suite's 111 pre-existing failures are unchanged and this introduces none.
- **Exercised against the live API on exp:** `report list` (with paging), `coverage`, a filtered `message list`, and a `rule backtest` over the real 34-message window.