### PR TITLE
mailsec: add verdict-revision and report-reopen CLI/SDK surfaces

### DIFF
--- a/limacharlie/commands/mailsec.py
+++ b/limacharlie/commands/mailsec.py
@@ -131,6 +131,38 @@ Examples:
   limacharlie mailsec message action 0057db2b-... --action restore_message
 """
 
+_EXPLAIN_MESSAGE_REVISE = """\
+Revise a message's verdict as an analyst. Requires mailsec.act.
+
+This records a human triage decision over the scorer's — it is a
+disposition, not a remediation — and appends to the message's verdict
+history rather than overwriting it. --rationale is required and audited:
+at least one, at most ten, each <= 280 characters.
+
+mode is fixed to 'analyst' here because the operator of this CLI is a
+person. An autonomous agent revises with its OWN key and mode 'ai'
+through the API, not this command, so the audit can always say whether a
+person or a model decided.
+
+applied:false is an honest outcome, not an error: it means the message
+was already at this verdict and nothing changed.
+
+Examples:
+  limacharlie mailsec message revise 0057db2b-... --verdict malicious --rationale "confirmed credential harvest"
+  limacharlie mailsec message revise 0057db2b-... --verdict benign --rationale "internal test send" --rationale "sender verified"
+"""
+
+_EXPLAIN_MESSAGE_REVISIONS = """\
+The verdict revision history for one message, oldest first.
+
+Each entry is who decided (mode/actor), the verdict they set, when, and
+the rationale they gave — the audit of how a message's disposition moved
+over time.
+
+Examples:
+  limacharlie mailsec message revisions 0057db2b-...
+"""
+
 _EXPLAIN_CAMPAIGN_LIST = """\
 Campaigns: one attack triaged once, rather than once per mailbox.
 
@@ -224,6 +256,20 @@ an outcome that already holds.
 
 Examples:
   limacharlie mailsec report resolve <report_id> --disposition true_positive
+"""
+
+_EXPLAIN_REPORT_REOPEN = """\
+Reopen a resolved report. Requires mailsec.set.
+
+The inverse of resolve: a report closed too early, or contradicted by
+new evidence, returns to the queue rather than staying settled on a
+disposition that no longer holds.
+
+Reopening an already-open report succeeds and says so — the queue's
+state is the point, not who raced to change it.
+
+Examples:
+  limacharlie mailsec report reopen <report_id>
 """
 
 _EXPLAIN_HUNT_CREATE = """\
@@ -379,12 +425,12 @@ def group() -> None:
 
     \b
       coverage            Mailbox coverage and analysed volume
-      message ...         The triage queue, drawer, raw EML, similar, actions
+      message ...         The triage queue, drawer, raw EML, similar, actions, revise
       campaign ...        Campaigns and campaign-wide sweeps
       sender get          A sender's history with this org
       action get          One record from the action audit trail
       analyze             Parse and score an EML without ingesting it
-      report ...          Abuse-mailbox report queue (list, get, resolve)
+      report ...          Abuse-mailbox report queue (list, get, resolve, reopen)
       hunt ...            Retro-hunts (create, get, remediate)
       rule ...            Custom rule validation and backtest
       connection test     Provider connection preflight
@@ -394,7 +440,7 @@ def group() -> None:
 
 @group.group("message")
 def message_group() -> None:
-    """The message index, drawer, raw EML, similar mail, and actions."""
+    """The message index, drawer, raw EML, similar mail, actions, verdict revision."""
 
 
 @group.group("campaign")
@@ -414,7 +460,7 @@ def action_group() -> None:
 
 @group.group("report")
 def report_group() -> None:
-    """The abuse-mailbox report queue."""
+    """The abuse-mailbox report queue (list, get, resolve, reopen)."""
 
 
 @group.group("hunt")
@@ -620,6 +666,45 @@ def message_action(ctx, msg_uuid, action_name, reason, attempt, banner) -> None:
     ))
 
 
+@message_group.command("revise")
+@click.argument("msg_uuid")
+@click.option("--verdict", required=True,
+              type=click.Choice(["malicious", "suspicious", "graymail", "benign", "unknown"]),
+              help="The verdict to set.")
+@click.option("--rationale", "rationale", multiple=True, required=True,
+              help="Why the verdict is changing (repeatable, at least one, each <= 280 chars). "
+                   "Written to the revision audit.")
+@click.option("--score", default=None, type=float, help="Optional score to record with the revision.")
+@pass_context
+def message_revise(ctx, msg_uuid, verdict, rationale, score) -> None:
+    """Revise a message's verdict as an analyst (mailsec.act).
+
+    \b
+    mode is 'analyst' — the operator of this CLI is a person. An agent
+    revises with its own key and mode 'ai' through the API, not here.
+    applied:false means it was already this verdict, not an error.
+
+    \b
+    Example:
+      limacharlie mailsec message revise 0057db2b-... --verdict malicious --rationale "confirmed phish"
+    """
+    ms = _get_mailsec(ctx)
+    _output(ctx, ms.revise_verdict(msg_uuid, verdict, list(rationale), score=score))
+
+
+@message_group.command("revisions")
+@click.argument("msg_uuid")
+@pass_context
+def message_revisions(ctx, msg_uuid) -> None:
+    """The verdict revision history for a message, oldest first.
+
+    \b
+    Example:
+      limacharlie mailsec message revisions 0057db2b-...
+    """
+    _output(ctx, _get_mailsec(ctx).list_revisions(msg_uuid))
+
+
 # ---------------------------------------------------------------------------
 # Campaigns
 # ---------------------------------------------------------------------------
@@ -770,6 +855,23 @@ def report_resolve(ctx, report_id, disposition) -> None:
     _output(ctx, _get_mailsec(ctx).resolve_report(report_id, disposition))
 
 
+@report_group.command("reopen")
+@click.argument("report_id")
+@pass_context
+def report_reopen(ctx, report_id) -> None:
+    """Reopen a resolved report (mailsec.set).
+
+    \b
+    The inverse of resolve. Reopening an already-open report succeeds
+    and says so.
+
+    \b
+    Example:
+      limacharlie mailsec report reopen <report_id>
+    """
+    _output(ctx, _get_mailsec(ctx).reopen_report(report_id))
+
+
 # ---------------------------------------------------------------------------
 # Hunts
 # ---------------------------------------------------------------------------
@@ -913,6 +1015,8 @@ register_explain("mailsec.message.get", _EXPLAIN_MESSAGE_GET)
 register_explain("mailsec.message.eml", _EXPLAIN_MESSAGE_EML)
 register_explain("mailsec.message.similar", _EXPLAIN_MESSAGE_SIMILAR)
 register_explain("mailsec.message.action", _EXPLAIN_MESSAGE_ACTION)
+register_explain("mailsec.message.revise", _EXPLAIN_MESSAGE_REVISE)
+register_explain("mailsec.message.revisions", _EXPLAIN_MESSAGE_REVISIONS)
 register_explain("mailsec.campaign.list", _EXPLAIN_CAMPAIGN_LIST)
 register_explain("mailsec.campaign.get", _EXPLAIN_CAMPAIGN_GET)
 register_explain("mailsec.campaign.action", _EXPLAIN_CAMPAIGN_ACTION)
@@ -921,6 +1025,7 @@ register_explain("mailsec.action.get", _EXPLAIN_ACTION_GET)
 register_explain("mailsec.report.list", _EXPLAIN_REPORT_LIST)
 register_explain("mailsec.report.get", _EXPLAIN_REPORT_GET)
 register_explain("mailsec.report.resolve", _EXPLAIN_REPORT_RESOLVE)
+register_explain("mailsec.report.reopen", _EXPLAIN_REPORT_REOPEN)
 register_explain("mailsec.hunt.create", _EXPLAIN_HUNT_CREATE)
 register_explain("mailsec.hunt.get", _EXPLAIN_HUNT_GET)
 register_explain("mailsec.hunt.remediate", _EXPLAIN_HUNT_REMEDIATE)

--- a/limacharlie/sdk/mailsec.py
+++ b/limacharlie/sdk/mailsec.py
@@ -2,10 +2,10 @@
 
 Wraps the ``/mailsec/{oid}/...`` REST routes served by the API gateway: the
 coverage screen, the message index and its drawer, the justified raw-EML
-download, campaigns, sender profiles, the action audit trail, the
-abuse-mailbox report queue, standalone EML analysis, retro-hunts, custom-rule
-validation and backtest, the provider connection preflight, and the served
-onboarding guide.
+download, analyst verdict revision and its history, campaigns, sender
+profiles, the action audit trail, the abuse-mailbox report queue and its
+reopen, standalone EML analysis, retro-hunts, custom-rule validation and
+backtest, the provider connection preflight, and the served onboarding guide.
 
 Permissions, which are four rather than the usual get/set pair because mailsec
 asks to be trusted with four different things:
@@ -48,6 +48,14 @@ from urllib.parse import quote as _quote
 
 if TYPE_CHECKING:
     from .organization import Organization
+
+
+# Verdict-revision rationale bounds, mirrored client-side so a caller learns
+# the limit from a clear local error rather than from a 400 after the round
+# trip. These match the gateway's own validation: at least one line, at most
+# ten, each no longer than 280 characters.
+_MAX_RATIONALE_LINES = 10
+_MAX_RATIONALE_LEN = 280
 
 
 def _seg(value: str) -> str:
@@ -330,6 +338,84 @@ class Mailsec:
                 body[key] = val
         return self._post(f"messages/{_seg(msg_uuid)}/actions", body)
 
+    def revise_verdict(
+        self,
+        msg_uuid: str,
+        verdict: str,
+        rationale: list[str],
+        *,
+        mode: str = "analyst",
+        score: float | None = None,
+    ) -> dict[str, Any]:
+        """Revise the verdict on one message. Requires ``mailsec.act``.
+
+        This records a human's disposition over the scorer's — a triage
+        decision, not a remediation — and appends a revision to the message's
+        immutable verdict history rather than overwriting the last one.
+
+        ``mode`` defaults to ``analyst`` because the caller of this SDK from
+        the CLI is a person. An autonomous agent revises with its own key and
+        ``mode="ai"``; the two are kept distinct so the audit trail can always
+        say whether a person or a model decided.
+
+        The rationale is REQUIRED and audited: at least one line, at most ten,
+        each no longer than 280 characters. The bounds are checked here so a
+        caller gets a clear local error instead of a 400 after the round trip.
+
+        Args:
+            msg_uuid: The message whose verdict is being revised.
+            verdict: ``malicious``, ``suspicious``, ``graymail``, ``benign``,
+                or ``unknown``.
+            rationale: One or more free-text lines explaining the change.
+            mode: The deciding actor's mode; ``analyst`` for a human,
+                ``ai`` for an agent. The gateway stamps the actor identity
+                itself — this only says which KIND of actor decided.
+            score: An optional numeric score to record alongside the verdict.
+
+        Returns:
+            The revision result. ``applied`` is the honest outcome to read:
+            ``applied: false`` means the message was already at this verdict
+            and nothing changed — a no-op reported truthfully, not an error.
+            The response also carries ``revision_seq``, ``prior``, and
+            ``newly_flagged``.
+        """
+        if not rationale:
+            raise ValueError(
+                "a verdict revision needs at least one rationale line: the change is "
+                "audited, and an unexplained one is not auditable"
+            )
+        if len(rationale) > _MAX_RATIONALE_LINES:
+            raise ValueError(
+                f"too many rationale lines: {len(rationale)} given, at most "
+                f"{_MAX_RATIONALE_LINES} allowed"
+            )
+        for line in rationale:
+            if not isinstance(line, str) or not line.strip():
+                raise ValueError("every rationale line must be non-empty text")
+            if len(line) > _MAX_RATIONALE_LEN:
+                raise ValueError(
+                    f"a rationale line is too long: {len(line)} characters, at most "
+                    f"{_MAX_RATIONALE_LEN} allowed"
+                )
+        body: dict[str, Any] = {
+            "verdict": verdict,
+            "mode": mode,
+            "rationale": list(rationale),
+        }
+        if score is not None:
+            body["score"] = score
+        return self._post(f"messages/{_seg(msg_uuid)}/verdict", body)
+
+    def list_revisions(self, msg_uuid: str) -> dict[str, Any]:
+        """The verdict revision history for one message, oldest first.
+
+        Requires ``mailsec.get``. Every entry carries its ``seq``, the
+        ``mode`` and ``actor`` that decided it, the ``verdict`` it set, its
+        ``decided_at`` time, and the ``rationale`` given — the audit of how a
+        message's disposition moved over time, read from the bottom up.
+        """
+        return self._get(f"messages/{_seg(msg_uuid)}/revisions")
+
     # ------------------------------------------------------------------
     # Campaigns
     # ------------------------------------------------------------------
@@ -525,6 +611,19 @@ class Mailsec:
             holds.
         """
         return self._post(f"reports/{_seg(report_id)}/resolve", {"disposition": disposition})
+
+    def reopen_report(self, report_id: str) -> dict[str, Any]:
+        """Reopen a resolved report. Requires ``mailsec.set``.
+
+        The inverse of :meth:`resolve_report`: a report closed too early, or
+        closed and then contradicted by new evidence, returns to the queue
+        rather than staying settled on a disposition that no longer holds.
+
+        Reopening an already-open report succeeds and says so — the queue's
+        state is what matters, not who raced to change it — so a client does
+        not have to treat "already open" as a failure.
+        """
+        return self._post(f"reports/{_seg(report_id)}/reopen", {})
 
     # ------------------------------------------------------------------
     # Hunts

--- a/tests/unit/test_cli_mailsec_revision.py
+++ b/tests/unit/test_cli_mailsec_revision.py
@@ -1,0 +1,123 @@
+"""Tests for the mailsec CLI's verdict-revision and report-reopen verbs."""
+
+import json
+
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from limacharlie.cli import cli
+
+OID = "11111111-2222-3333-4444-555555555555"
+
+
+def _invoke(*args, sdk_returns=None, mock_sdk=True):
+    """Invoke the CLI. When mock_sdk is True the Mailsec class is replaced with
+    a MagicMock so the SDK call is asserted directly; when False the real SDK
+    runs over a mocked transport, which is how client-side validation is
+    exercised end to end without a live call."""
+    with (
+        patch("limacharlie.commands.mailsec.Client"),
+        patch("limacharlie.commands.mailsec.Organization"),
+    ):
+        if mock_sdk:
+            with patch("limacharlie.commands.mailsec.Mailsec") as mailsec_cls:
+                mailsec = MagicMock()
+                if sdk_returns is not None:
+                    for name, value in sdk_returns.items():
+                        getattr(mailsec, name).return_value = value
+                mailsec_cls.return_value = mailsec
+                result = CliRunner().invoke(cli, ["--oid", OID, "--output", "json", *args])
+                return result, mailsec
+        result = CliRunner().invoke(cli, ["--oid", OID, "--output", "json", *args])
+        return result, None
+
+
+class TestMessageRevise:
+    def test_revise_reaches_the_sdk_with_defaults(self):
+        result, mailsec = _invoke(
+            "mailsec", "message", "revise", "msg-1",
+            "--verdict", "malicious",
+            "--rationale", "confirmed phish",
+            sdk_returns={"revise_verdict": {"applied": True, "revision_seq": 3}},
+        )
+        assert result.exit_code == 0, result.output
+        mailsec.revise_verdict.assert_called_once_with(
+            "msg-1", "malicious", ["confirmed phish"], score=None
+        )
+
+    def test_repeated_rationale_and_score_forwarded(self):
+        result, mailsec = _invoke(
+            "mailsec", "message", "revise", "msg-1",
+            "--verdict", "benign",
+            "--rationale", "internal send",
+            "--rationale", "sender verified",
+            "--score", "12.5",
+            sdk_returns={"revise_verdict": {"applied": True}},
+        )
+        assert result.exit_code == 0, result.output
+        mailsec.revise_verdict.assert_called_once_with(
+            "msg-1", "benign", ["internal send", "sender verified"], score=12.5
+        )
+
+    def test_applied_false_is_a_non_error(self):
+        """A no-op revision is the honest outcome, not a failure: the response
+        carries applied:false and the command still exits 0."""
+        result, _ = _invoke(
+            "mailsec", "message", "revise", "msg-1",
+            "--verdict", "malicious",
+            "--rationale", "already malicious",
+            sdk_returns={"revise_verdict": {"applied": False, "revision_seq": 2}},
+        )
+        assert result.exit_code == 0, result.output
+        assert json.loads(result.output)["applied"] is False
+
+    def test_rationale_is_required(self):
+        result, _ = _invoke(
+            "mailsec", "message", "revise", "msg-1", "--verdict", "malicious",
+            sdk_returns={"revise_verdict": {"applied": True}},
+        )
+        assert result.exit_code != 0
+        assert "rationale" in result.output.lower()
+
+    def test_verdict_choice_is_constrained(self):
+        result, _ = _invoke(
+            "mailsec", "message", "revise", "msg-1",
+            "--verdict", "totally-bad",
+            "--rationale", "x",
+            sdk_returns={"revise_verdict": {"applied": True}},
+        )
+        assert result.exit_code != 0
+
+    def test_overlong_rationale_is_a_clean_client_side_error(self):
+        """Run the real SDK over a mocked transport: the 280-char bound is
+        enforced locally and surfaces as a clean non-zero exit, never a live
+        call."""
+        result, _ = _invoke(
+            "mailsec", "message", "revise", "msg-1",
+            "--verdict", "malicious",
+            "--rationale", "x" * 281,
+            mock_sdk=False,
+        )
+        assert result.exit_code != 0
+        assert "too long" in str(result.exception) or "too long" in result.output
+
+
+class TestMessageRevisions:
+    def test_revisions_reaches_the_sdk(self):
+        result, mailsec = _invoke(
+            "mailsec", "message", "revisions", "msg-1",
+            sdk_returns={"list_revisions": {"revisions": []}},
+        )
+        assert result.exit_code == 0, result.output
+        mailsec.list_revisions.assert_called_once_with("msg-1")
+
+
+class TestReportReopen:
+    def test_reopen_reaches_the_sdk(self):
+        result, mailsec = _invoke(
+            "mailsec", "report", "reopen", "rep-1",
+            sdk_returns={"reopen_report": {"report": {"status": "open"}}},
+        )
+        assert result.exit_code == 0, result.output
+        mailsec.reopen_report.assert_called_once_with("rep-1")

--- a/tests/unit/test_sdk_mailsec.py
+++ b/tests/unit/test_sdk_mailsec.py
@@ -208,6 +208,72 @@ class TestReports:
         assert url == f"mailsec/{OID}/reports/rep-1/resolve"
         assert body == {"disposition": "true_positive"}
 
+    def test_reopen_sends_empty_body(self, ms, mock_org):
+        ms.reopen_report("rep-1")
+        url, body = _post_call(mock_org)
+        assert url == f"mailsec/{OID}/reports/rep-1/reopen"
+        assert body == {}
+
+
+class TestVerdictRevision:
+    """A verdict revision is a human triage decision appended to the message's
+    verdict history. mode defaults to analyst because the caller is a person;
+    the rationale is required and audited, so its bounds are enforced locally
+    to fail with a clear message rather than a 400 after the round trip."""
+
+    def test_revise_body_defaults_to_analyst_mode(self, ms, mock_org):
+        ms.revise_verdict("msg-1", "malicious", ["confirmed phish"])
+        url, body = _post_call(mock_org)
+        assert url == f"mailsec/{OID}/messages/msg-1/verdict"
+        assert body == {
+            "verdict": "malicious",
+            "mode": "analyst",
+            "rationale": ["confirmed phish"],
+        }
+
+    def test_revise_forwards_score_and_multiple_rationale(self, ms, mock_org):
+        ms.revise_verdict("msg-1", "benign", ["a", "b"], score=12.5)
+        _, body = _post_call(mock_org)
+        assert body["rationale"] == ["a", "b"]
+        assert body["score"] == 12.5
+
+    def test_score_is_omitted_when_absent(self, ms, mock_org):
+        ms.revise_verdict("msg-1", "benign", ["a"])
+        _, body = _post_call(mock_org)
+        assert "score" not in body
+
+    def test_empty_rationale_is_refused(self, ms):
+        with pytest.raises(ValueError, match="at least one rationale"):
+            ms.revise_verdict("msg-1", "malicious", [])
+
+    def test_blank_rationale_line_is_refused(self, ms):
+        with pytest.raises(ValueError, match="non-empty"):
+            ms.revise_verdict("msg-1", "malicious", ["   "])
+
+    def test_too_many_rationale_lines_is_refused(self, ms):
+        with pytest.raises(ValueError, match="too many rationale"):
+            ms.revise_verdict("msg-1", "malicious", [f"line {i}" for i in range(11)])
+
+    def test_ten_rationale_lines_is_allowed(self, ms, mock_org):
+        ms.revise_verdict("msg-1", "malicious", [f"line {i}" for i in range(10)])
+        _, body = _post_call(mock_org)
+        assert len(body["rationale"]) == 10
+
+    def test_overlong_rationale_line_is_refused(self, ms):
+        with pytest.raises(ValueError, match="too long"):
+            ms.revise_verdict("msg-1", "malicious", ["x" * 281])
+
+    def test_rationale_line_at_the_limit_is_allowed(self, ms, mock_org):
+        ms.revise_verdict("msg-1", "malicious", ["x" * 280])
+        _, body = _post_call(mock_org)
+        assert body["rationale"] == ["x" * 280]
+
+    def test_revisions_reads_oldest_first_history(self, ms, mock_org):
+        ms.list_revisions("msg-1")
+        url, qp = _get_call(mock_org)
+        assert url == f"mailsec/{OID}/messages/msg-1/revisions"
+        assert qp is None
+
 
 class TestRules:
     def test_validate_body(self, ms, mock_org):
@@ -274,6 +340,7 @@ class TestRouteCoverage:
             (lambda: ms.get_message("m"), "GET", f"mailsec/{OID}/messages/m"),
             (lambda: ms.get_message_eml("m", "why"), "GET", f"mailsec/{OID}/messages/m/eml"),
             (lambda: ms.list_similar_messages("m"), "GET", f"mailsec/{OID}/messages/m/similar"),
+            (lambda: ms.list_revisions("m"), "GET", f"mailsec/{OID}/messages/m/revisions"),
             (lambda: ms.list_campaigns(), "GET", f"mailsec/{OID}/campaigns"),
             (lambda: ms.get_campaign("c"), "GET", f"mailsec/{OID}/campaigns/c"),
             (lambda: ms.get_sender_profile("s"), "GET", f"mailsec/{OID}/senders/s"),
@@ -284,16 +351,18 @@ class TestRouteCoverage:
             (lambda: ms.get_onboarding(), "GET", f"mailsec/{OID}/onboarding"),
             (lambda: ms.analyze(eml="x"), "POST", f"mailsec/{OID}/analyze"),
             (lambda: ms.act_on_message("m", "a"), "POST", f"mailsec/{OID}/messages/m/actions"),
+            (lambda: ms.revise_verdict("m", "malicious", ["why"]), "POST", f"mailsec/{OID}/messages/m/verdict"),
             (lambda: ms.act_on_campaign("c", "a"), "POST", f"mailsec/{OID}/campaigns/c/actions"),
             (lambda: ms.resolve_report("r", "benign"), "POST", f"mailsec/{OID}/reports/r/resolve"),
+            (lambda: ms.reopen_report("r"), "POST", f"mailsec/{OID}/reports/r/reopen"),
             (lambda: ms.create_hunt(lcql="q"), "POST", f"mailsec/{OID}/hunts"),
             (lambda: ms.remediate_hunt("h", "a"), "POST", f"mailsec/{OID}/hunts/h/remediate"),
             (lambda: ms.validate_rule({}), "POST", f"mailsec/{OID}/rules/validate"),
             (lambda: ms.backtest_rule({}), "POST", f"mailsec/{OID}/rules/backtest"),
             (lambda: ms.test_connection("rec"), "POST", f"mailsec/{OID}/connections/rec/test"),
         ]
-        # 22 gateway routes, 22 SDK methods.
-        assert len(calls) == 22
+        # 25 gateway routes, 25 SDK methods.
+        assert len(calls) == 25
         for fn, method, expected_url in calls:
             mock_org.client.request.reset_mock()
             fn()


### PR DESCRIPTION
## What

Wires the P3 verdict-revision and report-reopen mailsec gateway routes (now live on exp) into the `limacharlie mailsec` CLI and its SDK, building on the existing coverage/message/campaign/report/action/analyze/connection/onboarding group.

### New verbs (matching the group's existing noun-verb grammar)

- **`mailsec message revise MSG_UUID --verdict <malicious|suspicious|graymail|benign|unknown> --rationale <text> [--rationale ...] [--score N]`**
  → `POST /mailsec/{oid}/messages/{msg_uuid}/verdict` (perm `mailsec.act`). Records an analyst verdict. `--rationale` is repeatable and required (1..10 lines, each ≤280 chars). `mode` is fixed to `analyst` because the CLI operator is a human — an autonomous agent revises with its own key and `mode: ai` through the API, not this command. `applied:false` is rendered as an honest no-op (already the current verdict), not an error.
- **`mailsec message revisions MSG_UUID`**
  → `GET /mailsec/{oid}/messages/{msg_uuid}/revisions` (perm `mailsec.get`). Oldest-first revision history (seq/mode/actor/verdict/decided_at/rationale), rendered via the standard `--output` json/table path.
- **`mailsec report reopen REPORT_ID`**
  → `POST /mailsec/{oid}/reports/{report_id}/reopen` (perm `mailsec.set`). The inverse of the existing `report resolve`; added beside it without duplicating resolve.

### Conventions followed

- Positional id argument (like `message get/eml/similar/action`, `report get/resolve`), `Client.request` wrapper via the `Mailsec` SDK, gateway stamps the actor (nothing stamped client-side), generic `format_output` rendering, `register_explain` AI-help entries, and the same explain/help text style.
- Rationale bounds are enforced client-side (clear `ValueError` → clean non-zero CLI exit) so a caller learns the limit locally rather than from a 400.

## Tests

Extends the established mock-the-transport pattern (no live API calls): asserts URL/method/body for each verb, the `analyst` mode default, rationale bounds (empty/blank/too-many/too-long, plus at-limit accepted), and that `applied:false` exits 0. The SDK route-coverage test is updated 22→25. Full unit + microbenchmark suite green (4003 passed, 5 pre-existing skips).

🤖 Generated with [Claude Code](https://claude.com/claude-code)