### PR TITLE
mailsec: return exact bytes from justified EML downloads

### DIFF
--- a/limacharlie/commands/mailsec.py
+++ b/limacharlie/commands/mailsec.py
@@ -575,13 +575,12 @@ def message_eml(ctx, msg_uuid, justification, out_path) -> None:
     ms = _get_mailsec(ctx)
     data = ms.get_message_eml(msg_uuid, justification)
     if out_path:
-        payload = data if isinstance(data, (bytes, bytearray)) else str(data).encode()
         with open(out_path, "wb") as f:
-            f.write(payload)
+            f.write(data)
         if not ctx.obj.quiet:
-            click.echo(f"wrote {len(payload)} bytes to {out_path}")
+            click.echo(f"wrote {len(data)} bytes to {out_path}")
         return
-    _output(ctx, data)
+    click.get_binary_stream("stdout").write(data)
 
 
 @message_group.command("similar")

--- a/limacharlie/sdk/mailsec.py
+++ b/limacharlie/sdk/mailsec.py
@@ -40,6 +40,8 @@ Two conventions inherited from the API contract that callers must not
 
 from __future__ import annotations
 
+import base64
+import binascii
 import json
 from typing import Any, TYPE_CHECKING
 from urllib.parse import quote as _quote
@@ -243,7 +245,7 @@ class Mailsec:
         """
         return self._get(f"messages/{_seg(msg_uuid)}")
 
-    def get_message_eml(self, msg_uuid: str, justification: str) -> Any:
+    def get_message_eml(self, msg_uuid: str, justification: str) -> bytes:
         """The original RFC822 bytes of a message.
 
         Requires ``mailsec.get.eml`` — a different privilege from opening the
@@ -261,10 +263,22 @@ class Mailsec:
                 "a justification is required to download raw mail: the access is audited, "
                 "and an unexplained one is not auditable"
             )
-        return self._get(
+        response = self._get(
             f"messages/{_seg(msg_uuid)}/eml",
             [("justification", justification)],
         )
+        if not isinstance(response, dict) or not isinstance(response.get("eml_b64"), str):
+            raise ValueError("mailsec EML response did not contain eml_b64")
+        try:
+            raw = base64.b64decode(response["eml_b64"], validate=True)
+        except (binascii.Error, ValueError) as exc:
+            raise ValueError("mailsec EML response contained invalid base64") from exc
+        size = response.get("size")
+        if not isinstance(size, int) or isinstance(size, bool) or size != len(raw):
+            raise ValueError(
+                f"mailsec EML response size mismatch: declared {size!r}, decoded {len(raw)}"
+            )
+        return raw
 
     def list_similar_messages(
         self,

--- a/tests/unit/test_cli_mailsec_eml.py
+++ b/tests/unit/test_cli_mailsec_eml.py
@@ -1,0 +1,70 @@
+"""Regression coverage for public mailsec EML downloads."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from limacharlie.cli import cli
+
+
+def test_eml_out_file_contains_original_bytes():
+    raw = b"From: marker@example.com\r\nSubject: test\r\n\r\nmarker body\r\n"
+    with (
+        patch("limacharlie.commands.mailsec.Client"),
+        patch("limacharlie.commands.mailsec.Organization"),
+        patch("limacharlie.commands.mailsec.Mailsec") as mailsec_cls,
+        CliRunner().isolated_filesystem(),
+    ):
+        mailsec = MagicMock()
+        mailsec.get_message_eml.return_value = raw
+        mailsec_cls.return_value = mailsec
+        result = CliRunner().invoke(
+            cli,
+            [
+                "--oid",
+                "11111111-2222-3333-4444-555555555555",
+                "mailsec",
+                "message",
+                "eml",
+                "msg-1",
+                "--justification",
+                "P0 marker-only acceptance evidence",
+                "--out-file",
+                "message.eml",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert Path("message.eml").read_bytes() == raw
+        mailsec.get_message_eml.assert_called_once_with(
+            "msg-1", "P0 marker-only acceptance evidence"
+        )
+
+
+def test_eml_stdout_contains_original_bytes():
+    raw = b"From: marker@example.com\r\n\r\nmarker body\r\n"
+    with (
+        patch("limacharlie.commands.mailsec.Client"),
+        patch("limacharlie.commands.mailsec.Organization"),
+        patch("limacharlie.commands.mailsec.Mailsec") as mailsec_cls,
+    ):
+        mailsec = MagicMock()
+        mailsec.get_message_eml.return_value = raw
+        mailsec_cls.return_value = mailsec
+        result = CliRunner().invoke(
+            cli,
+            [
+                "--oid",
+                "11111111-2222-3333-4444-555555555555",
+                "mailsec",
+                "message",
+                "eml",
+                "msg-1",
+                "--justification",
+                "P0 marker-only acceptance evidence",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert result.stdout_bytes == raw

--- a/tests/unit/test_sdk_mailsec.py
+++ b/tests/unit/test_sdk_mailsec.py
@@ -110,10 +110,29 @@ class TestEMLRequiresJustification:
             ms.get_message_eml("msg-1", "   ")
 
     def test_justification_is_forwarded(self, ms, mock_org):
-        ms.get_message_eml("msg-1", "INC-4471")
+        mock_org.client.request.return_value = {
+            "eml_b64": "RnJvbTogc2VuZGVyQGV4YW1wbGUuY29tDQoNCmhlbGxvDQo=",
+            "size": 35,
+        }
+        raw = ms.get_message_eml("msg-1", "INC-4471")
         url, qp = _get_call(mock_org)
         assert url == f"mailsec/{OID}/messages/msg-1/eml"
         assert ("justification", "INC-4471") in qp
+        assert raw == b"From: sender@example.com\r\n\r\nhello\r\n"
+
+    @pytest.mark.parametrize(
+        "response, match",
+        [
+            ({}, "did not contain eml_b64"),
+            ({"eml_b64": "***", "size": 0}, "invalid base64"),
+            ({"eml_b64": "YWJj", "size": 2}, "size mismatch"),
+            ({"eml_b64": "YWJj", "size": True}, "size mismatch"),
+        ],
+    )
+    def test_malformed_download_response_is_refused(self, ms, mock_org, response, match):
+        mock_org.client.request.return_value = response
+        with pytest.raises(ValueError, match=match):
+            ms.get_message_eml("msg-1", "INC-4471")
 
 
 class TestActions:
@@ -225,6 +244,9 @@ class TestRouteCoverage:
     """
 
     def test_every_route_has_a_method(self, ms, mock_org):
+        # Most methods do not inspect the mocked response. The EML route does,
+        # because its SDK contract is the decoded byte stream.
+        mock_org.client.request.return_value = {"eml_b64": "", "size": 0}
         calls = [
             (lambda: ms.get_coverage(), "GET", f"mailsec/{OID}/coverage"),
             (lambda: ms.list_messages(), "GET", f"mailsec/{OID}/messages"),


### PR DESCRIPTION
## Summary
- decode the public mailsec EML route's base64 JSON envelope in the SDK
- refuse malformed base64 and declared-size mismatches instead of returning corrupt evidence
- write exact RFC822 bytes to the CLI output file or binary stdout
- cover the audited justification, response validation, file output, and stdout contracts

## P0 relevance
Section 12.2 requires a public justified EML download. The service returns `{eml_b64,size,...}`; before this change the SDK returned that dictionary and `message eml --out-file` wrote its Python representation, not the original message.

This PR performs no provider mutation and no deployment.

## Validation
- `python3 -m pytest -q -o addopts='' tests/unit/test_sdk_mailsec.py tests/unit/test_cli_mailsec_eml.py` (31 passed)
- `python3 -m pytest -q -o addopts='' tests/unit` (3874 passed, 19 skipped)
- `python3 -m compileall -q limacharlie`
- `git diff --check`