### PR TITLE
mailsec: honor banner action wire contract

### DIFF
--- a/limacharlie/commands/mailsec.py
+++ b/limacharlie/commands/mailsec.py
@@ -602,7 +602,7 @@ def message_similar(ctx, msg_uuid, cursor, limit) -> None:
 @message_group.command("action")
 @click.argument("msg_uuid")
 @click.option("--action", "action_name", required=True,
-              help="quarantine_message|trash_message|restore_message|apply_banner|remove_banner")
+              help="quarantine_message|trash_message|restore_message|banner_message|unbanner_message")
 @click.option("--reason", default=None, help="Recorded on the audit row.")
 @click.option("--attempt", default=None, help="Caller-supplied idempotency token.")
 @click.option("--banner", default=None, help="Banner HTML, for the banner actions.")

--- a/limacharlie/sdk/mailsec.py
+++ b/limacharlie/sdk/mailsec.py
@@ -298,7 +298,7 @@ class Mailsec:
         Args:
             msg_uuid: The message to act on.
             action: ``quarantine_message``, ``trash_message``,
-                ``restore_message``, ``apply_banner``, ``remove_banner``.
+                ``restore_message``, ``banner_message``, ``unbanner_message``.
             reason: Free-text justification recorded on the audit row.
             attempt: Caller-supplied idempotency token.
             banner: Banner HTML, for the banner actions.
@@ -311,7 +311,7 @@ class Mailsec:
             ``ok``.
         """
         body: dict[str, Any] = {"action": action}
-        for key, val in (("reason", reason), ("attempt", attempt), ("banner", banner)):
+        for key, val in (("reason", reason), ("attempt", attempt), ("banner_html", banner)):
             if val is not None:
                 body[key] = val
         return self._post(f"messages/{_seg(msg_uuid)}/actions", body)

--- a/tests/unit/test_sdk_mailsec.py
+++ b/tests/unit/test_sdk_mailsec.py
@@ -123,6 +123,14 @@ class TestActions:
         assert url == f"mailsec/{OID}/messages/msg-1/actions"
         assert body == {"action": "quarantine_message", "reason": "phish"}
 
+    def test_banner_uses_the_gateway_wire_name(self, ms, mock_org):
+        ms.act_on_message("msg-1", "banner_message", banner="<div>external sender</div>")
+        _, body = _post_call(mock_org)
+        assert body == {
+            "action": "banner_message",
+            "banner_html": "<div>external sender</div>",
+        }
+
     def test_campaign_action_previews_without_confirm(self, ms, mock_org):
         """confirm is what turns a preview into an execution. Its absence must
         reach the server as an absence, not as an empty string that could be


### PR DESCRIPTION
## Summary
- send banner HTML using the public gateway's `banner_html` field
- advertise the collector's supported `banner_message` and `unbanner_message` action names
- lock the exact public request body with a regression test

## Why
The Python client advertised `apply_banner` / `remove_banner` and sent HTML under `banner`. The public API forwards `banner_html`, while mailsec accepts `banner_message` / `unbanner_message`, so a live P0 capability check through the supported public route could not exercise the provider implementation correctly.

## Validation
- focused mailsec SDK/CLI tests: 26 passed
- complete unit suite: 3869 passed, 19 skipped
- `python -m compileall -q limacharlie`
- `git diff --check`

No deployment or live provider mutation was performed.
