### PR TITLE
mailsec: expose email object searches in CLI help

### DIFF
--- a/limacharlie/commands/ioc.py
+++ b/limacharlie/commands/ioc.py
@@ -91,6 +91,7 @@ Supported --type values:
   file_path    - Full file path
   file_name    - File name only (no directory)
   user         - User or account name
+  email        - Email address
   service_name - Service/daemon name
   package_name - Installed package name
 
@@ -144,7 +145,7 @@ The file should map IOC types to lists of values:
     file_hash:
       - abc123def456...
 
-Valid IOC types: domain, ip, file_hash, file_path, file_name, user,
+Valid IOC types: domain, ip, file_hash, file_path, file_name, user, email,
 service_name, package_name.
 
 This is more efficient than running individual searches when you have
@@ -233,7 +234,7 @@ including related objects, first/last seen times, and context from
 sensor telemetry.
 
 Supported --type values: domain, ip, file_hash, file_path, file_name,
-user, service_name, package_name.
+user, email, service_name, package_name.
 
 Unlike "search" (which returns prevalence per sensor), "enrich" returns
 the object's own metadata and relationships.
@@ -247,7 +248,7 @@ register_explain("ioc.enrich", _EXPLAIN_ENRICH)
 
 
 @group.command()
-@click.option("--type", "obj_type", required=True, help="Indicator type (domain, ip, file_hash, file_path, file_name, user, service_name, package_name).")
+@click.option("--type", "obj_type", required=True, help="Indicator type (domain, ip, file_hash, file_path, file_name, user, email, service_name, package_name).")
 @click.option("--value", required=True, help="Indicator value to look up.")
 @pass_context
 def enrich(ctx: click.Context, obj_type: str, value: str) -> None:
@@ -272,7 +273,7 @@ of values:
     ip:
       - 1.2.3.4
 
-Valid types: domain, ip, file_hash, file_path, file_name, user,
+Valid types: domain, ip, file_hash, file_path, file_name, user, email,
 service_name, package_name.
 
 Results include object metadata and relationships for each indicator.

--- a/limacharlie/help_topics.py
+++ b/limacharlie/help_topics.py
@@ -520,11 +520,13 @@ for searching across your telemetry:
   ip             - IP address (IPv4 or IPv6)
   domain         - Domain name
   user           - User name
+  email          - Email address
   service_name   - Service/daemon name
   package_name   - Software package name
 
 Usage:
   limacharlie ioc search --type ip --value "10.0.0.1"
+  limacharlie ioc search --type email --value "analyst@example.com"
   limacharlie ioc batch-search --input-file iocs.json
 
 The batch-search command accepts a JSON file with multiple IOC searches.

--- a/limacharlie/sdk/insight.py
+++ b/limacharlie/sdk/insight.py
@@ -32,7 +32,7 @@ class Insight:
         """Search for an IOC.
 
         Args:
-            obj_type: IOC type (domain, ip, file_hash, file_path, file_name, user, service_name, package_name).
+            obj_type: IOC type (domain, ip, file_hash, file_path, file_name, user, email, service_name, package_name).
             obj_name: IOC value to search for.
             info: Type of information to query ('summary' or 'locations').
             case_sensitive: Case-sensitive matching (default True).
@@ -103,7 +103,7 @@ class Insight:
         about an observed object (IOC).
 
         Args:
-            obj_type: Object type (domain, ip, file_hash, file_path, file_name, user, service_name, package_name).
+            obj_type: Object type (domain, ip, file_hash, file_path, file_name, user, email, service_name, package_name).
             obj_name: Object value to look up.
             info: Type of information ('summary' or 'locations').
             case_sensitive: Case-sensitive matching (default True).
@@ -120,4 +120,3 @@ class Insight:
             wildcards=wildcards,
             limit=limit,
         )
-

--- a/tests/unit/test_sdk_insight.py
+++ b/tests/unit/test_sdk_insight.py
@@ -97,6 +97,13 @@ class TestInsightSearchIoc:
         call_args = mock_org.client.request.call_args
         assert call_args[0][1] == "insight/test-oid/objects/file_hash"
 
+    def test_email_object_type_reaches_public_route(self, insight, mock_org):
+        mock_org.client.request.return_value = {"results": []}
+        insight.search_ioc("email", "analyst@example.com")
+        call_args = mock_org.client.request.call_args
+        assert call_args[0][1] == "insight/test-oid/objects/email"
+        assert call_args[1]["query_params"]["name"] == "analyst@example.com"
+
 
 class TestInsightBatchSearch:
     def test_path_and_params(self, insight, mock_org):


### PR DESCRIPTION
## Summary
- document the new `email` object type in IOC search, batch search, enrichment, SDK, and help-topic surfaces
- add an SDK regression proving an email lookup reaches the public `/objects/email` route without rewriting its value
- retain server-authoritative type validation so future object types do not require a CLI release merely to be usable

## Validation
- `python3 -m pytest -q -o addopts='' tests/unit/test_sdk_insight.py` (19 passed)
- `python3 -m compileall -q limacharlie/commands/ioc.py limacharlie/sdk/insight.py limacharlie/help_topics.py`
- `git diff --check`

## Dependency / rollout
Documentation and pass-through only. The corresponding public API and backend object-index stack must land before this is advertised in a release. No release or deployment is included.