### PR TITLE
mailsec: expose Workspace watch lifecycle probe

### DIFF
--- a/limacharlie/commands/mailsec.py
+++ b/limacharlie/commands/mailsec.py
@@ -296,6 +296,7 @@ admin granted.
 
 Examples:
   limacharlie mailsec connection test gws-exp
+  limacharlie mailsec connection test gws-exp --include-watch
 """
 
 _EXPLAIN_ONBOARDING = """\
@@ -880,8 +881,14 @@ def rule_backtest(ctx, rule_file, rule_id, since, until) -> None:
 
 @connection_group.command("test")
 @click.argument("record")
+@click.option(
+    "--include-watch",
+    is_flag=True,
+    default=False,
+    help="Establish a real Workspace push watch to verify delivery (side effect; idempotent).",
+)
 @pass_context
-def connection_test(ctx, record) -> None:
+def connection_test(ctx, record, include_watch) -> None:
     """Exercise a saved provider connection end to end.
 
     \b
@@ -890,8 +897,9 @@ def connection_test(ctx, record) -> None:
     \b
     Example:
       limacharlie mailsec connection test gws-exp
+      limacharlie mailsec connection test gws-exp --include-watch
     """
-    _output(ctx, _get_mailsec(ctx).test_connection(record))
+    _output(ctx, _get_mailsec(ctx).test_connection(record, include_watch=include_watch))
 
 
 # ---------------------------------------------------------------------------

--- a/limacharlie/sdk/mailsec.py
+++ b/limacharlie/sdk/mailsec.py
@@ -631,7 +631,7 @@ class Mailsec:
     # Connections and onboarding
     # ------------------------------------------------------------------
 
-    def test_connection(self, record: str) -> dict[str, Any]:
+    def test_connection(self, record: str, *, include_watch: bool = False) -> dict[str, Any]:
         """Exercise a saved provider connection end to end.
 
         Takes the RECORD NAME of a ``mailsec_provider`` hive record, never a
@@ -640,8 +640,17 @@ class Mailsec:
         connection can actually do — directory access, mail read, and the
         per-connection capabilities that depend on which scopes the customer's
         admin granted.
+
+        Args:
+            record: Saved ``mailsec_provider`` record name.
+            include_watch: Opt in to the side-effecting Workspace push probe.
+                The provider establishes or replaces a real watch; the call is
+                idempotent and the watch expires on its provider schedule.
         """
-        return self._post(f"connections/{_seg(record)}/test", {})
+        body: dict[str, Any] = {}
+        if include_watch:
+            body["include_watch"] = True
+        return self._post(f"connections/{_seg(record)}/test", body)
 
     def get_onboarding(self, *, provider: str | None = None) -> dict[str, Any]:
         """The setup guide for connecting a mail provider, with this org's own

--- a/tests/unit/test_cli_mailsec.py
+++ b/tests/unit/test_cli_mailsec.py
@@ -1,0 +1,35 @@
+"""Tests for the mailsec CLI's public lifecycle probe."""
+
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from limacharlie.cli import cli
+
+
+def invoke_connection(*args: str):
+    with (
+        patch("limacharlie.commands.mailsec.Client"),
+        patch("limacharlie.commands.mailsec.Organization"),
+        patch("limacharlie.commands.mailsec.Mailsec") as mailsec_cls,
+    ):
+        mailsec = MagicMock()
+        mailsec.test_connection.return_value = {"ok": True}
+        mailsec_cls.return_value = mailsec
+        result = CliRunner().invoke(
+            cli,
+            ["--oid", "11111111-2222-3333-4444-555555555555", "--output", "json", "mailsec", "connection", "test", *args],
+        )
+        return result, mailsec
+
+
+def test_connection_diagnostic_is_read_only_by_default():
+    result, mailsec = invoke_connection("workspace")
+    assert result.exit_code == 0, result.output
+    mailsec.test_connection.assert_called_once_with("workspace", include_watch=False)
+
+
+def test_include_watch_reaches_the_public_sdk_call():
+    result, mailsec = invoke_connection("workspace", "--include-watch")
+    assert result.exit_code == 0, result.output
+    mailsec.test_connection.assert_called_once_with("workspace", include_watch=True)

--- a/tests/unit/test_sdk_mailsec.py
+++ b/tests/unit/test_sdk_mailsec.py
@@ -137,6 +137,19 @@ class TestActions:
         assert body["confirm"] == "cmp-1"
 
 
+class TestConnectionDiagnostics:
+    def test_watch_probe_is_absent_by_default(self, ms, mock_org):
+        ms.test_connection("workspace")
+        url, body = _post_call(mock_org)
+        assert url == f"mailsec/{OID}/connections/workspace/test"
+        assert body == {}
+
+    def test_watch_probe_requires_explicit_opt_in(self, ms, mock_org):
+        ms.test_connection("workspace", include_watch=True)
+        _, body = _post_call(mock_org)
+        assert body == {"include_watch": True}
+
+
 class TestAnalyze:
     def test_analyze_needs_content(self, ms):
         with pytest.raises(ValueError, match="eml"):


### PR DESCRIPTION
## Summary\n\n- expose the gateway's existing include_watch connection-test option in the Mailsec SDK\n- add --include-watch to the CLI connection diagnostic\n- keep the default diagnostic body empty so a normal preflight remains read-only\n- document that the explicit probe establishes/replaces a real Workspace watch\n\nThis closes a public-path prerequisite for the P0 dual-provider lifecycle gate. The gateway and collector already accept include_watch; this PR makes that opt-in reachable by the supported CLI.\n\n## Verification\n\n- python3 -m compileall -q limacharlie\n- focused mailsec SDK/CLI tests: 29 passed\n- full unit suite: 3,872 passed, 19 skipped\n\nNo provider call, deployment, release, or live mutation was performed.