### PR TITLE
task: document the new sensor taskings, and fix two broken examples

### DIFF
--- a/doc/cli/sensor-management.md
+++ b/doc/cli/sensor-management.md
@@ -46,7 +46,7 @@ limacharlie endpoint-policy unseal --sid SENSOR_ID
 ## task
 
 ```bash
-limacharlie task send --sid SENSOR_ID --command os_processes
+limacharlie task send --sid SENSOR_ID --task os_processes
 limacharlie task request --sid SENSOR_ID --command os_processes  # Wait for response
 limacharlie task reliable-send --sid SENSOR_ID --command os_processes
 limacharlie task reliable-list --sid SENSOR_ID

--- a/limacharlie/commands/task.py
+++ b/limacharlie/commands/task.py
@@ -78,6 +78,8 @@ The --task value is the full command string.  Common task commands:
 
   File system:
     dir_list <path>             - List a directory
+    dir_find <path>             - Find files by size, mtime or hash (bounded)
+    file_grep <path> -p <str>   - Search file contents for a literal (bounded)
     file_get <path>             - Retrieve a file as artifact
     file_del <path>             - Delete a file
     file_hash <path>            - Get hash of a file
@@ -98,7 +100,8 @@ The --task value is the full command string.  Common task commands:
 
   Scanning:
     yara_scan <rule> <path>     - YARA scan a file or directory
-    artifact_get <path>         - Collect an artifact (file/log)
+    artifact_get --file <path>  - Collect one file as an artifact
+    artifact_get --root-dir <p> - Collect many files as artifacts (bounded)
 
   System info:
     os_version                  - Get OS version info
@@ -106,6 +109,16 @@ The --task value is the full command string.  Common task commands:
     os_autoruns                 - List autorun entries
     os_users                    - List local user accounts (Win)
     history_dump                - Dump recent telemetry
+    container_list              - List containers and images (Linux only)
+
+The commands marked (bounded) stop at whichever budget is reached first
+and report that in the reply via SCAN_IS_TRUNCATED and
+SCAN_STOPPED_REASON, so an empty result is not necessarily a clean host.
+Widen with --depth, --limit, --max-seconds and --max-files-scanned.
+
+This list is not exhaustive.  The task string is parsed by the backend,
+not by this CLI, so the full and current set of commands and flags is
+documented at https://docs.limacharlie.io/8-reference/endpoint-commands.
 
 This command does not wait for a response.  To see results, use
 'limacharlie task request' (synchronous) or 'limacharlie stream events'.

--- a/limacharlie/help_topics.py
+++ b/limacharlie/help_topics.py
@@ -715,8 +715,9 @@ limacharlie tag add --sid <sid> --tag incident-2024-01
 # Send investigative tasks
 limacharlie task send --sid <sid> --task os_processes
 limacharlie task send --sid <sid> --task os_services
-limacharlie task send --sid <sid> --task dir_list --args '{"rootDir":"C:\\\\Users"}'
-limacharlie task send --sid <sid> --task file_hash --args '{"filePath":"C:\\\\suspect.exe"}'
+limacharlie task send --sid <sid> --task 'dir_list "C:\\\\Users" "*.exe"'
+limacharlie task send --sid <sid> --task 'file_hash "C:\\\\suspect.exe"'
+limacharlie task send --sid <sid> --task 'file_grep "C:\\\\Users" -p "<literal>" --no-content'
 
 # Search for IOCs
 limacharlie ioc search --type file_hash --value <sha256>


### PR DESCRIPTION
## Summary

Documentation only — **no functional change, and none is needed.**

The CLI does not parse or validate the task string. `task send` forwards it to the backend verbatim (`commands/task.py:127` → `sdk/sensor.py:118`), and the backend generates its own help from the command parser's argument definitions. So `dir_find`, `file_grep`, `container_list` and `artifact_get --root-dir` already work against the current CLI:

```
limacharlie task send --sid <SID> --task 'dir_find "C:\Users" -x "*.exe" --with-hashes'
```

What was missing is discoverability. This adds them to the `task send` command menu, which also feeds `--ai-help` through the explain registry.

I also noted the budget convention once: a bounded search stops at the first budget reached and reports it in `SCAN_IS_TRUNCATED` / `SCAN_STOPPED_REASON`, so an empty result is not necessarily a clean host.

Rather than inline ~15 flags per command — this menu has never carried flags for any command — the text points at the backend reference, which is the authority on them.

## Two pre-existing bugs, same lines

Both verified against the actual Click options rather than assumed:

- The `incident-response` cheatsheet (`help_topics.py`) told users to pass `--args` to `task send`, which accepts only `--sid`, `--task` and `--investigation-id`. Both examples errored out on copy-paste. Rewritten as task strings, matching the form the reference documentation uses.
- `doc/cli/sensor-management.md` used `task send --command`. `send` takes `--task`; `--command` belongs to `request` and `reliable-send`.

## Context

`repo_list` and `usb_list_devices` are also absent from this menu — this list has drifted from the backend for a while. I did not add them here to keep the change scoped, but they are worth a follow-up.

## Validation

- `pytest` — 4005 passed, 5 skipped
- Confirmed the rendered `--ai-help` text and cheatsheet output, not just the source