### PR TITLE
mailsec: bulk remediation across a caller-supplied selection

### DIFF
--- a/limacharlie/commands/_output_helpers.py
+++ b/limacharlie/commands/_output_helpers.py
@@ -23,3 +23,20 @@ def command_output(ctx: click.Context, data: Any) -> None:
     fmt = ctx.obj.output_format or detect_output_format()
     if not ctx.obj.quiet:
         click.echo(format_output(data, fmt))
+
+
+def note(ctx: click.Context, text: str) -> None:
+    """Narrate one line to STDERR, suppressed by --quiet.
+
+    The counterpart to :func:`command_output`, and the reason it exists is the
+    split: a command that makes several calls and prints each of them emits
+    several documents where ``--output json`` promises one. Progress, warnings
+    and the handle for a job that is still running belong beside the operator on
+    stderr; the result belongs in the pipe.
+
+    Args:
+        ctx: Click context carrying obj.quiet.
+        text: The line to narrate.
+    """
+    if not ctx.obj.quiet:
+        click.echo(text, err=True)

--- a/limacharlie/commands/mailsec.py
+++ b/limacharlie/commands/mailsec.py
@@ -32,8 +32,7 @@ post-save preflight (``mailsec connection test``) and the served setup guide
 from __future__ import annotations
 
 import json
-import sys
-import time
+import re
 from typing import Any
 
 import click
@@ -44,6 +43,8 @@ from ..sdk.organization import Organization
 from ..sdk.mailsec import BULK_ACTIONS, Mailsec, normalize_bulk_selection
 from ..output import format_output, detect_output_format
 from ..discovery import register_explain
+from ._input_helpers import load_file, load_stdin
+from ._output_helpers import note
 
 
 # ---------------------------------------------------------------------------
@@ -174,26 +175,56 @@ on all of them at once. Up to 500 per call — a larger selection is
 REFUSED, not truncated, because acting on the first 500 of 900 leaves
 the rest in inboxes nobody will look at. Split it yourself.
 
-PREVIEWS FIRST, ALWAYS. The preview reads the index and reports, per
-message, whether it still exists, where it is now, and whether it is
-already where the action would put it — plus the distinct-mailbox count,
-which is the blast radius you are actually approving. Then it asks. Pass
---yes to skip the question in a script, or --preview-only to stop there.
+TWO STEPS, like `campaign action` and `hunt remediate`:
 
-The preview's `confirm` token is DERIVED FROM THE EXACT SELECTION, not
-issued as a nonce, so it can only execute the set you read. This command
-reuses one normalized list for both calls, so that holds by construction;
-if you two-step it by hand, feed --confirm the identical --msg-uuids.
+  omit --confirm         preview only; nothing is changed
+  --confirm <token>      execute the previewed selection
+
+The preview reads the index and reports, per message, whether it still
+exists, where it is now, and whether it is already where the action would
+put it — plus the distinct-mailbox count, which is the blast radius you
+are actually approving. It prints on stdout, `confirm` token included, so
+a script reads step one's answer and passes it to step two.
+
+The token is DERIVED FROM (action, attempt, the normalized member list),
+not issued as a nonce, so it can only execute what you previewed. The
+execute must therefore repeat the IDENTICAL --action, --msg-uuids and
+--attempt the preview was minted with; change any of the three and the
+server refuses the token as stale rather than acting on a set nobody read.
 
 Expired ids and already-done messages are REPORTED, not errors and not
 dropped. They stay in the confirmed set, and the provider re-checks each
 one and answers `skipped` — the index only records where remediation last
 put a message, and its owner may have moved it since.
 
+Ids must be message UUIDs. A selection that carries anything else — the
+header row and second column of a pasted CSV are the usual way this
+happens — is refused by name, because a phantom id comes back from the
+preview as "NOT IN INDEX", identical to a legitimately expired one, and
+the counts you would be consenting over would be wrong.
+
 Execution is ASYNCHRONOUS: 500 provider writes paced to respect Microsoft
 365 / Google throttling cannot fit in one request. You get a bulk_id back
-immediately; --wait (the default) polls until the job settles. Partial
-failure is a normal, honestly-reported outcome, never a rollback.
+immediately (announced on stderr before the first poll, so a poll that
+fails still leaves you the handle); --wait (the default) polls until the
+job settles. Partial failure is a normal, honestly-reported outcome,
+never a rollback.
+
+THE EXIT CODE CARRIES THE OUTCOME, so `&&` means what it looks like:
+
+  0    complete, with at least one message acted on (or --no-wait, or a
+       preview that produced a token)
+  !=0  not accepted; complete but every attempt failed; interrupted;
+       stalled; still running at the timeout; or a poll that errored
+
+A stalled job is the one worth knowing: the worker that accepted it is
+gone. Re-send the same execute request with the same confirmation token
+to finish it — every message already acted on collapses onto its existing
+action row rather than being acted on twice.
+
+--quiet silences both streams, as everywhere in this CLI. With it, the
+exit code above and `mailsec message bulk-status <bulk_id>` are how you
+read the result.
 
 There is no --reason: the execute route does not carry one, and a
 justification that never reaches the audit trail would be worse than an
@@ -201,10 +232,12 @@ absent one. Use `mailsec message action --reason` per message when the
 reason matters.
 
 Examples:
-  limacharlie mailsec message bulk-action --action trash_message --msg-uuids a,b,c
-  limacharlie mailsec message bulk-action --action quarantine_message --input-file uuids.txt --yes
-  limacharlie mailsec message bulk-action --action quarantine_message --msg-uuids a,b --preview-only
-  limacharlie mailsec message bulk-action --action quarantine_message --msg-uuids a,b --confirm 3f31ed...
+  limacharlie mailsec message bulk-action --action trash_message --msg-uuids 0057db2b-3a06-5aab-b3be-c1e6c15dcf10
+  limacharlie mailsec message bulk-action --action quarantine_message --input-file uuids.txt
+  limacharlie mailsec message list --verdict malicious --output json \\
+    | jq -r '.messages[].msg_uuid' \\
+    | limacharlie mailsec message bulk-action --action quarantine_message --input-file -
+  limacharlie mailsec message bulk-action --action quarantine_message --msg-uuids 0057db2b-... --confirm 3f31ed...
 """
 
 _EXPLAIN_MESSAGE_BULK_STATUS = """\
@@ -216,10 +249,10 @@ failures is complete, because what a poller asks is whether anything is
 still moving.
 
 stalled:true means the worker that accepted the job is gone — the record
-has not been heartbeaten within its window. The repair is one more
-execute with the SAME confirmation and the same selection: every message
-already acted on collapses onto its existing action row rather than being
-acted on twice.
+has not been heartbeaten within its window. The repair is to re-send the
+same execute request with the same confirmation token to finish it: every
+message already acted on collapses onto its existing action row rather
+than being acted on twice.
 
 Each item carries the action_id of its authoritative audit row, which
 `mailsec action get` expands. items is a projection of the job record and
@@ -462,26 +495,72 @@ def _load_json_file(path: str, param_hint: str) -> Any:
         raise click.BadParameter(f"{path} is not valid JSON: {e}", param_hint=param_hint)
 
 
-def _note(ctx: click.Context, text: str) -> None:
-    """Narrate to STDERR.
-
-    Deliberately not stdout: a bulk action makes three calls, and a command that
-    printed each of them would emit three documents where `--output json` promises
-    one. Progress belongs beside the operator, the result belongs in the pipe.
-    Suppressed by --quiet, like every other narration in this CLI.
-    """
-    if not ctx.obj.quiet:
-        click.echo(text, err=True)
-
-
 def _split_ids(text: str) -> list[str]:
-    """Split a selection on commas and whitespace, dropping blanks.
+    """Split one --msg-uuids value on commas, trimming each item.
 
-    Both separators, because the two sources this reads spell a list differently:
-    a shell argument is `a,b,c` and a file is one id per line. Accepting either
-    everywhere means a caller never has to know which parser they landed in.
+    Comma-only, matching every other repeatable-and-comma-separated option in
+    this CLI. It TRIMS around items rather than splitting ON whitespace, so a
+    shell-quoted `"a, b"` is two ids and a value that somehow contains a space
+    stays one token — which is what lets the shape check below name it instead
+    of silently turning one bad paste into several plausible-looking members.
     """
-    return [part for chunk in text.split(",") for part in chunk.split() if part]
+    return [part.strip() for part in text.split(",") if part.strip()]
+
+
+def _ids_from_document(value: Any, hint: str) -> list[str]:
+    """Pull message ids out of a parsed --input-file / stdin document.
+
+    The file goes through the shared YAML-or-JSON loader, so a caller can hand
+    us a JSON array, a YAML list, or the ordinary one-id-per-line file. That
+    last one parses as a single folded scalar — YAML turns its line breaks into
+    spaces — so splitting the scalar on whitespace here is restoring the file's
+    own line separators, not the flag-splitting rule above.
+    """
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [part for line in value.split() for part in _split_ids(line)]
+    if isinstance(value, (list, tuple)):
+        ids: list[str] = []
+        for item in value:
+            if not isinstance(item, str):
+                raise click.BadParameter(
+                    f"expected message ids; found a {type(item).__name__}", param_hint=hint,
+                )
+            ids.extend(part for line in item.split() for part in _split_ids(line))
+        return ids
+    raise click.BadParameter(
+        f"expected a list of message ids or one id per line; found a {type(value).__name__}",
+        param_hint=hint,
+    )
+
+
+# A msg_uuid is a UUID the backend derives; nothing else is one.
+_MSG_UUID_RE = re.compile(
+    r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+)
+
+
+def _reject_non_message_ids(ids: list[str]) -> None:
+    """Refuse a selection carrying anything that is not a message id.
+
+    Shape-checking input is usually the server's job, but not here, because the
+    server's answer is INDISTINGUISHABLE from a legitimate one: a phantom member
+    comes back from the preview as "NOT IN INDEX", exactly like an id that
+    expired past the 35-day retention. The member_count and mailbox_count a human
+    is consenting over would silently be wrong.
+
+    The way this happens in practice is a pasted CSV export: the header row and
+    the second column become members. So the first offending token is named, in
+    the order it was given, rather than reported as a count.
+    """
+    for value in ids:
+        if not _MSG_UUID_RE.match(value):
+            raise click.UsageError(
+                f"'{value}' does not look like a message id: expected a UUID such as "
+                "0057db2b-3a06-5aab-b3be-c1e6c15dcf10. A selection pasted out of a CSV "
+                "usually needs its header row and its other columns removed."
+            )
 
 
 def _bulk_selection(msg_uuids: tuple[str, ...], input_file: str | None) -> list[str]:
@@ -490,22 +569,31 @@ def _bulk_selection(msg_uuids: tuple[str, ...], input_file: str | None) -> list[
     Normalized once and reused, never rebuilt between the preview and the execute:
     the confirmation token is derived from the member list, so a second derivation
     is a second chance to disagree with the set a human just approved.
+
+    Three sources, in the CLI's usual order of explicitness: the flag, a named
+    file (``-`` being stdin), and — following the hive commands' idiom — a pipe,
+    when nothing was named and stdin is not a terminal.
     """
-    raw = list(msg_uuids)
-    if input_file:
-        try:
-            with open(input_file, "r", encoding="utf-8") as f:
-                raw.append(f.read())
-        except OSError as e:
-            raise click.BadParameter(f"cannot read {input_file}: {e}", param_hint="--input-file")
     ids: list[str] = []
-    for chunk in raw:
+    for chunk in msg_uuids:
         ids.extend(_split_ids(chunk))
+    if input_file == "-":
+        ids.extend(_ids_from_document(load_stdin(), "stdin"))
+    elif input_file:
+        ids.extend(_ids_from_document(load_file(input_file, "--input-file"), "--input-file"))
+    elif not ids:
+        ids.extend(_ids_from_document(load_stdin(), "stdin"))
+    if not ids:
+        # An empty selection is a usage mistake, not a backend one, and it is
+        # worth saying so before a round trip that would only agree.
+        raise click.UsageError(
+            "a bulk action needs at least one msg_uuid: pass --msg-uuids, --input-file, "
+            "or pipe ids on stdin"
+        )
+    _reject_non_message_ids(ids)
     try:
         return normalize_bulk_selection(ids)
     except ValueError as e:
-        # An empty selection is a usage mistake, not a backend one, and it is
-        # worth saying so before a round trip that would only agree.
         raise click.UsageError(f"{e}: pass --msg-uuids and/or --input-file")
 
 
@@ -517,33 +605,62 @@ def _echo_bulk_preview(ctx: click.Context, preview: dict) -> None:
     operator is being asked to approve.
     """
     summary = preview.get("summary") or {}
-    _note(ctx, "")
-    _note(ctx, f"action:        {preview.get('action')}")
+    note(ctx, "")
+    note(ctx, f"action:        {preview.get('action')}")
     if preview.get("has_target_state"):
-        _note(ctx, f"target state:  {preview.get('target_state')}")
-    _note(ctx, f"selected:      {preview.get('member_count')} of at most {preview.get('cap')}")
-    _note(ctx, f"mailboxes:     {summary.get('mailbox_count')}")
+        note(ctx, f"target state:  {preview.get('target_state')}")
+    note(ctx, f"selected:      {preview.get('member_count')} of at most {preview.get('cap')}")
+    note(ctx, f"mailboxes:     {summary.get('mailbox_count')}")
     by_provider = summary.get("by_provider") or {}
     if by_provider:
-        _note(ctx, "providers:     " + ", ".join(f"{k}={v}" for k, v in sorted(by_provider.items())))
-    _note(
+        note(ctx, "providers:     " + ", ".join(f"{k}={v}" for k, v in sorted(by_provider.items())))
+    note(
         ctx,
         f"actionable:    {summary.get('actionable')}   "
         f"(already in target state: {summary.get('already_in_target_state')}, "
         f"no longer indexed: {summary.get('missing')})",
     )
-    _note(ctx, "")
+    note(ctx, "")
     for m in preview.get("messages") or []:
         if not m.get("exists"):
-            _note(ctx, f"  {m.get('msg_uuid')}  NOT IN INDEX (expired past retention, or never ingested)")
+            note(ctx, f"  {m.get('msg_uuid')}  NOT IN INDEX (expired past retention, or never ingested)")
             continue
         flag = "  already in target state" if m.get("already_in_target_state") else ""
-        _note(
+        note(
             ctx,
             f"  {m.get('msg_uuid')}  state={m.get('state')} "
             f"mailbox={m.get('mailbox')} provider={m.get('provider')}{flag}",
         )
-    _note(ctx, "")
+    note(ctx, "")
+    if preview.get("confirm"):
+        note(ctx, f"confirm:       {preview.get('confirm')}")
+        note(ctx, "")
+
+
+def _output_preview(ctx: click.Context, preview: dict) -> None:
+    """Emit the preview document without the table renderer's lossy summarising.
+
+    Now that the preview IS the default output of this verb, the format matters.
+    The table renderer flattens a record to one row per key and renders any
+    nested value as a placeholder: measured on this document, `messages` becomes
+    "[2 items]" and `summary` becomes "{7 keys}". Those two ARE the preview — the
+    per-message placement and the mailbox count are the blast radius the operator
+    is being asked to approve — so a table renders away the entire point.
+
+    (The `confirm` token itself survives: the gateway's token is 32 hex
+    characters and the renderer's cell width is never below 40. It is printed on
+    stderr as well, by :func:`_echo_bulk_preview`, so a copy-paste never depends
+    on that arithmetic staying true.)
+
+    So the human rendering of a preview is the stderr report, and the document on
+    stdout falls back to JSON when the format would have been a table. Every
+    other format round-trips nested values whole and is left alone.
+    """
+    fmt = ctx.obj.output_format or detect_output_format()
+    if fmt == "table":
+        fmt = "json"
+    if not ctx.obj.quiet:
+        click.echo(format_output(preview, fmt))
 
 
 def _bulk_state_line(status: dict) -> str:
@@ -556,43 +673,69 @@ def _bulk_state_line(status: dict) -> str:
 
 
 def _wait_for_bulk(ctx: click.Context, ms: Mailsec, bulk_id: str, timeout: int,
-                   poll_interval: float) -> dict:
-    """Poll a bulk job until it settles, bounded by *timeout*.
+                   poll_interval: int) -> dict:
+    """Poll a bulk job until it settles, narrating each poll.
 
-    Every exit emits exactly one terminal line — settled, stalled, or timed out —
-    so a watcher never ends in silence and a caller never has to infer which of
-    the three happened from the absence of the other two.
-
-    `stalled` is terminal HERE even though the job is not finished, because there
-    is deliberately no automatic resumption: the record is not being heartbeaten,
-    so no amount of further polling will move it. The repair is stated instead.
+    The loop itself lives in the SDK (:meth:`Mailsec.wait_for_bulk`), where a
+    caller that is not this CLI can have it too. This is the narration half:
+    progress lines while the job is moving, and nothing at the end, because the
+    single terminal line is :func:`_bulk_outcome`'s to write next to the exit
+    code it chooses.
     """
-    deadline = time.monotonic() + timeout
-    status = ms.bulk_action_status(bulk_id)
-    while True:
-        if status.get("state") != "running":
-            _note(ctx, f"bulk {bulk_id} settled: {_bulk_state_line(status)}")
-            return status
-        if status.get("stalled"):
-            _note(
+    def _on_poll(status: dict) -> None:
+        if status.get("state") == "running" and not status.get("stalled"):
+            note(ctx, f"bulk {bulk_id} {_bulk_state_line(status)}")
+
+    return ms.wait_for_bulk(bulk_id, timeout=timeout, poll_interval=poll_interval,
+                            on_poll=_on_poll)
+
+
+def _bulk_outcome(ctx: click.Context, bulk_id: str, status: dict, timeout: int) -> int:
+    """Say how the job ended, once, and return the exit code that means it.
+
+    Exactly one terminal line per exit, so a watcher never ends in silence, and
+    the code is the machine-readable half of the same sentence: a runbook chained
+    with `&&` must stop when nothing was remediated, and must not stop merely
+    because some members were already where the action would have put them.
+    """
+    line = _bulk_state_line(status)
+    counts = status.get("counts") or {}
+    if status.get("stalled"):
+        note(
+            ctx,
+            f"bulk {bulk_id} is STALLED: {line} — no worker has touched it within its "
+            f"heartbeat window. Re-send the same execute request with the same confirmation "
+            f"token to finish it; nothing is acted on twice.",
+        )
+        return 1
+    if status.get("state") == "interrupted":
+        note(
+            ctx,
+            f"bulk {bulk_id} settled: {line} — INTERRUPTED: the job was finalized before "
+            f"every member was acted on. The outcomes above are real; inspect them with "
+            f"`limacharlie mailsec message bulk-status {bulk_id}`.",
+        )
+        return 1
+    if status.get("state") == "complete":
+        # Per-item failures inside an otherwise successful batch are the caller's
+        # data, not an error. Zero successes and at least one failure is not:
+        # nothing was remediated, and a chained command must not run as if it was.
+        if not counts.get("ok") and counts.get("failed"):
+            note(
                 ctx,
-                f"bulk {bulk_id} is STALLED: {_bulk_state_line(status)} — no worker has "
-                f"touched it within its heartbeat window. Re-send the same execute with the "
-                f"same --confirm and --msg-uuids to finish it; nothing is acted on twice.",
+                f"bulk {bulk_id} settled: {line} — NOTHING WAS REMEDIATED: every attempted "
+                f"member failed. `limacharlie mailsec message bulk-status {bulk_id}` has the "
+                f"per-message reason.",
             )
-            return status
-        remaining = deadline - time.monotonic()
-        if remaining <= 0:
-            _note(
-                ctx,
-                f"bulk {bulk_id} still running after {timeout}s: {_bulk_state_line(status)} — "
-                f"the job is unaffected; keep polling with "
-                f"`limacharlie mailsec message bulk-status {bulk_id}`",
-            )
-            return status
-        _note(ctx, f"bulk {bulk_id} {_bulk_state_line(status)}")
-        time.sleep(min(poll_interval, remaining))
-        status = ms.bulk_action_status(bulk_id)
+            return 1
+        note(ctx, f"bulk {bulk_id} settled: {line}")
+        return 0
+    note(
+        ctx,
+        f"bulk {bulk_id} still running after {timeout}s: {line} — the job is unaffected; "
+        f"keep polling with `limacharlie mailsec message bulk-status {bulk_id}`",
+    )
+    return 1
 
 
 def _tri_state(flag: bool, no_flag: bool, name: str) -> bool | None:
@@ -912,47 +1055,46 @@ def message_revisions(ctx, msg_uuid) -> None:
               help="The action to apply to every selected message: " + "|".join(BULK_ACTIONS) + ".")
 @click.option("--msg-uuids", "msg_uuids", multiple=True,
               help="Message ids, comma-separated and/or repeatable. Combined with --input-file.")
-@click.option("--input-file", default=None, type=click.Path(exists=True, dir_okay=False),
-              help="File of message ids, one per line (commas also accepted).")
+@click.option("--input-file", default=None,
+              type=click.Path(exists=True, dir_okay=False, allow_dash=True),
+              help="File of message ids: a JSON/YAML list, or one per line. '-' reads stdin, and "
+                   "stdin is also read when neither this nor --msg-uuids is given.")
 @click.option("--attempt", default=None,
               help="Idempotency token. It is part of the confirmation, so a NEW attempt over the "
                    "same selection is a deliberate second run rather than a re-run of the first.")
 @click.option("--banner", default=None, help="Banner HTML, for banner_message. Applies to the whole batch.")
 @click.option("--confirm", default=None,
-              help="Execute directly with a token from an earlier --preview-only, skipping this "
-                   "command's own preview. The token is bound to the selection it was minted over, "
-                   "so pass the identical --msg-uuids.")
-@click.option("--preview-only", is_flag=True, default=False,
-              help="Stop after the preview and print it, including the confirm token, so a script "
-                   "can review and then execute in a second call.")
-@click.option("--yes", "-y", is_flag=True, default=False,
-              help="Skip the interactive confirmation. The preview still runs and is still shown.")
+              help="Pass the token the preview returned to EXECUTE. Omit to preview. The token is "
+                   "derived from the action, the attempt and the member list, so the execute must "
+                   "repeat the identical --action, --msg-uuids and --attempt.")
 @click.option("--wait/--no-wait", default=True,
               help="Poll until the job settles (default), or return as soon as it is accepted.")
-@click.option("--timeout", default=300, type=int, help="Maximum seconds to wait (default: 300).")
-@click.option("--poll-interval", default=3.0, type=float, help="Seconds between polls (default: 3).")
+@click.option("--timeout", default=300, type=click.IntRange(min=5),
+              help="Maximum seconds to wait (default: 300).")
+@click.option("--poll-interval", default=3, type=click.IntRange(min=1),
+              help="Seconds between polls (default: 3).")
 @pass_context
 def message_bulk_action(ctx, action_name, msg_uuids, input_file, attempt, banner, confirm,
-                        preview_only, yes, wait, timeout, poll_interval) -> None:
+                        wait, timeout, poll_interval) -> None:
     """Remediate a set of messages you name, in bulk (mailsec.act).
 
     \b
-    Previews, asks, then executes asynchronously and polls. The preview's
-    confirm token is bound to the exact selection, so the set you approve
-    is the set that runs. Up to 500 per call; a larger one is refused
+    Previews unless --confirm is given, like `campaign action` and
+    `hunt remediate`. The preview prints its confirm token, which is
+    bound to the action, the attempt and the exact selection: repeat all
+    three on the execute. Up to 500 per call; a larger one is refused
     rather than truncated.
 
     \b
-    Example:
-      limacharlie mailsec message bulk-action --action trash_message --msg-uuids a,b,c
-      limacharlie mailsec message bulk-action --action quarantine_message --input-file uuids.txt --yes
-    """
-    if preview_only and confirm:
-        raise click.UsageError(
-            "--preview-only and --confirm are opposite halves of the same two-step: the first "
-            "mints a token, the second spends one"
-        )
+    The exit code carries the outcome: 0 for a completed job that acted on
+    something, non-zero for not-accepted, all-failed, interrupted, stalled,
+    timed-out, or a failed poll.
 
+    \b
+    Example:
+      limacharlie mailsec message bulk-action --action trash_message --msg-uuids 0057db2b-...
+      limacharlie mailsec message bulk-action --action trash_message --msg-uuids 0057db2b-... --confirm 3f31ed...
+    """
     # ONE list, normalized once, used by both calls. Rebuilding it between the
     # preview and the execute would be a second chance to disagree with the set
     # the operator just approved, which is exactly what the token exists to catch.
@@ -961,39 +1103,52 @@ def message_bulk_action(ctx, action_name, msg_uuids, input_file, attempt, banner
 
     if not confirm:
         preview = ms.bulk_action_preview(action_name, selection, attempt=attempt)
-        if preview_only:
-            _output(ctx, preview)
-            return
         _echo_bulk_preview(ctx, preview)
-        confirm = preview.get("confirm")
-        if not confirm:
-            raise click.ClickException("the preview returned no confirmation token; refusing to execute")
-        if not yes:
-            # Consent has to be given by someone who saw the preview. With --quiet
-            # it was suppressed, and off a TTY nobody is there to read it, so both
-            # are refused with the flag that says "I already decided" rather than
-            # prompted into a stream that cannot answer.
-            if ctx.obj.quiet or not sys.stdin.isatty():
-                raise click.UsageError(
-                    "not running interactively: pass --yes to execute without the prompt, or "
-                    "--preview-only to review the selection first"
-                )
-            click.confirm(
-                f"Apply {action_name} to {len(selection)} message(s)?",
-                abort=True, err=True,
-            )
+        _output_preview(ctx, preview)
+        return
 
     accepted = ms.bulk_action_execute(
         action_name, selection, confirm, attempt=attempt, banner=banner,
     )
     bulk_id = accepted.get("bulk_id")
-    if not wait or not bulk_id:
+    if not accepted.get("accepted") or not bulk_id:
+        # The response says it did not take the job. Reporting success here is
+        # how a runbook proceeds to its next step over mail nobody touched.
+        note(ctx, "the bulk execute was NOT accepted; nothing is running")
+        _output(ctx, accepted)
+        ctx.exit(1)
+        return
+
+    # The handle, on stderr, BEFORE anything that can fail. A poll that 502s
+    # after this still leaves the operator holding the id of a job that is
+    # running; one that 502s before it would have orphaned the job entirely.
+    note(ctx, f"bulk {bulk_id} accepted")
+    if not accepted.get("started", True):
+        note(ctx, f"bulk {bulk_id} already existed; adopting it rather than acting twice")
+
+    if not wait:
         _output(ctx, accepted)
         return
 
-    if not accepted.get("started", True):
-        _note(ctx, f"bulk {bulk_id} already existed; adopting it rather than acting twice")
-    _output(ctx, _wait_for_bulk(ctx, ms, bulk_id, timeout, poll_interval))
+    try:
+        status = _wait_for_bulk(ctx, ms, bulk_id, timeout, poll_interval)
+    except Exception as e:
+        note(ctx, f"bulk {bulk_id} accepted, but polling it failed: {e}")
+        note(
+            ctx,
+            f"the job is unaffected; resume with: "
+            f"limacharlie mailsec message bulk-status {bulk_id}",
+        )
+        # The acceptance is what stdout has to carry: it is the document that
+        # holds the bulk_id, and stdout stays one parseable document either way.
+        _output(ctx, accepted)
+        ctx.exit(1)
+        return
+
+    _output(ctx, status)
+    code = _bulk_outcome(ctx, bulk_id, status, timeout)
+    if code:
+        ctx.exit(code)
 
 
 @message_group.command("bulk-status")

--- a/limacharlie/commands/mailsec.py
+++ b/limacharlie/commands/mailsec.py
@@ -1,11 +1,11 @@
 """Email Security (mailsec) commands for LimaCharlie CLI v2.
 
 Commands for the ``/mailsec`` API surface: the coverage screen, the message
-index and its drawer, the justified raw-EML download, campaigns and
-campaign-wide sweeps, sender profiles, the action audit trail, the
-abuse-mailbox report queue, standalone EML analysis, retro-hunts, custom-rule
-validation and backtest, the connection preflight, and the served onboarding
-guide.
+index and its drawer, the justified raw-EML download, bulk remediation across a
+selection you name, campaigns and campaign-wide sweeps, sender profiles, the
+action audit trail, the abuse-mailbox report queue, standalone EML analysis,
+retro-hunts, custom-rule validation and backtest, the connection preflight, and
+the served onboarding guide.
 
 Four permissions rather than the usual get/set pair, because mailsec asks to be
 trusted with four different things:
@@ -32,6 +32,8 @@ post-save preflight (``mailsec connection test``) and the served setup guide
 from __future__ import annotations
 
 import json
+import sys
+import time
 from typing import Any
 
 import click
@@ -39,7 +41,7 @@ import click
 from ..cli import pass_context
 from ..client import Client
 from ..sdk.organization import Organization
-from ..sdk.mailsec import Mailsec
+from ..sdk.mailsec import BULK_ACTIONS, Mailsec, normalize_bulk_selection
 from ..output import format_output, detect_output_format
 from ..discovery import register_explain
 
@@ -161,6 +163,71 @@ over time.
 
 Examples:
   limacharlie mailsec message revisions 0057db2b-...
+"""
+
+_EXPLAIN_MESSAGE_BULK_ACTION = """\
+Remediate a set of messages you name, in bulk. Requires mailsec.act.
+
+This is what turns a search result into provider-side action: pipe ids
+out of `mailsec message list`, or paste a selection into a file, and act
+on all of them at once. Up to 500 per call — a larger selection is
+REFUSED, not truncated, because acting on the first 500 of 900 leaves
+the rest in inboxes nobody will look at. Split it yourself.
+
+PREVIEWS FIRST, ALWAYS. The preview reads the index and reports, per
+message, whether it still exists, where it is now, and whether it is
+already where the action would put it — plus the distinct-mailbox count,
+which is the blast radius you are actually approving. Then it asks. Pass
+--yes to skip the question in a script, or --preview-only to stop there.
+
+The preview's `confirm` token is DERIVED FROM THE EXACT SELECTION, not
+issued as a nonce, so it can only execute the set you read. This command
+reuses one normalized list for both calls, so that holds by construction;
+if you two-step it by hand, feed --confirm the identical --msg-uuids.
+
+Expired ids and already-done messages are REPORTED, not errors and not
+dropped. They stay in the confirmed set, and the provider re-checks each
+one and answers `skipped` — the index only records where remediation last
+put a message, and its owner may have moved it since.
+
+Execution is ASYNCHRONOUS: 500 provider writes paced to respect Microsoft
+365 / Google throttling cannot fit in one request. You get a bulk_id back
+immediately; --wait (the default) polls until the job settles. Partial
+failure is a normal, honestly-reported outcome, never a rollback.
+
+There is no --reason: the execute route does not carry one, and a
+justification that never reaches the audit trail would be worse than an
+absent one. Use `mailsec message action --reason` per message when the
+reason matters.
+
+Examples:
+  limacharlie mailsec message bulk-action --action trash_message --msg-uuids a,b,c
+  limacharlie mailsec message bulk-action --action quarantine_message --input-file uuids.txt --yes
+  limacharlie mailsec message bulk-action --action quarantine_message --msg-uuids a,b --preview-only
+  limacharlie mailsec message bulk-action --action quarantine_message --msg-uuids a,b --confirm 3f31ed...
+"""
+
+_EXPLAIN_MESSAGE_BULK_STATUS = """\
+A bulk action's progress and per-message outcomes.
+
+state is 'running', 'complete' or 'interrupted', and it answers a
+different question from the outcome: a job that finished with six
+failures is complete, because what a poller asks is whether anything is
+still moving.
+
+stalled:true means the worker that accepted the job is gone — the record
+has not been heartbeaten within its window. The repair is one more
+execute with the SAME confirmation and the same selection: every message
+already acted on collapses onto its existing action row rather than being
+acted on twice.
+
+Each item carries the action_id of its authoritative audit row, which
+`mailsec action get` expands. items is a projection of the job record and
+can lag by up to one heartbeat; it says so (items_source) rather than
+presenting itself as the audit trail.
+
+Examples:
+  limacharlie mailsec message bulk-status 8f1c2d3e4a5b6c7d8e9f0a1b2c3d4e5f
 """
 
 _EXPLAIN_CAMPAIGN_LIST = """\
@@ -395,6 +462,139 @@ def _load_json_file(path: str, param_hint: str) -> Any:
         raise click.BadParameter(f"{path} is not valid JSON: {e}", param_hint=param_hint)
 
 
+def _note(ctx: click.Context, text: str) -> None:
+    """Narrate to STDERR.
+
+    Deliberately not stdout: a bulk action makes three calls, and a command that
+    printed each of them would emit three documents where `--output json` promises
+    one. Progress belongs beside the operator, the result belongs in the pipe.
+    Suppressed by --quiet, like every other narration in this CLI.
+    """
+    if not ctx.obj.quiet:
+        click.echo(text, err=True)
+
+
+def _split_ids(text: str) -> list[str]:
+    """Split a selection on commas and whitespace, dropping blanks.
+
+    Both separators, because the two sources this reads spell a list differently:
+    a shell argument is `a,b,c` and a file is one id per line. Accepting either
+    everywhere means a caller never has to know which parser they landed in.
+    """
+    return [part for chunk in text.split(",") for part in chunk.split() if part]
+
+
+def _bulk_selection(msg_uuids: tuple[str, ...], input_file: str | None) -> list[str]:
+    """Build the ONE normalized selection both bulk calls will use.
+
+    Normalized once and reused, never rebuilt between the preview and the execute:
+    the confirmation token is derived from the member list, so a second derivation
+    is a second chance to disagree with the set a human just approved.
+    """
+    raw = list(msg_uuids)
+    if input_file:
+        try:
+            with open(input_file, "r", encoding="utf-8") as f:
+                raw.append(f.read())
+        except OSError as e:
+            raise click.BadParameter(f"cannot read {input_file}: {e}", param_hint="--input-file")
+    ids: list[str] = []
+    for chunk in raw:
+        ids.extend(_split_ids(chunk))
+    try:
+        return normalize_bulk_selection(ids)
+    except ValueError as e:
+        # An empty selection is a usage mistake, not a backend one, and it is
+        # worth saying so before a round trip that would only agree.
+        raise click.UsageError(f"{e}: pass --msg-uuids and/or --input-file")
+
+
+def _echo_bulk_preview(ctx: click.Context, preview: dict) -> None:
+    """Render the preview for a human to consent from, on stderr.
+
+    Every member is listed rather than a head of them: the point of this screen
+    is the blast radius, and a truncated one under-reports exactly the thing the
+    operator is being asked to approve.
+    """
+    summary = preview.get("summary") or {}
+    _note(ctx, "")
+    _note(ctx, f"action:        {preview.get('action')}")
+    if preview.get("has_target_state"):
+        _note(ctx, f"target state:  {preview.get('target_state')}")
+    _note(ctx, f"selected:      {preview.get('member_count')} of at most {preview.get('cap')}")
+    _note(ctx, f"mailboxes:     {summary.get('mailbox_count')}")
+    by_provider = summary.get("by_provider") or {}
+    if by_provider:
+        _note(ctx, "providers:     " + ", ".join(f"{k}={v}" for k, v in sorted(by_provider.items())))
+    _note(
+        ctx,
+        f"actionable:    {summary.get('actionable')}   "
+        f"(already in target state: {summary.get('already_in_target_state')}, "
+        f"no longer indexed: {summary.get('missing')})",
+    )
+    _note(ctx, "")
+    for m in preview.get("messages") or []:
+        if not m.get("exists"):
+            _note(ctx, f"  {m.get('msg_uuid')}  NOT IN INDEX (expired past retention, or never ingested)")
+            continue
+        flag = "  already in target state" if m.get("already_in_target_state") else ""
+        _note(
+            ctx,
+            f"  {m.get('msg_uuid')}  state={m.get('state')} "
+            f"mailbox={m.get('mailbox')} provider={m.get('provider')}{flag}",
+        )
+    _note(ctx, "")
+
+
+def _bulk_state_line(status: dict) -> str:
+    counts = status.get("counts") or {}
+    parts = ", ".join(
+        f"{k}={counts[k]}" for k in ("ok", "skipped", "failed", "alert_only", "not_found", "pending")
+        if k in counts
+    )
+    return f"state={status.get('state')} {parts}".rstrip()
+
+
+def _wait_for_bulk(ctx: click.Context, ms: Mailsec, bulk_id: str, timeout: int,
+                   poll_interval: float) -> dict:
+    """Poll a bulk job until it settles, bounded by *timeout*.
+
+    Every exit emits exactly one terminal line — settled, stalled, or timed out —
+    so a watcher never ends in silence and a caller never has to infer which of
+    the three happened from the absence of the other two.
+
+    `stalled` is terminal HERE even though the job is not finished, because there
+    is deliberately no automatic resumption: the record is not being heartbeaten,
+    so no amount of further polling will move it. The repair is stated instead.
+    """
+    deadline = time.monotonic() + timeout
+    status = ms.bulk_action_status(bulk_id)
+    while True:
+        if status.get("state") != "running":
+            _note(ctx, f"bulk {bulk_id} settled: {_bulk_state_line(status)}")
+            return status
+        if status.get("stalled"):
+            _note(
+                ctx,
+                f"bulk {bulk_id} is STALLED: {_bulk_state_line(status)} — no worker has "
+                f"touched it within its heartbeat window. Re-send the same execute with the "
+                f"same --confirm and --msg-uuids to finish it; nothing is acted on twice.",
+            )
+            return status
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            _note(
+                ctx,
+                f"bulk {bulk_id} still running after {timeout}s: {_bulk_state_line(status)} — "
+                f"the job is unaffected; keep polling with "
+                f"`limacharlie mailsec message bulk-status {bulk_id}`",
+            )
+            return status
+        _note(ctx, f"bulk {bulk_id} {_bulk_state_line(status)}")
+        time.sleep(min(poll_interval, remaining))
+        status = ms.bulk_action_status(bulk_id)
+
+
 def _tri_state(flag: bool, no_flag: bool, name: str) -> bool | None:
     """Resolve a --x / --no-x pair into a tri-state.
 
@@ -425,7 +625,8 @@ def group() -> None:
 
     \b
       coverage            Mailbox coverage and analysed volume
-      message ...         The triage queue, drawer, raw EML, similar, actions, revise
+      message ...         The triage queue, drawer, raw EML, similar, actions,
+                          revise, and bulk remediation of a selection
       campaign ...        Campaigns and campaign-wide sweeps
       sender get          A sender's history with this org
       action get          One record from the action audit trail
@@ -440,7 +641,8 @@ def group() -> None:
 
 @group.group("message")
 def message_group() -> None:
-    """The message index, drawer, raw EML, similar mail, actions, verdict revision."""
+    """The message index, drawer, raw EML, similar mail, actions, verdict revision,
+    and bulk remediation across a selection you name."""
 
 
 @group.group("campaign")
@@ -703,6 +905,112 @@ def message_revisions(ctx, msg_uuid) -> None:
       limacharlie mailsec message revisions 0057db2b-...
     """
     _output(ctx, _get_mailsec(ctx).list_revisions(msg_uuid))
+
+
+@message_group.command("bulk-action")
+@click.option("--action", "action_name", required=True,
+              help="The action to apply to every selected message: " + "|".join(BULK_ACTIONS) + ".")
+@click.option("--msg-uuids", "msg_uuids", multiple=True,
+              help="Message ids, comma-separated and/or repeatable. Combined with --input-file.")
+@click.option("--input-file", default=None, type=click.Path(exists=True, dir_okay=False),
+              help="File of message ids, one per line (commas also accepted).")
+@click.option("--attempt", default=None,
+              help="Idempotency token. It is part of the confirmation, so a NEW attempt over the "
+                   "same selection is a deliberate second run rather than a re-run of the first.")
+@click.option("--banner", default=None, help="Banner HTML, for banner_message. Applies to the whole batch.")
+@click.option("--confirm", default=None,
+              help="Execute directly with a token from an earlier --preview-only, skipping this "
+                   "command's own preview. The token is bound to the selection it was minted over, "
+                   "so pass the identical --msg-uuids.")
+@click.option("--preview-only", is_flag=True, default=False,
+              help="Stop after the preview and print it, including the confirm token, so a script "
+                   "can review and then execute in a second call.")
+@click.option("--yes", "-y", is_flag=True, default=False,
+              help="Skip the interactive confirmation. The preview still runs and is still shown.")
+@click.option("--wait/--no-wait", default=True,
+              help="Poll until the job settles (default), or return as soon as it is accepted.")
+@click.option("--timeout", default=300, type=int, help="Maximum seconds to wait (default: 300).")
+@click.option("--poll-interval", default=3.0, type=float, help="Seconds between polls (default: 3).")
+@pass_context
+def message_bulk_action(ctx, action_name, msg_uuids, input_file, attempt, banner, confirm,
+                        preview_only, yes, wait, timeout, poll_interval) -> None:
+    """Remediate a set of messages you name, in bulk (mailsec.act).
+
+    \b
+    Previews, asks, then executes asynchronously and polls. The preview's
+    confirm token is bound to the exact selection, so the set you approve
+    is the set that runs. Up to 500 per call; a larger one is refused
+    rather than truncated.
+
+    \b
+    Example:
+      limacharlie mailsec message bulk-action --action trash_message --msg-uuids a,b,c
+      limacharlie mailsec message bulk-action --action quarantine_message --input-file uuids.txt --yes
+    """
+    if preview_only and confirm:
+        raise click.UsageError(
+            "--preview-only and --confirm are opposite halves of the same two-step: the first "
+            "mints a token, the second spends one"
+        )
+
+    # ONE list, normalized once, used by both calls. Rebuilding it between the
+    # preview and the execute would be a second chance to disagree with the set
+    # the operator just approved, which is exactly what the token exists to catch.
+    selection = _bulk_selection(msg_uuids, input_file)
+    ms = _get_mailsec(ctx)
+
+    if not confirm:
+        preview = ms.bulk_action_preview(action_name, selection, attempt=attempt)
+        if preview_only:
+            _output(ctx, preview)
+            return
+        _echo_bulk_preview(ctx, preview)
+        confirm = preview.get("confirm")
+        if not confirm:
+            raise click.ClickException("the preview returned no confirmation token; refusing to execute")
+        if not yes:
+            # Consent has to be given by someone who saw the preview. With --quiet
+            # it was suppressed, and off a TTY nobody is there to read it, so both
+            # are refused with the flag that says "I already decided" rather than
+            # prompted into a stream that cannot answer.
+            if ctx.obj.quiet or not sys.stdin.isatty():
+                raise click.UsageError(
+                    "not running interactively: pass --yes to execute without the prompt, or "
+                    "--preview-only to review the selection first"
+                )
+            click.confirm(
+                f"Apply {action_name} to {len(selection)} message(s)?",
+                abort=True, err=True,
+            )
+
+    accepted = ms.bulk_action_execute(
+        action_name, selection, confirm, attempt=attempt, banner=banner,
+    )
+    bulk_id = accepted.get("bulk_id")
+    if not wait or not bulk_id:
+        _output(ctx, accepted)
+        return
+
+    if not accepted.get("started", True):
+        _note(ctx, f"bulk {bulk_id} already existed; adopting it rather than acting twice")
+    _output(ctx, _wait_for_bulk(ctx, ms, bulk_id, timeout, poll_interval))
+
+
+@message_group.command("bulk-status")
+@click.argument("bulk_id")
+@pass_context
+def message_bulk_status(ctx, bulk_id) -> None:
+    """A bulk action's progress and per-message outcomes.
+
+    \b
+    state is running|complete|interrupted. stalled:true means the worker
+    is gone — re-send the same execute to finish it.
+
+    \b
+    Example:
+      limacharlie mailsec message bulk-status 8f1c2d3e4a5b6c7d8e9f0a1b2c3d4e5f
+    """
+    _output(ctx, _get_mailsec(ctx).bulk_action_status(bulk_id))
 
 
 # ---------------------------------------------------------------------------
@@ -1017,6 +1325,8 @@ register_explain("mailsec.message.similar", _EXPLAIN_MESSAGE_SIMILAR)
 register_explain("mailsec.message.action", _EXPLAIN_MESSAGE_ACTION)
 register_explain("mailsec.message.revise", _EXPLAIN_MESSAGE_REVISE)
 register_explain("mailsec.message.revisions", _EXPLAIN_MESSAGE_REVISIONS)
+register_explain("mailsec.message.bulk-action", _EXPLAIN_MESSAGE_BULK_ACTION)
+register_explain("mailsec.message.bulk-status", _EXPLAIN_MESSAGE_BULK_STATUS)
 register_explain("mailsec.campaign.list", _EXPLAIN_CAMPAIGN_LIST)
 register_explain("mailsec.campaign.get", _EXPLAIN_CAMPAIGN_GET)
 register_explain("mailsec.campaign.action", _EXPLAIN_CAMPAIGN_ACTION)

--- a/limacharlie/sdk/mailsec.py
+++ b/limacharlie/sdk/mailsec.py
@@ -2,10 +2,11 @@
 
 Wraps the ``/mailsec/{oid}/...`` REST routes served by the API gateway: the
 coverage screen, the message index and its drawer, the justified raw-EML
-download, analyst verdict revision and its history, campaigns, sender
-profiles, the action audit trail, the abuse-mailbox report queue and its
-reopen, standalone EML analysis, retro-hunts, custom-rule validation and
-backtest, the provider connection preflight, and the served onboarding guide.
+download, analyst verdict revision and its history, bulk remediation across a
+caller-supplied selection, campaigns, sender profiles, the action audit trail,
+the abuse-mailbox report queue and its reopen, standalone EML analysis,
+retro-hunts, custom-rule validation and backtest, the provider connection
+preflight, and the served onboarding guide.
 
 Permissions, which are four rather than the usual get/set pair because mailsec
 asks to be trusted with four different things:
@@ -56,6 +57,72 @@ if TYPE_CHECKING:
 # ten, each no longer than 280 characters.
 _MAX_RATIONALE_LINES = 10
 _MAX_RATIONALE_LEN = 280
+
+
+# The bulk remediation vocabulary, for documentation and for building help text.
+#
+# It is the per-message vocabulary plus ``move_to_spam`` and minus
+# ``submit_to_triage``: bulk-submitting 500 messages to triage is not a bulk
+# remediation but a bulk SPEND, so it sits behind a decision about cost rather
+# than behind a preview that reports placement.
+#
+# Nothing in this module validates against it. The server owns the vocabulary,
+# names the whole set in its refusal (``error_code: bulk_unsupported_action``,
+# with ``supported_actions``), and a client-side copy that went stale would
+# refuse an action the backend had just started supporting.
+BULK_ACTIONS = (
+    "quarantine_message",
+    "trash_message",
+    "move_to_spam",
+    "restore_message",
+    "banner_message",
+    "unbanner_message",
+)
+
+
+def normalize_bulk_selection(msg_uuids: Any) -> list[str]:
+    """Trim, drop blanks, deduplicate and sort a bulk selection.
+
+    This mirrors the server's own normalization step for step, and that IS the
+    contract rather than a tidy-up: the confirmation token a preview mints is
+    derived from the normalized member list, so previewing one selection and
+    executing a different one is refused instead of acting on messages nobody
+    approved. Normalizing once and reusing the result for both calls is what
+    makes the two lists provably the same list.
+
+    Deduplication is a safety property and not only a convenience — a repeated
+    id would otherwise be counted twice in the totals a human reads.
+
+    The CAP is deliberately NOT applied here. 500 is the server's policy, it is
+    re-checked on every call, and a second copy in the client would be a limit
+    that drifts. A client that silently truncated a 900-message selection to fit
+    would leave the remaining 400 in inboxes nobody is going to look at, which is
+    why the server refuses an oversized selection rather than trimming it.
+
+    Raises:
+        ValueError: when the selection is empty once blanks are dropped. A bulk
+            action over nothing is a caller bug worth surfacing rather than a
+            successful no-op.
+    """
+    if isinstance(msg_uuids, str):
+        raise ValueError(
+            "msg_uuids must be a list of message ids, not a single string: pass "
+            "[uuid] rather than uuid so a selection of one is still a selection"
+        )
+    out: list[str] = []
+    seen: set[str] = set()
+    for raw in msg_uuids or []:
+        if not isinstance(raw, str):
+            raise ValueError(f"every msg_uuid must be a string; found a {type(raw).__name__}")
+        value = raw.strip()
+        if not value or value in seen:
+            continue
+        seen.add(value)
+        out.append(value)
+    if not out:
+        raise ValueError("a bulk action needs at least one msg_uuid")
+    out.sort()
+    return out
 
 
 def _seg(value: str) -> str:
@@ -415,6 +482,181 @@ class Mailsec:
         message's disposition moved over time, read from the bottom up.
         """
         return self._get(f"messages/{_seg(msg_uuid)}/revisions")
+
+    # ------------------------------------------------------------------
+    # Bulk remediation by message id
+    # ------------------------------------------------------------------
+    #
+    # The campaign sweep's preview-then-confirm discipline over a selection the
+    # CALLER names rather than a cluster the backend clusters — which is what
+    # turns any search result (the message index, a hunt, a shell pipeline) into
+    # provider-side action.
+    #
+    # Three routes rather than two, because the execute CANNOT finish inside a
+    # request: 500 provider writes paced to respect Microsoft 365 / Google
+    # throttling do not fit the gateway's action budget. Execute therefore
+    # returns a handle and the work proceeds on the collector, so a caller polls
+    # :meth:`bulk_action_status` for outcomes.
+
+    def bulk_action_preview(
+        self,
+        action: str,
+        msg_uuids: Any,
+        *,
+        attempt: str | None = None,
+    ) -> dict[str, Any]:
+        """Report what a bulk action would do, and mint the confirmation that
+        authorizes exactly that. Requires ``mailsec.get``.
+
+        NOTHING IS CHANGED and no job is created. This reads the message index
+        and reports, per message, whether it still exists, its current verdict
+        and placement, and whether it is already where the action would put it.
+
+        It REPORTS rather than refuses. A message that expired past the 35-day
+        retention, and a message already in the target state, are both reported
+        and both stay in the confirmed set — acting on a search result taken
+        minutes ago legitimately includes both, and failing the batch over one
+        expired id would make the feature unusable at exactly the window it
+        exists for. An already-done message is still executed rather than
+        filtered out, because ``already_in_target_state`` is read off the index
+        and is ADVISORY: the index records where remediation last put a message
+        and its owner may have moved it since, so the provider re-checks and
+        answers ``skipped``.
+
+        Args:
+            action: One of :data:`BULK_ACTIONS`.
+            msg_uuids: The selection. Normalized by
+                :func:`normalize_bulk_selection` before it is sent.
+            attempt: Caller-supplied idempotency token. It participates in the
+                confirmation, so a NEW attempt over the same selection is a new
+                token, a new job, and a deliberate second run — which is the
+                escape hatch for acting on the same messages again.
+
+        Returns:
+            The per-message report in ``messages``, a ``summary``
+            (``total``/``found``/``missing``/``already_in_target_state``/
+            ``actionable``/``mailbox_count``/``by_provider`` — note
+            ``mailbox_count``, which is the blast radius an operator actually
+            reasons about), the ``cap``, and a ``confirm`` token DERIVED FROM
+            THE EXACT SELECTION. Pass that token, this action, this attempt and
+            this same list to :meth:`bulk_action_execute`; any change to the
+            selection invalidates it.
+
+        Raises:
+            ValueError: on an empty selection. An oversized one is refused by
+                the server, which names the cap and answers
+                ``error_code: bulk_too_large`` so a caller can split rather
+                than guess.
+        """
+        body: dict[str, Any] = {
+            "action": action,
+            "msg_uuids": normalize_bulk_selection(msg_uuids),
+        }
+        if attempt is not None:
+            body["attempt"] = attempt
+        return self._post("actions/bulk/preview", body)
+
+    def bulk_action_execute(
+        self,
+        action: str,
+        msg_uuids: Any,
+        confirm: str,
+        *,
+        attempt: str | None = None,
+        banner: str | None = None,
+    ) -> dict[str, Any]:
+        """Execute a previewed bulk action. Requires ``mailsec.act``.
+
+        ASYNCHRONOUS, and the shape is not a convenience: up to 500 provider
+        writes paced by the collector's rate governor cannot fit in one request,
+        so this RETURNS IMMEDIATELY with a ``bulk_id`` and the work proceeds in
+        the background. A caller that reported "quarantined 300 messages" off
+        this response would be reporting what was asked for, not what happened;
+        poll :meth:`bulk_action_status` for that.
+
+        Idempotent by construction. The confirmation re-derives to a fixed bulk
+        id, so re-sending the same request ADOPTS the existing job rather than
+        acting twice, and each member's action collapses onto the audit row it
+        already has. That is also the repair for a job whose worker died —
+        status reports ``stalled``, and one more execute with the same
+        confirmation finishes it.
+
+        Partial failure is a normal, honestly-reported outcome and never a
+        rollback: provider actions are not transactional, and "restoring" a
+        message we quarantined is a second visible move in somebody's mailbox
+        rather than an undo.
+
+        Args:
+            action: The action the preview was taken over. It is part of the
+                confirmation, so it must match.
+            msg_uuids: The SAME selection the preview was taken over. Normalized
+                identically here, so passing the preview's own list back is
+                enough; passing a different set is refused rather than acted on.
+            confirm: The token from :meth:`bulk_action_preview`.
+            attempt: The same attempt the preview used, when one was used.
+            banner: Banner HTML for ``banner_message``, supplied once for the
+                whole batch — it carries the org's text, which is a property of
+                the org rather than of any one message.
+
+        Returns:
+            ``{"accepted": True, "bulk_id": str, "state": str, "counts": {...},
+            "member_count": int, "started": bool, "already_running": bool,
+            "already_complete": bool}``. ``started: false`` means this call
+            adopted a job that already existed, which is the idempotent path and
+            not a failure.
+
+        Note:
+            There is deliberately no ``reason``. The gateway forwards only
+            ``action``, ``msg_uuids``, ``confirm``, ``attempt`` and the banner on
+            this route, so a reason would be accepted by this client and dropped
+            in transit — a justification that silently never reaches the audit
+            trail is worse than one the caller knows it cannot give. Per-message
+            reasons remain available through :meth:`act_on_message`.
+        """
+        body: dict[str, Any] = {
+            "action": action,
+            "msg_uuids": normalize_bulk_selection(msg_uuids),
+            "confirm": confirm,
+        }
+        for key, val in (("attempt", attempt), ("banner", banner)):
+            if val is not None:
+                body[key] = val
+        return self._post("actions/bulk/execute", body)
+
+    def bulk_action_status(self, bulk_id: str) -> dict[str, Any]:
+        """A bulk action's progress and per-message outcomes. Requires
+        ``mailsec.get``.
+
+        Args:
+            bulk_id: The handle returned by :meth:`bulk_action_execute`. A
+                preview mints no job and an ordinary action id is not one;
+                either returns a typed not-found rather than a partial answer.
+
+        Returns:
+            ``state`` (``running``, ``complete`` or ``interrupted``), ``counts``
+            (``ok``/``skipped``/``failed``/``alert_only``/``not_found``/
+            ``pending``/``total``), and ``items`` — each member's ``result``,
+            its ``reason``, and the ``action_id`` of its authoritative audit row,
+            expandable through :meth:`get_action`.
+
+            ``state`` and the row's outcome are separate on purpose: a job that
+            finished with six failures is ``complete``, because the question a
+            poller asks is whether anything is still moving.
+
+            ``stalled`` is the field that makes a dead worker visible. The job
+            record is heartbeaten whether or not anything changed, so a running
+            job whose record has not moved is one nobody is working — and the
+            repair is one more execute with the same confirmation, which is safe
+            because every message already acted on collapses onto its existing
+            action row.
+
+            ``items`` is a projection of the job record rather than a re-read of
+            the audit rows (``items_source: bulk_record``), so it can lag by up
+            to one heartbeat. It says so rather than presenting itself as the
+            audit trail, because a lag that looked authoritative would look like
+            a lost action.
+        """
+        return self._get(f"actions/bulk/{_seg(bulk_id)}")
 
     # ------------------------------------------------------------------
     # Campaigns

--- a/limacharlie/sdk/mailsec.py
+++ b/limacharlie/sdk/mailsec.py
@@ -44,7 +44,8 @@ from __future__ import annotations
 import base64
 import binascii
 import json
-from typing import Any, TYPE_CHECKING
+import time
+from typing import Any, Callable, TYPE_CHECKING
 from urllib.parse import quote as _quote
 
 if TYPE_CHECKING:
@@ -78,6 +79,17 @@ BULK_ACTIONS = (
     "banner_message",
     "unbanner_message",
 )
+
+
+# The states in which a bulk job has stopped moving of its own accord.
+#
+# ``interrupted`` belongs here with ``complete``: a worker that lost its pod
+# finalizes the record with whatever outcomes it had, so the answer has already
+# arrived and polling for a different one only burns the wait. What is NOT here
+# is ``stalled``, which is a flag on a still-``running`` record rather than a
+# state, and which is terminal for a different reason — see
+# :meth:`Mailsec.wait_for_bulk`.
+BULK_TERMINAL_STATES = ("complete", "interrupted")
 
 
 def normalize_bulk_selection(msg_uuids: Any) -> list[str]:
@@ -657,6 +669,52 @@ class Mailsec:
             a lost action.
         """
         return self._get(f"actions/bulk/{_seg(bulk_id)}")
+
+    def wait_for_bulk(
+        self,
+        bulk_id: str,
+        timeout: int = 300,
+        poll_interval: int = 3,
+        *,
+        on_poll: Callable[[dict[str, Any]], None] | None = None,
+    ) -> dict[str, Any]:
+        """Poll a bulk action until it stops moving, bounded by *timeout*.
+
+        Three things stop the loop, and they are deliberately not one thing:
+
+        - the job reached a state in :data:`BULK_TERMINAL_STATES`;
+        - ``stalled`` is true, which is terminal even though the job is not
+          finished, because there is no automatic resumption — the record is not
+          being heartbeaten, so no amount of further polling will move it;
+        - the deadline passed, which says nothing about the job.
+
+        Args:
+            bulk_id: The handle returned by :meth:`bulk_action_execute`.
+            timeout: Maximum seconds to wait.
+            poll_interval: Seconds between polls.
+            on_poll: Called with each status document as it arrives, for a
+                caller that wants to narrate progress. It is invoked for the
+                terminal poll too, so a caller that only wants progress should
+                filter on the state itself.
+
+        Returns:
+            dict: The LAST status document, whichever of the three stopped the
+            loop. There is no timeout exception, following :meth:`Jobs.wait`:
+            a document that comes back ``running`` and not ``stalled`` is one
+            the deadline ended, and the distinction is the caller's to draw
+            because only the caller knows what it wants to do about it.
+        """
+        deadline = time.monotonic() + timeout
+        while True:
+            status = self.bulk_action_status(bulk_id)
+            if on_poll is not None:
+                on_poll(status)
+            if status.get("state") in BULK_TERMINAL_STATES or status.get("stalled"):
+                return status
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return status
+            time.sleep(min(poll_interval, remaining))
 
     # ------------------------------------------------------------------
     # Campaigns

--- a/tests/unit/test_cli_mailsec_bulk.py
+++ b/tests/unit/test_cli_mailsec_bulk.py
@@ -1,0 +1,433 @@
+"""Tests for the mailsec CLI's bulk remediation verbs.
+
+The property under test throughout is the CONSENT BINDING: the confirmation a
+preview mints is derived from the exact selection, so the list the CLI shows a
+human and the list it later executes have to be the same object, not two
+independently-built lists that happen to agree today.
+"""
+
+import json
+
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from limacharlie.cli import cli
+
+OID = "11111111-2222-3333-4444-555555555555"
+
+
+def _preview(confirm="tok-1", messages=None, member_count=2):
+    return {
+        "preview": True,
+        "action": "trash_message",
+        "target_state": "trashed",
+        "has_target_state": True,
+        "member_count": member_count,
+        "cap": 500,
+        "messages": messages if messages is not None else [
+            {"msg_uuid": "a", "exists": True, "state": "delivered",
+             "mailbox": "cfo@corp.example", "provider": "m365",
+             "already_in_target_state": False},
+            {"msg_uuid": "b", "exists": False, "state": "", "mailbox": "",
+             "provider": "", "already_in_target_state": False},
+        ],
+        "summary": {
+            "total": member_count, "found": 1, "missing": 1,
+            "already_in_target_state": 0, "mailbox_count": 1,
+            "by_provider": {"m365": 1}, "actionable": 1,
+        },
+        "confirm": confirm,
+    }
+
+
+def _accepted(bulk_id="bulk-1", started=True):
+    return {
+        "accepted": True, "bulk_id": bulk_id, "member_count": 2,
+        "started": started, "already_running": not started,
+        "already_complete": False, "state": "running",
+        "counts": {"total": 2, "pending": 2, "ok": 0, "skipped": 0,
+                   "failed": 0, "alert_only": 0, "not_found": 0},
+    }
+
+
+def _status(state="complete", stalled=False, ok=2, pending=0):
+    return {
+        "bulk_id": "bulk-1", "state": state, "stalled": stalled,
+        "counts": {"total": 2, "pending": pending, "ok": ok, "skipped": 0,
+                   "failed": 0, "alert_only": 0, "not_found": 0},
+        "items": [{"msg_uuid": "a", "result": "ok", "reason": "", "action_id": "act-a"}],
+        "items_source": "bulk_record",
+    }
+
+
+def _invoke(*args, sdk_returns=None, isatty=True, mock_sdk=True):
+    """Invoke the CLI with the Mailsec class mocked, and return (result, sdk).
+
+    The streams are kept SEPARATE (``mix_stderr=False``, this repo's idiom): the
+    command's contract is that stdout holds one parseable document while progress
+    goes to stderr, and a runner that merged them could not tell the two apart.
+
+    ``isatty`` is patched rather than left to the runner because the confirmation
+    prompt's whole job is to refuse a stream nobody is reading, and CliRunner's
+    stdin is never a TTY.
+    """
+    runner = CliRunner(mix_stderr=False)
+    with (
+        patch("limacharlie.commands.mailsec.Client"),
+        patch("limacharlie.commands.mailsec.Organization"),
+        patch("limacharlie.commands.mailsec.sys.stdin.isatty", return_value=isatty),
+        patch("limacharlie.commands.mailsec.time.sleep"),
+    ):
+        if not mock_sdk:
+            return runner.invoke(cli, ["--oid", OID, "--output", "json", *args]), None
+        with patch("limacharlie.commands.mailsec.Mailsec") as mailsec_cls:
+            mailsec = MagicMock()
+            for name, value in (sdk_returns or {}).items():
+                if isinstance(value, list):
+                    getattr(mailsec, name).side_effect = value
+                else:
+                    getattr(mailsec, name).return_value = value
+            mailsec_cls.return_value = mailsec
+            result = runner.invoke(cli, ["--oid", OID, "--output", "json", *args])
+            return result, mailsec
+
+
+_HAPPY = {
+    "bulk_action_preview": _preview(),
+    "bulk_action_execute": _accepted(),
+    "bulk_action_status": _status(),
+}
+
+
+class TestPreviewToExecuteBinding:
+    """The confirmation is bound to the selection, so the two calls must carry
+    the identical list. Rebuilding it between them is the mistake that would
+    execute a set nobody approved — and it would look like a stale-token bug
+    rather than like the consent failure it is."""
+
+    def test_execute_reuses_the_exact_list_the_preview_was_taken_over(self):
+        result, ms = _invoke(
+            "mailsec", "message", "bulk-action",
+            "--action", "trash_message", "--msg-uuids", "b,a,b", "--yes",
+            sdk_returns=_HAPPY,
+        )
+        assert result.exit_code == 0, result.output
+        previewed = ms.bulk_action_preview.call_args.args[1]
+        executed = ms.bulk_action_execute.call_args.args[1]
+        assert previewed == executed == ["a", "b"]
+        assert previewed is executed, "the two calls must share one list, not two equal ones"
+
+    def test_the_minted_token_is_what_gets_spent(self):
+        result, ms = _invoke(
+            "mailsec", "message", "bulk-action",
+            "--action", "trash_message", "--msg-uuids", "a,b", "--yes",
+            sdk_returns={**_HAPPY, "bulk_action_preview": _preview(confirm="3f31ed")},
+        )
+        assert result.exit_code == 0, result.output
+        assert ms.bulk_action_execute.call_args.args[2] == "3f31ed"
+
+    def test_the_attempt_reaches_both_calls(self):
+        """attempt is hashed into the confirmation, so a preview taken with one
+        and an execute sent without it are different selections."""
+        result, ms = _invoke(
+            "mailsec", "message", "bulk-action",
+            "--action", "trash_message", "--msg-uuids", "a", "--attempt", "inc-9", "--yes",
+            sdk_returns=_HAPPY,
+        )
+        assert result.exit_code == 0, result.output
+        assert ms.bulk_action_preview.call_args.kwargs["attempt"] == "inc-9"
+        assert ms.bulk_action_execute.call_args.kwargs["attempt"] == "inc-9"
+
+    def test_a_preview_without_a_token_refuses_to_execute(self):
+        result, ms = _invoke(
+            "mailsec", "message", "bulk-action",
+            "--action", "trash_message", "--msg-uuids", "a", "--yes",
+            sdk_returns={**_HAPPY, "bulk_action_preview": _preview(confirm=None)},
+        )
+        assert result.exit_code != 0
+        ms.bulk_action_execute.assert_not_called()
+
+
+class TestSelectionAssembly:
+    def test_ids_come_from_the_flag_and_the_file_together(self, tmp_path):
+        f = tmp_path / "uuids.txt"
+        f.write_text("c\nd\n\n")
+        result, ms = _invoke(
+            "mailsec", "message", "bulk-action", "--action", "trash_message",
+            "--msg-uuids", "a,b", "--input-file", str(f), "--yes",
+            sdk_returns=_HAPPY,
+        )
+        assert result.exit_code == 0, result.output
+        assert ms.bulk_action_preview.call_args.args[1] == ["a", "b", "c", "d"]
+
+    def test_repeated_flags_accumulate(self):
+        result, ms = _invoke(
+            "mailsec", "message", "bulk-action", "--action", "trash_message",
+            "--msg-uuids", "a", "--msg-uuids", "b,c", "--yes",
+            sdk_returns=_HAPPY,
+        )
+        assert result.exit_code == 0, result.output
+        assert ms.bulk_action_preview.call_args.args[1] == ["a", "b", "c"]
+
+    def test_an_empty_selection_is_a_usage_error_before_any_call(self):
+        result, ms = _invoke(
+            "mailsec", "message", "bulk-action", "--action", "trash_message", "--yes",
+            sdk_returns=_HAPPY,
+        )
+        assert result.exit_code != 0
+        assert "at least one msg_uuid" in result.stderr
+        ms.bulk_action_preview.assert_not_called()
+
+    def test_a_file_of_only_blanks_is_the_same_refusal(self, tmp_path):
+        f = tmp_path / "uuids.txt"
+        f.write_text("\n  \n")
+        result, ms = _invoke(
+            "mailsec", "message", "bulk-action", "--action", "trash_message",
+            "--input-file", str(f), "--yes",
+            sdk_returns=_HAPPY,
+        )
+        assert result.exit_code != 0
+        ms.bulk_action_preview.assert_not_called()
+
+    def test_an_oversized_selection_is_sent_whole_for_the_server_to_refuse(self):
+        """The cap is the server's and it refuses rather than truncates. A CLI
+        that trimmed to 500 would report success over a selection whose tail was
+        silently left in inboxes."""
+        ids = ",".join(f"m{i:04d}" for i in range(900))
+        result, ms = _invoke(
+            "mailsec", "message", "bulk-action", "--action", "trash_message",
+            "--msg-uuids", ids, "--yes",
+            sdk_returns=_HAPPY,
+        )
+        assert result.exit_code == 0, result.output
+        assert len(ms.bulk_action_preview.call_args.args[1]) == 900
+
+
+class TestConsent:
+    def test_without_yes_off_a_tty_nothing_is_executed(self):
+        """Consent has to come from someone who saw the preview. Off a TTY there
+        is nobody, so the refusal names the flag that says 'I already decided'
+        instead of prompting a stream that cannot answer."""
+        result, ms = _invoke(
+            "mailsec", "message", "bulk-action", "--action", "trash_message",
+            "--msg-uuids", "a", isatty=False,
+            sdk_returns=_HAPPY,
+        )
+        assert result.exit_code != 0
+        assert "--yes" in result.stderr
+        ms.bulk_action_execute.assert_not_called()
+
+    def test_quiet_suppresses_the_preview_so_it_also_requires_yes(self):
+        """--quiet hides the very thing consent would be given to; prompting
+        anyway would be asking a human to approve a blank screen."""
+        with (
+            patch("limacharlie.commands.mailsec.Client"),
+            patch("limacharlie.commands.mailsec.Organization"),
+            patch("limacharlie.commands.mailsec.sys.stdin.isatty", return_value=True),
+            patch("limacharlie.commands.mailsec.Mailsec") as mailsec_cls,
+        ):
+            ms = MagicMock()
+            ms.bulk_action_preview.return_value = _preview()
+            mailsec_cls.return_value = ms
+            result = CliRunner().invoke(cli, [
+                "--oid", OID, "--quiet", "mailsec", "message", "bulk-action",
+                "--action", "trash_message", "--msg-uuids", "a",
+            ])
+        assert result.exit_code != 0
+        ms.bulk_action_execute.assert_not_called()
+
+    def test_declining_the_prompt_executes_nothing(self):
+        with (
+            patch("limacharlie.commands.mailsec.Client"),
+            patch("limacharlie.commands.mailsec.Organization"),
+            patch("limacharlie.commands.mailsec.sys.stdin.isatty", return_value=True),
+            patch("limacharlie.commands.mailsec.Mailsec") as mailsec_cls,
+        ):
+            ms = MagicMock()
+            ms.bulk_action_preview.return_value = _preview()
+            mailsec_cls.return_value = ms
+            result = CliRunner().invoke(cli, [
+                "--oid", OID, "--output", "json", "mailsec", "message", "bulk-action",
+                "--action", "trash_message", "--msg-uuids", "a",
+            ], input="n\n")
+        assert result.exit_code != 0
+        ms.bulk_action_execute.assert_not_called()
+
+    def test_the_preview_is_shown_before_the_prompt(self):
+        result, _ = _invoke(
+            "mailsec", "message", "bulk-action", "--action", "trash_message",
+            "--msg-uuids", "a,b", "--yes",
+            sdk_returns=_HAPPY,
+        )
+        assert result.exit_code == 0, result.output
+        # Every member is listed, including the one that is no longer indexed:
+        # a truncated blast radius under-reports the thing being approved.
+        assert "cfo@corp.example" in result.stderr
+        assert "NOT IN INDEX" in result.stderr
+        assert "mailboxes:     1" in result.stderr
+
+
+class TestPreviewOnlyAndTwoStep:
+    def test_preview_only_prints_the_token_and_executes_nothing(self):
+        result, ms = _invoke(
+            "mailsec", "message", "bulk-action", "--action", "trash_message",
+            "--msg-uuids", "a,b", "--preview-only",
+            sdk_returns=_HAPPY,
+        )
+        assert result.exit_code == 0, result.output
+        assert json.loads(result.stdout)["confirm"] == "tok-1"
+        ms.bulk_action_execute.assert_not_called()
+
+    def test_an_explicit_confirm_skips_the_preview_entirely(self):
+        """The second half of a hand-driven two-step. Re-previewing here would
+        mint a fresh token and quietly discard the one the operator reviewed."""
+        result, ms = _invoke(
+            "mailsec", "message", "bulk-action", "--action", "trash_message",
+            "--msg-uuids", "a,b", "--confirm", "3f31ed",
+            sdk_returns=_HAPPY,
+        )
+        assert result.exit_code == 0, result.output
+        ms.bulk_action_preview.assert_not_called()
+        assert ms.bulk_action_execute.call_args.args[2] == "3f31ed"
+
+    def test_preview_only_and_confirm_are_mutually_exclusive(self):
+        result, ms = _invoke(
+            "mailsec", "message", "bulk-action", "--action", "trash_message",
+            "--msg-uuids", "a", "--preview-only", "--confirm", "tok",
+            sdk_returns=_HAPPY,
+        )
+        assert result.exit_code != 0
+        ms.bulk_action_preview.assert_not_called()
+        ms.bulk_action_execute.assert_not_called()
+
+
+class TestWaiting:
+    def test_it_polls_until_the_job_leaves_running(self):
+        result, ms = _invoke(
+            "mailsec", "message", "bulk-action", "--action", "trash_message",
+            "--msg-uuids", "a,b", "--yes",
+            sdk_returns={
+                **_HAPPY,
+                "bulk_action_status": [
+                    _status(state="running", ok=0, pending=2),
+                    _status(state="running", ok=1, pending=1),
+                    _status(state="complete", ok=2),
+                ],
+            },
+        )
+        assert result.exit_code == 0, result.output
+        assert ms.bulk_action_status.call_count == 3
+        assert json.loads(result.stdout)["state"] == "complete"
+        assert "settled: state=complete" in result.stderr
+
+    def test_interrupted_is_terminal_too(self):
+        """A rolled pod finalizes the job as interrupted with its partial
+        outcomes intact. Treating only 'complete' as terminal would poll it
+        until the timeout for an answer that already arrived."""
+        result, ms = _invoke(
+            "mailsec", "message", "bulk-action", "--action", "trash_message",
+            "--msg-uuids", "a,b", "--yes",
+            sdk_returns={**_HAPPY, "bulk_action_status": _status(state="interrupted", ok=1)},
+        )
+        assert result.exit_code == 0, result.output
+        assert ms.bulk_action_status.call_count == 1
+        assert "settled: state=interrupted" in result.stderr
+
+    def test_a_stalled_job_stops_polling_and_states_the_repair(self):
+        """There is deliberately no automatic resumption, so a stalled record
+        will never move on its own; polling it to the timeout would burn the
+        window in which someone could re-drive it."""
+        result, ms = _invoke(
+            "mailsec", "message", "bulk-action", "--action", "trash_message",
+            "--msg-uuids", "a,b", "--yes",
+            sdk_returns={
+                **_HAPPY,
+                "bulk_action_status": _status(state="running", stalled=True, ok=1, pending=1),
+            },
+        )
+        assert result.exit_code == 0, result.output
+        assert ms.bulk_action_status.call_count == 1
+        assert "STALLED" in result.stderr
+        assert "--confirm" in result.stderr
+
+    def test_the_wait_is_bounded_and_says_so(self):
+        """A job that outlives the timeout is not a failure and is not silence:
+        the loop stops, says the job is unaffected, and names the command that
+        resumes the poll."""
+        result, ms = _invoke(
+            "mailsec", "message", "bulk-action", "--action", "trash_message",
+            "--msg-uuids", "a,b", "--yes", "--timeout", "0",
+            sdk_returns={**_HAPPY, "bulk_action_status": _status(state="running", ok=0, pending=2)},
+        )
+        assert result.exit_code == 0, result.output
+        assert ms.bulk_action_status.call_count == 1
+        assert "still running after 0s" in result.stderr
+        assert "bulk-status bulk-1" in result.stderr
+        assert json.loads(result.stdout)["state"] == "running"
+
+    def test_no_wait_returns_the_acceptance_without_polling(self):
+        result, ms = _invoke(
+            "mailsec", "message", "bulk-action", "--action", "trash_message",
+            "--msg-uuids", "a,b", "--yes", "--no-wait",
+            sdk_returns=_HAPPY,
+        )
+        assert result.exit_code == 0, result.output
+        ms.bulk_action_status.assert_not_called()
+        assert json.loads(result.stdout)["bulk_id"] == "bulk-1"
+
+    def test_adopting_an_existing_job_is_reported_not_hidden(self):
+        """started:false is the idempotent path — a re-sent execute adopting the
+        job it already created. Saying so is what stops it reading as a second
+        batch."""
+        result, _ = _invoke(
+            "mailsec", "message", "bulk-action", "--action", "trash_message",
+            "--msg-uuids", "a,b", "--yes",
+            sdk_returns={**_HAPPY, "bulk_action_execute": _accepted(started=False)},
+        )
+        assert result.exit_code == 0, result.output
+        assert "already existed" in result.stderr
+
+    def test_stdout_carries_exactly_one_document(self):
+        """Three calls, one answer. Narration goes to stderr so `--output json`
+        keeps its promise that stdout is a single parseable document."""
+        result, _ = _invoke(
+            "mailsec", "message", "bulk-action", "--action", "trash_message",
+            "--msg-uuids", "a,b", "--yes",
+            sdk_returns=_HAPPY,
+        )
+        assert result.exit_code == 0, result.output
+        assert json.loads(result.stdout)["bulk_id"] == "bulk-1"
+
+
+class TestBulkStatusCommand:
+    def test_status_reaches_the_sdk(self):
+        result, ms = _invoke(
+            "mailsec", "message", "bulk-status", "bulk-1",
+            sdk_returns={"bulk_action_status": _status()},
+        )
+        assert result.exit_code == 0, result.output
+        ms.bulk_action_status.assert_called_once_with("bulk-1")
+        assert json.loads(result.stdout)["counts"]["ok"] == 2
+
+
+class TestGuidance:
+    def test_help_names_the_bulk_vocabulary_including_move_to_spam(self):
+        """The bulk vocabulary is not the per-message one: it adds move_to_spam
+        and drops submit_to_triage. A caller who cannot see the difference will
+        assume they match."""
+        result = CliRunner().invoke(cli, ["mailsec", "message", "bulk-action", "--help"])
+        assert result.exit_code == 0, result.output
+        assert "move_to_spam" in result.output
+        assert "submit_to_triage" not in result.output
+
+    def test_ai_help_explains_the_selection_binding(self):
+        result = CliRunner().invoke(cli, ["mailsec", "message", "bulk-action", "--ai-help"])
+        assert result.exit_code == 0, result.output
+        assert "DERIVED FROM THE EXACT SELECTION" in result.output
+        assert "REFUSED, not truncated" in result.output
+
+    def test_ai_help_for_status_explains_stalled(self):
+        result = CliRunner().invoke(cli, ["mailsec", "message", "bulk-status", "--ai-help"])
+        assert result.exit_code == 0, result.output
+        assert "stalled" in result.output

--- a/tests/unit/test_cli_mailsec_bulk.py
+++ b/tests/unit/test_cli_mailsec_bulk.py
@@ -1,9 +1,17 @@
 """Tests for the mailsec CLI's bulk remediation verbs.
 
-The property under test throughout is the CONSENT BINDING: the confirmation a
-preview mints is derived from the exact selection, so the list the CLI shows a
-human and the list it later executes have to be the same object, not two
-independently-built lists that happen to agree today.
+Three properties are under test, and they are the three ways this verb can hurt
+someone:
+
+- the CONSENT BINDING — the confirmation a preview mints is derived from the
+  exact selection, so the list the CLI shows and the list it later executes have
+  to be the same list, not two independently-built ones that agree today;
+- the SELECTION SHAPE — a member that is not a message id comes back from the
+  preview as "NOT IN INDEX", identical to a legitimately expired one, so the
+  counts a human consents over would silently be wrong;
+- the OUTCOME CONTRACT — stdout carries one document, stderr carries the handle
+  and exactly one terminal line, and the exit code says what happened, because a
+  runbook chained with `&&` acts on the exit code and nothing else.
 """
 
 import json
@@ -13,11 +21,24 @@ from unittest.mock import MagicMock, patch
 from click.testing import CliRunner
 
 from limacharlie.cli import cli
+from limacharlie.sdk.mailsec import Mailsec
 
 OID = "11111111-2222-3333-4444-555555555555"
 
+# Real msg_uuids. The backend derives them as v5-shaped UUIDs
+# (go-mailsec store.MessageUUID), and the CLI now refuses anything else, so a
+# fixture of "a"/"b" would be testing an input the verb no longer accepts.
+U_A = "0057db2b-3a06-5aab-b3be-c1e6c15dcf10"
+U_B = "1157db2b-3a06-5aab-b3be-c1e6c15dcf11"
+U_C = "2257db2b-3a06-5aab-b3be-c1e6c15dcf12"
 
-def _preview(confirm="tok-1", messages=None, member_count=2):
+# The gateway's confirmation is 32 hex characters (bulk.Token slices the sha256
+# hex to 32); the bulk id is another 32, derived from the token.
+TOKEN = "3f31ed7c9b2a4d5e6f8a0b1c2d3e4f50"
+BULK_ID = "8f1c2d3e4a5b6c7d8e9f0a1b2c3d4e5f"
+
+
+def _preview(confirm=TOKEN, messages=None, member_count=2):
     return {
         "preview": True,
         "action": "trash_message",
@@ -26,10 +47,10 @@ def _preview(confirm="tok-1", messages=None, member_count=2):
         "member_count": member_count,
         "cap": 500,
         "messages": messages if messages is not None else [
-            {"msg_uuid": "a", "exists": True, "state": "delivered",
+            {"msg_uuid": U_A, "exists": True, "state": "delivered",
              "mailbox": "cfo@corp.example", "provider": "m365",
              "already_in_target_state": False},
-            {"msg_uuid": "b", "exists": False, "state": "", "mailbox": "",
+            {"msg_uuid": U_B, "exists": False, "state": "", "mailbox": "",
              "provider": "", "already_in_target_state": False},
         ],
         "summary": {
@@ -41,9 +62,9 @@ def _preview(confirm="tok-1", messages=None, member_count=2):
     }
 
 
-def _accepted(bulk_id="bulk-1", started=True):
+def _accepted(bulk_id=BULK_ID, started=True, accepted=True):
     return {
-        "accepted": True, "bulk_id": bulk_id, "member_count": 2,
+        "accepted": accepted, "bulk_id": bulk_id, "member_count": 2,
         "started": started, "already_running": not started,
         "already_complete": False, "state": "running",
         "counts": {"total": 2, "pending": 2, "ok": 0, "skipped": 0,
@@ -51,46 +72,61 @@ def _accepted(bulk_id="bulk-1", started=True):
     }
 
 
-def _status(state="complete", stalled=False, ok=2, pending=0):
+def _status(state="complete", stalled=False, ok=2, pending=0, failed=0, skipped=0):
     return {
-        "bulk_id": "bulk-1", "state": state, "stalled": stalled,
-        "counts": {"total": 2, "pending": pending, "ok": ok, "skipped": 0,
-                   "failed": 0, "alert_only": 0, "not_found": 0},
-        "items": [{"msg_uuid": "a", "result": "ok", "reason": "", "action_id": "act-a"}],
+        "bulk_id": BULK_ID, "state": state, "stalled": stalled,
+        "counts": {"total": 2, "pending": pending, "ok": ok, "skipped": skipped,
+                   "failed": failed, "alert_only": 0, "not_found": 0},
+        "items": [{"msg_uuid": U_A, "result": "ok", "reason": "", "action_id": "act-a"}],
         "items_source": "bulk_record",
     }
 
 
-def _invoke(*args, sdk_returns=None, isatty=True, mock_sdk=True):
+def _invoke(*args, sdk_returns=None, input=None, monotonic=None):
     """Invoke the CLI with the Mailsec class mocked, and return (result, sdk).
 
-    The streams are kept SEPARATE (``mix_stderr=False``, this repo's idiom): the
-    command's contract is that stdout holds one parseable document while progress
-    goes to stderr, and a runner that merged them could not tell the two apart.
+    The streams are kept SEPARATE (``mix_stderr=False``, valid because this
+    package pins click==8.1.8 and the parameter was removed in click 8.2): the
+    verb's contract is that stdout holds one parseable document while progress,
+    the job handle and the terminal line go to stderr, and a runner that merged
+    them could not tell the two apart.
 
-    ``isatty`` is patched rather than left to the runner because the confirmation
-    prompt's whole job is to refuse a stream nobody is reading, and CliRunner's
-    stdin is never a TTY.
+    ``wait_for_bulk`` is wired to the REAL SDK implementation bound to the mock,
+    so the polling loop under test is the shipped one and only the HTTP-facing
+    ``bulk_action_status`` is stubbed. Mocking the wait away would leave the
+    loop's terminal semantics — which decide the exit code — untested.
     """
     runner = CliRunner(mix_stderr=False)
-    with (
+    patches = [
         patch("limacharlie.commands.mailsec.Client"),
         patch("limacharlie.commands.mailsec.Organization"),
-        patch("limacharlie.commands.mailsec.sys.stdin.isatty", return_value=isatty),
-        patch("limacharlie.commands.mailsec.time.sleep"),
-    ):
-        if not mock_sdk:
-            return runner.invoke(cli, ["--oid", OID, "--output", "json", *args]), None
-        with patch("limacharlie.commands.mailsec.Mailsec") as mailsec_cls:
+        patch("limacharlie.sdk.mailsec.time.sleep"),
+    ]
+    if monotonic is not None:
+        patches.append(patch("limacharlie.sdk.mailsec.time.monotonic", side_effect=monotonic))
+    with patch("limacharlie.commands.mailsec.Mailsec") as mailsec_cls:
+        for p in patches:
+            p.start()
+        try:
             mailsec = MagicMock()
             for name, value in (sdk_returns or {}).items():
                 if isinstance(value, list):
                     getattr(mailsec, name).side_effect = value
+                elif isinstance(value, BaseException) or (
+                    isinstance(value, type) and issubclass(value, BaseException)
+                ):
+                    getattr(mailsec, name).side_effect = value
                 else:
                     getattr(mailsec, name).return_value = value
+            mailsec.wait_for_bulk = lambda *a, **kw: Mailsec.wait_for_bulk(mailsec, *a, **kw)
             mailsec_cls.return_value = mailsec
-            result = runner.invoke(cli, ["--oid", OID, "--output", "json", *args])
+            result = runner.invoke(
+                cli, ["--oid", OID, "--output", "json", *args], input=input or "",
+            )
             return result, mailsec
+        finally:
+            for p in reversed(patches):
+                p.stop()
 
 
 _HAPPY = {
@@ -100,79 +136,267 @@ _HAPPY = {
 }
 
 
-class TestPreviewToExecuteBinding:
-    """The confirmation is bound to the selection, so the two calls must carry
-    the identical list. Rebuilding it between them is the mistake that would
-    execute a set nobody approved — and it would look like a stale-token bug
-    rather than like the consent failure it is."""
+class TestPreviewIsTheDefault:
+    """The grammar the sibling remediation verbs use: omit --confirm and you get
+    a preview, pass one and it executes. There is no prompt and no --yes, which
+    is what makes the verb usable from a script without a flag that means
+    "skip the safety"."""
 
-    def test_execute_reuses_the_exact_list_the_preview_was_taken_over(self):
+    def test_omitting_confirm_previews_and_changes_nothing(self):
         result, ms = _invoke(
-            "mailsec", "message", "bulk-action",
-            "--action", "trash_message", "--msg-uuids", "b,a,b", "--yes",
+            "mailsec", "message", "bulk-action", "--action", "trash_message",
+            "--msg-uuids", f"{U_A},{U_B}",
             sdk_returns=_HAPPY,
         )
-        assert result.exit_code == 0, result.output
-        previewed = ms.bulk_action_preview.call_args.args[1]
-        executed = ms.bulk_action_execute.call_args.args[1]
-        assert previewed == executed == ["a", "b"]
-        assert previewed is executed, "the two calls must share one list, not two equal ones"
+        assert result.exit_code == 0, result.stderr
+        ms.bulk_action_preview.assert_called_once()
+        ms.bulk_action_execute.assert_not_called()
 
-    def test_the_minted_token_is_what_gets_spent(self):
-        result, ms = _invoke(
-            "mailsec", "message", "bulk-action",
-            "--action", "trash_message", "--msg-uuids", "a,b", "--yes",
-            sdk_returns={**_HAPPY, "bulk_action_preview": _preview(confirm="3f31ed")},
-        )
-        assert result.exit_code == 0, result.output
-        assert ms.bulk_action_execute.call_args.args[2] == "3f31ed"
-
-    def test_the_attempt_reaches_both_calls(self):
-        """attempt is hashed into the confirmation, so a preview taken with one
-        and an execute sent without it are different selections."""
-        result, ms = _invoke(
-            "mailsec", "message", "bulk-action",
-            "--action", "trash_message", "--msg-uuids", "a", "--attempt", "inc-9", "--yes",
+    def test_the_token_arrives_on_stdout_so_a_script_can_read_it(self):
+        """The whole point of the two-step: step one's answer has to be readable
+        by the thing that runs step two."""
+        result, _ = _invoke(
+            "mailsec", "message", "bulk-action", "--action", "trash_message",
+            "--msg-uuids", U_A,
             sdk_returns=_HAPPY,
         )
-        assert result.exit_code == 0, result.output
-        assert ms.bulk_action_preview.call_args.kwargs["attempt"] == "inc-9"
-        assert ms.bulk_action_execute.call_args.kwargs["attempt"] == "inc-9"
+        assert result.exit_code == 0, result.stderr
+        assert json.loads(result.stdout)["confirm"] == TOKEN
 
-    def test_a_preview_without_a_token_refuses_to_execute(self):
+    def test_the_table_format_does_not_render_the_preview_away(self):
+        """MEASURED: format_table flattens a record to one row per key and
+        renders nested values as placeholders — for this document `messages`
+        becomes "[2 items]" and `summary` becomes "{7 keys}". Those two ARE the
+        preview: the per-message placement and the mailbox count are the blast
+        radius being approved. Now that the preview is this verb's default
+        output, a table would print its substance away, so it falls back to
+        JSON. The token comes through whole either way, and this pins that too."""
+        runner = CliRunner(mix_stderr=False)
+        with (
+            patch("limacharlie.commands.mailsec.Client"),
+            patch("limacharlie.commands.mailsec.Organization"),
+            patch("limacharlie.commands.mailsec.Mailsec") as cls,
+        ):
+            ms = MagicMock()
+            ms.bulk_action_preview.return_value = _preview()
+            cls.return_value = ms
+            result = runner.invoke(cli, [
+                "--oid", OID, "--output", "table", "mailsec", "message", "bulk-action",
+                "--action", "trash_message", "--msg-uuids", f"{U_A},{U_B}",
+            ])
+        assert result.exit_code == 0, result.stderr
+        assert "[2 items]" not in result.stdout
+        doc = json.loads(result.stdout)
+        assert doc["confirm"] == TOKEN
+        assert [m["msg_uuid"] for m in doc["messages"]] == [U_A, U_B]
+
+    def test_the_blast_radius_is_narrated_for_a_human(self):
+        result, _ = _invoke(
+            "mailsec", "message", "bulk-action", "--action", "trash_message",
+            "--msg-uuids", f"{U_A},{U_B}",
+            sdk_returns=_HAPPY,
+        )
+        assert result.exit_code == 0, result.stderr
+        # Every member is listed, including the one that is no longer indexed:
+        # a truncated blast radius under-reports the thing being approved.
+        assert "cfo@corp.example" in result.stderr
+        assert "NOT IN INDEX" in result.stderr
+        assert "mailboxes:     1" in result.stderr
+        assert f"confirm:       {TOKEN}" in result.stderr
+
+    def test_there_is_no_yes_flag(self):
+        """The prompt and its escape hatch are gone. A --yes that still parsed
+        would leave scripts carrying a flag that no longer means anything."""
         result, ms = _invoke(
-            "mailsec", "message", "bulk-action",
-            "--action", "trash_message", "--msg-uuids", "a", "--yes",
-            sdk_returns={**_HAPPY, "bulk_action_preview": _preview(confirm=None)},
+            "mailsec", "message", "bulk-action", "--action", "trash_message",
+            "--msg-uuids", U_A, "--yes",
+            sdk_returns=_HAPPY,
         )
         assert result.exit_code != 0
+        ms.bulk_action_preview.assert_not_called()
+
+    def test_there_is_no_preview_only_flag(self):
+        result, ms = _invoke(
+            "mailsec", "message", "bulk-action", "--action", "trash_message",
+            "--msg-uuids", U_A, "--preview-only",
+            sdk_returns=_HAPPY,
+        )
+        assert result.exit_code != 0
+        ms.bulk_action_preview.assert_not_called()
+
+    def test_a_valueless_confirm_is_refused_rather_than_read_as_consent(self):
+        """--confirm takes a value here, unlike the boolean --confirm elsewhere
+        in the CLI. Click refuses the bare flag, which is the safe direction:
+        the failure mode of the other reading would be executing on a token
+        nobody supplied."""
+        result, ms = _invoke(
+            "mailsec", "message", "bulk-action", "--action", "trash_message",
+            "--msg-uuids", U_A, "--confirm",
+            sdk_returns=_HAPPY,
+        )
+        assert result.exit_code != 0
+        assert "requires an argument" in result.stderr
         ms.bulk_action_execute.assert_not_called()
+
+
+class TestPreviewToExecuteBinding:
+    """The confirmation is bound to (action, attempt, member list), so the two
+    calls must carry the identical list. Rebuilding it differently between them
+    is the mistake that would execute a set nobody approved — and it surfaces as
+    a stale-token error rather than as the consent failure it is."""
+
+    def test_the_two_steps_send_a_byte_identical_selection(self):
+        """The binding property, asserted where it now lives: across two
+        invocations, spelled in two orders, with a duplicate in one of them."""
+        _, preview_ms = _invoke(
+            "mailsec", "message", "bulk-action", "--action", "trash_message",
+            "--msg-uuids", f"{U_B},{U_A},{U_B}",
+            sdk_returns=_HAPPY,
+        )
+        _, execute_ms = _invoke(
+            "mailsec", "message", "bulk-action", "--action", "trash_message",
+            "--msg-uuids", f"{U_A},{U_B}", "--confirm", TOKEN,
+            sdk_returns=_HAPPY,
+        )
+        previewed = preview_ms.bulk_action_preview.call_args.args[1]
+        executed = execute_ms.bulk_action_execute.call_args.args[1]
+        assert previewed == executed == [U_A, U_B]
+
+    def test_the_execute_normalizes_once_and_sends_that_list(self):
+        result, ms = _invoke(
+            "mailsec", "message", "bulk-action", "--action", "trash_message",
+            "--msg-uuids", f"{U_C},{U_A},{U_A}", "--confirm", TOKEN,
+            sdk_returns=_HAPPY,
+        )
+        assert result.exit_code == 0, result.stderr
+        assert ms.bulk_action_execute.call_args.args[1] == [U_A, U_C]
+
+    def test_the_token_given_is_the_token_spent(self):
+        result, ms = _invoke(
+            "mailsec", "message", "bulk-action", "--action", "trash_message",
+            "--msg-uuids", U_A, "--confirm", TOKEN,
+            sdk_returns=_HAPPY,
+        )
+        assert result.exit_code == 0, result.stderr
+        assert ms.bulk_action_execute.call_args.args[2] == TOKEN
+
+    def test_the_attempt_reaches_whichever_call_runs(self):
+        """attempt is hashed into the confirmation, so a preview taken with one
+        and an execute sent without it are different selections to the server."""
+        _, preview_ms = _invoke(
+            "mailsec", "message", "bulk-action", "--action", "trash_message",
+            "--msg-uuids", U_A, "--attempt", "inc-9",
+            sdk_returns=_HAPPY,
+        )
+        _, execute_ms = _invoke(
+            "mailsec", "message", "bulk-action", "--action", "trash_message",
+            "--msg-uuids", U_A, "--attempt", "inc-9", "--confirm", TOKEN,
+            sdk_returns=_HAPPY,
+        )
+        assert preview_ms.bulk_action_preview.call_args.kwargs["attempt"] == "inc-9"
+        assert execute_ms.bulk_action_execute.call_args.kwargs["attempt"] == "inc-9"
+
+    def test_a_confirm_skips_the_preview_entirely(self):
+        """Re-previewing here would mint a fresh token and quietly discard the
+        one the operator reviewed."""
+        result, ms = _invoke(
+            "mailsec", "message", "bulk-action", "--action", "trash_message",
+            "--msg-uuids", f"{U_A},{U_B}", "--confirm", TOKEN,
+            sdk_returns=_HAPPY,
+        )
+        assert result.exit_code == 0, result.stderr
+        ms.bulk_action_preview.assert_not_called()
+
+    def test_the_banner_is_forwarded_on_the_execute(self):
+        result, ms = _invoke(
+            "mailsec", "message", "bulk-action", "--action", "banner_message",
+            "--msg-uuids", U_A, "--confirm", TOKEN, "--banner", "<b>caution</b>",
+            sdk_returns=_HAPPY,
+        )
+        assert result.exit_code == 0, result.stderr
+        assert ms.bulk_action_execute.call_args.kwargs["banner"] == "<b>caution</b>"
 
 
 class TestSelectionAssembly:
     def test_ids_come_from_the_flag_and_the_file_together(self, tmp_path):
         f = tmp_path / "uuids.txt"
-        f.write_text("c\nd\n\n")
+        f.write_text(f"{U_C}\n\n")
         result, ms = _invoke(
             "mailsec", "message", "bulk-action", "--action", "trash_message",
-            "--msg-uuids", "a,b", "--input-file", str(f), "--yes",
+            "--msg-uuids", f"{U_A},{U_B}", "--input-file", str(f),
             sdk_returns=_HAPPY,
         )
-        assert result.exit_code == 0, result.output
-        assert ms.bulk_action_preview.call_args.args[1] == ["a", "b", "c", "d"]
+        assert result.exit_code == 0, result.stderr
+        assert ms.bulk_action_preview.call_args.args[1] == [U_A, U_B, U_C]
 
     def test_repeated_flags_accumulate(self):
         result, ms = _invoke(
             "mailsec", "message", "bulk-action", "--action", "trash_message",
-            "--msg-uuids", "a", "--msg-uuids", "b,c", "--yes",
+            "--msg-uuids", U_A, "--msg-uuids", f"{U_B},{U_C}",
             sdk_returns=_HAPPY,
         )
-        assert result.exit_code == 0, result.output
-        assert ms.bulk_action_preview.call_args.args[1] == ["a", "b", "c"]
+        assert result.exit_code == 0, result.stderr
+        assert ms.bulk_action_preview.call_args.args[1] == [U_A, U_B, U_C]
+
+    def test_the_flag_splits_on_commas_and_trims_around_them(self):
+        """Comma-only, matching every other repeatable-and-comma-separated
+        option in this CLI. Whitespace around an item is trimmed; it is not
+        itself a separator."""
+        result, ms = _invoke(
+            "mailsec", "message", "bulk-action", "--action", "trash_message",
+            "--msg-uuids", f"  {U_A} ,  {U_B}  ",
+            sdk_returns=_HAPPY,
+        )
+        assert result.exit_code == 0, result.stderr
+        assert ms.bulk_action_preview.call_args.args[1] == [U_A, U_B]
+
+    def test_a_json_array_file_is_read_as_a_list(self, tmp_path):
+        f = tmp_path / "uuids.json"
+        f.write_text(json.dumps([U_B, U_A]))
+        result, ms = _invoke(
+            "mailsec", "message", "bulk-action", "--action", "trash_message",
+            "--input-file", str(f),
+            sdk_returns=_HAPPY,
+        )
+        assert result.exit_code == 0, result.stderr
+        assert ms.bulk_action_preview.call_args.args[1] == [U_A, U_B]
+
+    def test_a_yaml_list_file_is_read_as_a_list(self, tmp_path):
+        f = tmp_path / "uuids.yaml"
+        f.write_text(f"- {U_A}\n- {U_B}\n")
+        result, ms = _invoke(
+            "mailsec", "message", "bulk-action", "--action", "trash_message",
+            "--input-file", str(f),
+            sdk_returns=_HAPPY,
+        )
+        assert result.exit_code == 0, result.stderr
+        assert ms.bulk_action_preview.call_args.args[1] == [U_A, U_B]
+
+    def test_a_dash_reads_the_selection_from_stdin(self):
+        result, ms = _invoke(
+            "mailsec", "message", "bulk-action", "--action", "trash_message",
+            "--input-file", "-",
+            input=f"{U_A}\n{U_B}\n",
+            sdk_returns=_HAPPY,
+        )
+        assert result.exit_code == 0, result.stderr
+        assert ms.bulk_action_preview.call_args.args[1] == [U_A, U_B]
+
+    def test_a_pipe_with_no_flags_is_read_as_the_selection(self):
+        """The hive commands' idiom: nothing named and a pipe attached means the
+        pipe is the input. Piping ids in is the advertised way to turn a search
+        result into an action."""
+        result, ms = _invoke(
+            "mailsec", "message", "bulk-action", "--action", "trash_message",
+            input=f"{U_A}\n{U_B}\n",
+            sdk_returns=_HAPPY,
+        )
+        assert result.exit_code == 0, result.stderr
+        assert ms.bulk_action_preview.call_args.args[1] == [U_A, U_B]
 
     def test_an_empty_selection_is_a_usage_error_before_any_call(self):
         result, ms = _invoke(
-            "mailsec", "message", "bulk-action", "--action", "trash_message", "--yes",
+            "mailsec", "message", "bulk-action", "--action", "trash_message",
             sdk_returns=_HAPPY,
         )
         assert result.exit_code != 0
@@ -184,7 +408,7 @@ class TestSelectionAssembly:
         f.write_text("\n  \n")
         result, ms = _invoke(
             "mailsec", "message", "bulk-action", "--action", "trash_message",
-            "--input-file", str(f), "--yes",
+            "--input-file", str(f),
             sdk_returns=_HAPPY,
         )
         assert result.exit_code != 0
@@ -194,119 +418,284 @@ class TestSelectionAssembly:
         """The cap is the server's and it refuses rather than truncates. A CLI
         that trimmed to 500 would report success over a selection whose tail was
         silently left in inboxes."""
-        ids = ",".join(f"m{i:04d}" for i in range(900))
+        ids = ",".join(f"{i:08x}-3a06-5aab-b3be-c1e6c15dcf10" for i in range(900))
         result, ms = _invoke(
             "mailsec", "message", "bulk-action", "--action", "trash_message",
-            "--msg-uuids", ids, "--yes",
+            "--msg-uuids", ids,
             sdk_returns=_HAPPY,
         )
-        assert result.exit_code == 0, result.output
+        assert result.exit_code == 0, result.stderr
         assert len(ms.bulk_action_preview.call_args.args[1]) == 900
 
 
-class TestConsent:
-    def test_without_yes_off_a_tty_nothing_is_executed(self):
-        """Consent has to come from someone who saw the preview. Off a TTY there
-        is nobody, so the refusal names the flag that says 'I already decided'
-        instead of prompting a stream that cannot answer."""
+class TestSelectionShape:
+    """A member that is not a message id is reported by the preview as "NOT IN
+    INDEX" — the same answer a legitimately expired id gets — so member_count
+    and mailbox_count, which are the numbers consent is given over, would be
+    quietly wrong. It is refused by name instead."""
+
+    def test_a_pasted_csv_export_is_refused_naming_its_header(self):
         result, ms = _invoke(
             "mailsec", "message", "bulk-action", "--action", "trash_message",
-            "--msg-uuids", "a", isatty=False,
+            input=f"msg_uuid,mailbox\n{U_A},cfo@corp.example\n{U_B},cto@corp.example\n",
             sdk_returns=_HAPPY,
         )
         assert result.exit_code != 0
-        assert "--yes" in result.stderr
-        ms.bulk_action_execute.assert_not_called()
+        assert "'msg_uuid' does not look like a message id" in result.stderr
+        ms.bulk_action_preview.assert_not_called()
 
-    def test_quiet_suppresses_the_preview_so_it_also_requires_yes(self):
-        """--quiet hides the very thing consent would be given to; prompting
-        anyway would be asking a human to approve a blank screen."""
-        with (
-            patch("limacharlie.commands.mailsec.Client"),
-            patch("limacharlie.commands.mailsec.Organization"),
-            patch("limacharlie.commands.mailsec.sys.stdin.isatty", return_value=True),
-            patch("limacharlie.commands.mailsec.Mailsec") as mailsec_cls,
-        ):
-            ms = MagicMock()
-            ms.bulk_action_preview.return_value = _preview()
-            mailsec_cls.return_value = ms
-            result = CliRunner().invoke(cli, [
-                "--oid", OID, "--quiet", "mailsec", "message", "bulk-action",
-                "--action", "trash_message", "--msg-uuids", "a",
-            ])
+    def test_a_headerless_csv_row_is_refused_naming_the_second_column(self):
+        result, ms = _invoke(
+            "mailsec", "message", "bulk-action", "--action", "trash_message",
+            "--msg-uuids", f"{U_A},cfo@corp.example",
+            sdk_returns=_HAPPY,
+        )
+        assert result.exit_code != 0
+        assert "'cfo@corp.example' does not look like a message id" in result.stderr
+        ms.bulk_action_preview.assert_not_called()
+
+    def test_a_truncated_id_is_refused_rather_than_reported_as_expired(self):
+        result, ms = _invoke(
+            "mailsec", "message", "bulk-action", "--action", "trash_message",
+            "--msg-uuids", "0057db2b-3a06-5aab",
+            sdk_returns=_HAPPY,
+        )
+        assert result.exit_code != 0
+        assert "does not look like a message id" in result.stderr
+        ms.bulk_action_preview.assert_not_called()
+
+    def test_a_non_string_list_entry_is_refused_rather_than_crashing(self, tmp_path):
+        """YAML types values, so a list can arrive holding a date or an int.
+        Without this the caller gets an AttributeError traceback instead of a
+        usage message."""
+        f = tmp_path / "uuids.yaml"
+        f.write_text(f"- {U_A}\n- 2026-08-01\n")
+        result, ms = _invoke(
+            "mailsec", "message", "bulk-action", "--action", "trash_message",
+            "--input-file", str(f),
+            sdk_returns=_HAPPY,
+        )
+        assert result.exit_code != 0
+        assert "expected message ids" in result.stderr
+        ms.bulk_action_preview.assert_not_called()
+
+    def test_a_mapping_document_is_refused_with_its_shape(self, tmp_path):
+        f = tmp_path / "uuids.yaml"
+        f.write_text("msg_uuids:\n  - " + U_A + "\n")
+        result, ms = _invoke(
+            "mailsec", "message", "bulk-action", "--action", "trash_message",
+            "--input-file", str(f),
+            sdk_returns=_HAPPY,
+        )
+        assert result.exit_code != 0
+        assert "one id per line" in result.stderr
+        ms.bulk_action_preview.assert_not_called()
+
+
+class TestPollIntervalAndTimeoutBounds:
+    """Both bounds are enforced by click, which means BEFORE the execute fires.
+    A --poll-interval of 0 previously issued tens of thousands of requests in
+    seconds, and a negative one crashed after the provider writes had already
+    been ordered — the worst possible moment to learn about a flag typo."""
+
+    def test_a_zero_poll_interval_is_refused(self):
+        result, ms = _invoke(
+            "mailsec", "message", "bulk-action", "--action", "trash_message",
+            "--msg-uuids", U_A, "--confirm", TOKEN, "--poll-interval", "0",
+            sdk_returns=_HAPPY,
+        )
         assert result.exit_code != 0
         ms.bulk_action_execute.assert_not_called()
 
-    def test_declining_the_prompt_executes_nothing(self):
-        with (
-            patch("limacharlie.commands.mailsec.Client"),
-            patch("limacharlie.commands.mailsec.Organization"),
-            patch("limacharlie.commands.mailsec.sys.stdin.isatty", return_value=True),
-            patch("limacharlie.commands.mailsec.Mailsec") as mailsec_cls,
-        ):
-            ms = MagicMock()
-            ms.bulk_action_preview.return_value = _preview()
-            mailsec_cls.return_value = ms
-            result = CliRunner().invoke(cli, [
-                "--oid", OID, "--output", "json", "mailsec", "message", "bulk-action",
-                "--action", "trash_message", "--msg-uuids", "a",
-            ], input="n\n")
+    def test_a_negative_poll_interval_is_refused_before_the_execute(self):
+        result, ms = _invoke(
+            "mailsec", "message", "bulk-action", "--action", "trash_message",
+            "--msg-uuids", U_A, "--confirm", TOKEN, "--poll-interval", "-1",
+            sdk_returns=_HAPPY,
+        )
         assert result.exit_code != 0
         ms.bulk_action_execute.assert_not_called()
 
-    def test_the_preview_is_shown_before_the_prompt(self):
+    def test_a_timeout_under_the_floor_is_refused(self):
+        result, ms = _invoke(
+            "mailsec", "message", "bulk-action", "--action", "trash_message",
+            "--msg-uuids", U_A, "--confirm", TOKEN, "--timeout", "0",
+            sdk_returns=_HAPPY,
+        )
+        assert result.exit_code != 0
+        ms.bulk_action_execute.assert_not_called()
+
+
+class TestTheHandleIsNeverLost:
+    def test_the_bulk_id_is_announced_before_the_first_poll(self):
         result, _ = _invoke(
             "mailsec", "message", "bulk-action", "--action", "trash_message",
-            "--msg-uuids", "a,b", "--yes",
+            "--msg-uuids", U_A, "--confirm", TOKEN,
             sdk_returns=_HAPPY,
         )
-        assert result.exit_code == 0, result.output
-        # Every member is listed, including the one that is no longer indexed:
-        # a truncated blast radius under-reports the thing being approved.
-        assert "cfo@corp.example" in result.stderr
-        assert "NOT IN INDEX" in result.stderr
-        assert "mailboxes:     1" in result.stderr
+        assert result.exit_code == 0, result.stderr
+        lines = [ln for ln in result.stderr.splitlines() if BULK_ID in ln]
+        assert lines and lines[0] == f"bulk {BULK_ID} accepted"
 
-
-class TestPreviewOnlyAndTwoStep:
-    def test_preview_only_prints_the_token_and_executes_nothing(self):
+    def test_a_failing_first_poll_still_leaves_the_caller_the_handle(self):
+        """The measured bug: a 502 on the first poll exited 1 with an empty
+        stdout and the bulk_id nowhere, orphaning a job that was running."""
         result, ms = _invoke(
             "mailsec", "message", "bulk-action", "--action", "trash_message",
-            "--msg-uuids", "a,b", "--preview-only",
-            sdk_returns=_HAPPY,
-        )
-        assert result.exit_code == 0, result.output
-        assert json.loads(result.stdout)["confirm"] == "tok-1"
-        ms.bulk_action_execute.assert_not_called()
-
-    def test_an_explicit_confirm_skips_the_preview_entirely(self):
-        """The second half of a hand-driven two-step. Re-previewing here would
-        mint a fresh token and quietly discard the one the operator reviewed."""
-        result, ms = _invoke(
-            "mailsec", "message", "bulk-action", "--action", "trash_message",
-            "--msg-uuids", "a,b", "--confirm", "3f31ed",
-            sdk_returns=_HAPPY,
-        )
-        assert result.exit_code == 0, result.output
-        ms.bulk_action_preview.assert_not_called()
-        assert ms.bulk_action_execute.call_args.args[2] == "3f31ed"
-
-    def test_preview_only_and_confirm_are_mutually_exclusive(self):
-        result, ms = _invoke(
-            "mailsec", "message", "bulk-action", "--action", "trash_message",
-            "--msg-uuids", "a", "--preview-only", "--confirm", "tok",
-            sdk_returns=_HAPPY,
+            "--msg-uuids", U_A, "--confirm", TOKEN,
+            sdk_returns={**_HAPPY, "bulk_action_status": RuntimeError("502 Bad Gateway")},
         )
         assert result.exit_code != 0
-        ms.bulk_action_preview.assert_not_called()
-        ms.bulk_action_execute.assert_not_called()
+        assert json.loads(result.stdout)["bulk_id"] == BULK_ID
+        assert BULK_ID in result.stderr
+        assert f"bulk-status {BULK_ID}" in result.stderr
+        ms.bulk_action_execute.assert_called_once()
+
+    def test_adopting_an_existing_job_is_reported_not_hidden(self):
+        """started:false is the idempotent path — a re-sent execute adopting the
+        job it already created. Saying so is what stops it reading as a second
+        batch."""
+        result, _ = _invoke(
+            "mailsec", "message", "bulk-action", "--action", "trash_message",
+            "--msg-uuids", U_A, "--confirm", TOKEN,
+            sdk_returns={**_HAPPY, "bulk_action_execute": _accepted(started=False)},
+        )
+        assert result.exit_code == 0, result.stderr
+        assert "already existed" in result.stderr
+
+
+class TestExitCodesCarryTheOutcome:
+    def test_a_completed_job_that_acted_on_something_exits_zero(self):
+        result, _ = _invoke(
+            "mailsec", "message", "bulk-action", "--action", "trash_message",
+            "--msg-uuids", U_A, "--confirm", TOKEN,
+            sdk_returns=_HAPPY,
+        )
+        assert result.exit_code == 0, result.stderr
+        assert "settled: state=complete" in result.stderr
+
+    def test_per_item_failures_inside_a_successful_batch_are_data_not_an_error(self):
+        """counts is the caller's to read. Failing the command because two of
+        five messages could not be moved would make the normal partial outcome
+        indistinguishable from a batch that did nothing."""
+        result, _ = _invoke(
+            "mailsec", "message", "bulk-action", "--action", "trash_message",
+            "--msg-uuids", U_A, "--confirm", TOKEN,
+            sdk_returns={**_HAPPY, "bulk_action_status": _status(ok=3, failed=2)},
+        )
+        assert result.exit_code == 0, result.stderr
+
+    def test_a_completed_job_that_remediated_nothing_exits_non_zero(self):
+        """ok=0 with failures means no mail moved. A runbook chained with && must
+        not proceed as though it had."""
+        result, _ = _invoke(
+            "mailsec", "message", "bulk-action", "--action", "trash_message",
+            "--msg-uuids", U_A, "--confirm", TOKEN,
+            sdk_returns={**_HAPPY, "bulk_action_status": _status(ok=0, failed=2)},
+        )
+        assert result.exit_code != 0
+        assert "NOTHING WAS REMEDIATED" in result.stderr
+
+    def test_a_batch_of_only_skips_is_still_a_success(self):
+        """Every member already where the action would put it is the honest
+        answer to a re-run, not a failure."""
+        result, _ = _invoke(
+            "mailsec", "message", "bulk-action", "--action", "trash_message",
+            "--msg-uuids", U_A, "--confirm", TOKEN,
+            sdk_returns={**_HAPPY, "bulk_action_status": _status(ok=0, skipped=2)},
+        )
+        assert result.exit_code == 0, result.stderr
+
+    def test_interrupted_is_terminal_and_non_zero(self):
+        """A rolled pod finalizes the job as interrupted with its partial
+        outcomes intact. Treating only 'complete' as terminal would poll it
+        until the timeout for an answer that already arrived — but it did not
+        finish, so it is not a success either."""
+        result, ms = _invoke(
+            "mailsec", "message", "bulk-action", "--action", "trash_message",
+            "--msg-uuids", U_A, "--confirm", TOKEN,
+            sdk_returns={**_HAPPY, "bulk_action_status": _status(state="interrupted", ok=1)},
+        )
+        assert result.exit_code != 0
+        assert ms.bulk_action_status.call_count == 1
+        assert "INTERRUPTED" in result.stderr
+
+    def test_a_stalled_job_stops_polling_and_states_the_documented_repair(self):
+        """There is deliberately no automatic resumption, so a stalled record
+        will never move on its own; polling it to the timeout would burn the
+        window in which someone could re-drive it."""
+        result, ms = _invoke(
+            "mailsec", "message", "bulk-action", "--action", "trash_message",
+            "--msg-uuids", U_A, "--confirm", TOKEN,
+            sdk_returns={
+                **_HAPPY,
+                "bulk_action_status": _status(state="running", stalled=True, ok=1, pending=1),
+            },
+        )
+        assert result.exit_code != 0
+        assert ms.bulk_action_status.call_count == 1
+        assert "STALLED" in result.stderr
+        assert (
+            "Re-send the same execute request with the same confirmation token to finish it"
+            in result.stderr
+        )
+
+    def test_a_job_still_running_at_the_timeout_exits_non_zero(self):
+        """A job that outlives the timeout is not a failure and is not silence:
+        the loop stops, says the job is unaffected, and names the command that
+        resumes the poll — and the exit code stops a chained runbook."""
+        result, ms = _invoke(
+            "mailsec", "message", "bulk-action", "--action", "trash_message",
+            "--msg-uuids", U_A, "--confirm", TOKEN,
+            sdk_returns={**_HAPPY, "bulk_action_status": _status(state="running", ok=0, pending=2)},
+            monotonic=[0.0, 10_000.0],
+        )
+        assert result.exit_code != 0
+        assert ms.bulk_action_status.call_count == 1
+        assert "still running after 300s" in result.stderr
+        assert f"bulk-status {BULK_ID}" in result.stderr
+        assert json.loads(result.stdout)["state"] == "running"
+
+    def test_an_unaccepted_execute_exits_non_zero(self):
+        """MEASURED: this previously exited 0, silently downgraded to a no-wait,
+        and reported an acceptance that had not happened."""
+        result, ms = _invoke(
+            "mailsec", "message", "bulk-action", "--action", "trash_message",
+            "--msg-uuids", U_A, "--confirm", TOKEN,
+            sdk_returns={**_HAPPY, "bulk_action_execute": _accepted(accepted=False)},
+        )
+        assert result.exit_code != 0
+        assert "NOT accepted" in result.stderr
+        ms.bulk_action_status.assert_not_called()
+        assert json.loads(result.stdout)["accepted"] is False
+
+    def test_an_execute_without_a_bulk_id_exits_non_zero(self):
+        result, ms = _invoke(
+            "mailsec", "message", "bulk-action", "--action", "trash_message",
+            "--msg-uuids", U_A, "--confirm", TOKEN,
+            sdk_returns={**_HAPPY, "bulk_action_execute": _accepted(bulk_id=None)},
+        )
+        assert result.exit_code != 0
+        ms.bulk_action_status.assert_not_called()
+
+    def test_no_wait_reports_the_acceptance_and_exits_zero(self):
+        """accepted:true IS the success being reported here; the job's outcome
+        is deliberately not being waited for."""
+        result, ms = _invoke(
+            "mailsec", "message", "bulk-action", "--action", "trash_message",
+            "--msg-uuids", U_A, "--confirm", TOKEN, "--no-wait",
+            sdk_returns=_HAPPY,
+        )
+        assert result.exit_code == 0, result.stderr
+        ms.bulk_action_status.assert_not_called()
+        assert json.loads(result.stdout)["bulk_id"] == BULK_ID
 
 
 class TestWaiting:
     def test_it_polls_until_the_job_leaves_running(self):
         result, ms = _invoke(
             "mailsec", "message", "bulk-action", "--action", "trash_message",
-            "--msg-uuids", "a,b", "--yes",
+            "--msg-uuids", U_A, "--confirm", TOKEN,
             sdk_returns={
                 **_HAPPY,
                 "bulk_action_status": [
@@ -316,98 +705,50 @@ class TestWaiting:
                 ],
             },
         )
-        assert result.exit_code == 0, result.output
+        assert result.exit_code == 0, result.stderr
         assert ms.bulk_action_status.call_count == 3
         assert json.loads(result.stdout)["state"] == "complete"
         assert "settled: state=complete" in result.stderr
 
-    def test_interrupted_is_terminal_too(self):
-        """A rolled pod finalizes the job as interrupted with its partial
-        outcomes intact. Treating only 'complete' as terminal would poll it
-        until the timeout for an answer that already arrived."""
-        result, ms = _invoke(
-            "mailsec", "message", "bulk-action", "--action", "trash_message",
-            "--msg-uuids", "a,b", "--yes",
-            sdk_returns={**_HAPPY, "bulk_action_status": _status(state="interrupted", ok=1)},
-        )
-        assert result.exit_code == 0, result.output
-        assert ms.bulk_action_status.call_count == 1
-        assert "settled: state=interrupted" in result.stderr
-
-    def test_a_stalled_job_stops_polling_and_states_the_repair(self):
-        """There is deliberately no automatic resumption, so a stalled record
-        will never move on its own; polling it to the timeout would burn the
-        window in which someone could re-drive it."""
-        result, ms = _invoke(
-            "mailsec", "message", "bulk-action", "--action", "trash_message",
-            "--msg-uuids", "a,b", "--yes",
-            sdk_returns={
-                **_HAPPY,
-                "bulk_action_status": _status(state="running", stalled=True, ok=1, pending=1),
-            },
-        )
-        assert result.exit_code == 0, result.output
-        assert ms.bulk_action_status.call_count == 1
-        assert "STALLED" in result.stderr
-        assert "--confirm" in result.stderr
-
-    def test_the_wait_is_bounded_and_says_so(self):
-        """A job that outlives the timeout is not a failure and is not silence:
-        the loop stops, says the job is unaffected, and names the command that
-        resumes the poll."""
-        result, ms = _invoke(
-            "mailsec", "message", "bulk-action", "--action", "trash_message",
-            "--msg-uuids", "a,b", "--yes", "--timeout", "0",
-            sdk_returns={**_HAPPY, "bulk_action_status": _status(state="running", ok=0, pending=2)},
-        )
-        assert result.exit_code == 0, result.output
-        assert ms.bulk_action_status.call_count == 1
-        assert "still running after 0s" in result.stderr
-        assert "bulk-status bulk-1" in result.stderr
-        assert json.loads(result.stdout)["state"] == "running"
-
-    def test_no_wait_returns_the_acceptance_without_polling(self):
-        result, ms = _invoke(
-            "mailsec", "message", "bulk-action", "--action", "trash_message",
-            "--msg-uuids", "a,b", "--yes", "--no-wait",
-            sdk_returns=_HAPPY,
-        )
-        assert result.exit_code == 0, result.output
-        ms.bulk_action_status.assert_not_called()
-        assert json.loads(result.stdout)["bulk_id"] == "bulk-1"
-
-    def test_adopting_an_existing_job_is_reported_not_hidden(self):
-        """started:false is the idempotent path — a re-sent execute adopting the
-        job it already created. Saying so is what stops it reading as a second
-        batch."""
-        result, _ = _invoke(
-            "mailsec", "message", "bulk-action", "--action", "trash_message",
-            "--msg-uuids", "a,b", "--yes",
-            sdk_returns={**_HAPPY, "bulk_action_execute": _accepted(started=False)},
-        )
-        assert result.exit_code == 0, result.output
-        assert "already existed" in result.stderr
-
     def test_stdout_carries_exactly_one_document(self):
-        """Three calls, one answer. Narration goes to stderr so `--output json`
+        """Two calls, one answer. Narration goes to stderr so `--output json`
         keeps its promise that stdout is a single parseable document."""
         result, _ = _invoke(
             "mailsec", "message", "bulk-action", "--action", "trash_message",
-            "--msg-uuids", "a,b", "--yes",
+            "--msg-uuids", U_A, "--confirm", TOKEN,
             sdk_returns=_HAPPY,
         )
-        assert result.exit_code == 0, result.output
-        assert json.loads(result.stdout)["bulk_id"] == "bulk-1"
+        assert result.exit_code == 0, result.stderr
+        assert json.loads(result.stdout)["bulk_id"] == BULK_ID
+
+    def test_exactly_one_terminal_line_is_written(self):
+        """A watcher must never end in silence, and never with two endings it
+        has to choose between."""
+        result, _ = _invoke(
+            "mailsec", "message", "bulk-action", "--action", "trash_message",
+            "--msg-uuids", U_A, "--confirm", TOKEN,
+            sdk_returns={
+                **_HAPPY,
+                "bulk_action_status": [
+                    _status(state="running", ok=0, pending=2),
+                    _status(state="complete", ok=2),
+                ],
+            },
+        )
+        assert result.exit_code == 0, result.stderr
+        terminal = [ln for ln in result.stderr.splitlines()
+                    if "settled" in ln or "STALLED" in ln or "still running after" in ln]
+        assert len(terminal) == 1, result.stderr
 
 
 class TestBulkStatusCommand:
     def test_status_reaches_the_sdk(self):
         result, ms = _invoke(
-            "mailsec", "message", "bulk-status", "bulk-1",
+            "mailsec", "message", "bulk-status", BULK_ID,
             sdk_returns={"bulk_action_status": _status()},
         )
-        assert result.exit_code == 0, result.output
-        ms.bulk_action_status.assert_called_once_with("bulk-1")
+        assert result.exit_code == 0, result.stderr
+        ms.bulk_action_status.assert_called_once_with(BULK_ID)
         assert json.loads(result.stdout)["counts"]["ok"] == 2
 
 
@@ -421,11 +762,33 @@ class TestGuidance:
         assert "move_to_spam" in result.output
         assert "submit_to_triage" not in result.output
 
-    def test_ai_help_explains_the_selection_binding(self):
+    def test_help_states_the_two_step_grammar(self):
+        result = CliRunner().invoke(cli, ["mailsec", "message", "bulk-action", "--help"])
+        assert result.exit_code == 0, result.output
+        assert "Previews unless --confirm is given" in result.output
+
+    def test_ai_help_explains_what_the_token_binds(self):
+        """The server hashes (oid, action, attempt, members). Help that named
+        only the selection would leave a caller who previewed with --attempt and
+        executed without it staring at a stale-token error about a list they
+        never changed."""
         result = CliRunner().invoke(cli, ["mailsec", "message", "bulk-action", "--ai-help"])
         assert result.exit_code == 0, result.output
-        assert "DERIVED FROM THE EXACT SELECTION" in result.output
+        assert "DERIVED FROM (action, attempt, the normalized member list)" in result.output
+        assert "--action, --msg-uuids and\n--attempt" in result.output
         assert "REFUSED, not truncated" in result.output
+
+    def test_ai_help_documents_the_exit_codes_and_quiet(self):
+        result = CliRunner().invoke(cli, ["mailsec", "message", "bulk-action", "--ai-help"])
+        assert result.exit_code == 0, result.output
+        assert "THE EXIT CODE CARRIES THE OUTCOME" in result.output
+        assert "--quiet" in result.output
+
+    def test_ai_help_no_longer_advertises_the_removed_flags(self):
+        result = CliRunner().invoke(cli, ["mailsec", "message", "bulk-action", "--ai-help"])
+        assert result.exit_code == 0, result.output
+        assert "--yes" not in result.output
+        assert "--preview-only" not in result.output
 
     def test_ai_help_for_status_explains_stalled(self):
         result = CliRunner().invoke(cli, ["mailsec", "message", "bulk-status", "--ai-help"])

--- a/tests/unit/test_sdk_mailsec.py
+++ b/tests/unit/test_sdk_mailsec.py
@@ -2,11 +2,11 @@
 
 import json
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
-from limacharlie.sdk.mailsec import Mailsec, normalize_bulk_selection
+from limacharlie.sdk.mailsec import BULK_TERMINAL_STATES, Mailsec, normalize_bulk_selection
 
 
 OID = "11111111-2222-3333-4444-555555555555"
@@ -370,9 +370,12 @@ class TestBulkRemediation:
         assert preview_body["msg_uuids"] == execute_body["msg_uuids"] == ["a", "b", "c"]
 
     def test_banner_is_spelled_banner_on_the_wire(self, ms, mock_org):
-        """The gateway translates `banner` to the collector's `banner_html`.
-        Sending banner_html here would be dropped by its allow-list, and
-        banner_message would run with no banner."""
+        """`banner` is the PUBLIC spelling; the gateway translates it to the
+        collector's `banner_html` (mailsecBulkExecuteArgs). Its allow-list
+        happens to forward a literal `banner_html` too, so both would in fact
+        work — but only `banner` is in the documented body schema, and pinning
+        the documented name is what keeps this client on the contract rather
+        than on an implementation detail of the forwarder."""
         ms.bulk_action_execute("banner_message", ["a"], "tok", banner="<b>caution</b>")
         _, body = _post_call(mock_org)
         assert body["banner"] == "<b>caution</b>"
@@ -403,6 +406,91 @@ class TestBulkRemediation:
         ms.bulk_action_status("a/b")
         url, _ = _get_call(mock_org)
         assert url == f"mailsec/{OID}/actions/bulk/a%2Fb"
+
+
+def _bulk_status(state="running", stalled=False, ok=0):
+    return {"bulk_id": "b", "state": state, "stalled": stalled,
+            "counts": {"total": 2, "ok": ok, "failed": 0, "pending": 2 - ok}}
+
+
+class TestWaitForBulk:
+    """Three things stop the wait, and conflating any two of them costs a real
+    operator real time: a finished job, a job nobody is working, and a deadline
+    that says nothing about the job at all."""
+
+    def test_it_polls_until_the_job_leaves_running(self, ms):
+        ms.bulk_action_status = MagicMock(side_effect=[
+            _bulk_status("running"),
+            _bulk_status("running", ok=1),
+            _bulk_status("complete", ok=2),
+        ])
+        with patch("limacharlie.sdk.mailsec.time.sleep") as sleep:
+            final = ms.wait_for_bulk("b", timeout=300, poll_interval=3)
+        assert final["state"] == "complete"
+        assert ms.bulk_action_status.call_count == 3
+        assert sleep.call_count == 2
+
+    def test_interrupted_is_terminal_too(self, ms):
+        """A worker that lost its pod finalizes the record with the outcomes it
+        had. The answer has already arrived; polling for a different one would
+        burn the whole timeout."""
+        ms.bulk_action_status = MagicMock(return_value=_bulk_status("interrupted", ok=1))
+        final = ms.wait_for_bulk("b", timeout=300)
+        assert final["state"] == "interrupted"
+        assert ms.bulk_action_status.call_count == 1
+
+    def test_the_terminal_states_are_the_two_the_gateway_defines(self):
+        assert BULK_TERMINAL_STATES == ("complete", "interrupted")
+
+    def test_stalled_stops_the_wait_even_though_the_job_is_running(self, ms):
+        """There is deliberately no automatic resumption: the record is not
+        being heartbeaten, so no amount of further polling will move it."""
+        ms.bulk_action_status = MagicMock(return_value=_bulk_status("running", stalled=True))
+        final = ms.wait_for_bulk("b", timeout=300)
+        assert final["stalled"] is True
+        assert final["state"] == "running"
+        assert ms.bulk_action_status.call_count == 1
+
+    def test_the_deadline_returns_the_last_running_document(self, ms):
+        """No exception, following Jobs.wait: a document that comes back running
+        and not stalled is one the deadline ended, and the caller is the only
+        one who knows whether that matters."""
+        ms.bulk_action_status = MagicMock(return_value=_bulk_status("running"))
+        with patch("limacharlie.sdk.mailsec.time.monotonic", side_effect=[0.0, 10_000.0]):
+            final = ms.wait_for_bulk("b", timeout=300)
+        assert final["state"] == "running"
+        assert final["stalled"] is False
+        assert ms.bulk_action_status.call_count == 1
+
+    def test_the_sleep_never_overshoots_the_deadline(self, ms):
+        """A 300s poll interval against a 5s timeout must not park the caller
+        for five minutes past the deadline it asked for."""
+        ms.bulk_action_status = MagicMock(return_value=_bulk_status("running"))
+        with (
+            patch("limacharlie.sdk.mailsec.time.monotonic", side_effect=[0.0, 2.0, 10.0]),
+            patch("limacharlie.sdk.mailsec.time.sleep") as sleep,
+        ):
+            ms.wait_for_bulk("b", timeout=5, poll_interval=300)
+        assert sleep.call_args.args[0] == 3.0
+
+    def test_on_poll_sees_every_status_document(self, ms):
+        """The CLI narrates from this; a callback that skipped the terminal poll
+        would make a caller reconstruct the ending from the return value."""
+        seen = []
+        ms.bulk_action_status = MagicMock(side_effect=[
+            _bulk_status("running"), _bulk_status("complete", ok=2),
+        ])
+        with patch("limacharlie.sdk.mailsec.time.sleep"):
+            ms.wait_for_bulk("b", on_poll=seen.append)
+        assert [s["state"] for s in seen] == ["running", "complete"]
+
+    def test_it_adds_no_route_of_its_own(self, ms, mock_org):
+        """It is a loop over an existing route, not a new capability. If this
+        ever issued anything else, the route inventory below would be wrong."""
+        mock_org.client.request.return_value = _bulk_status("complete", ok=2)
+        ms.wait_for_bulk("b")
+        for call in mock_org.client.request.call_args_list:
+            assert call.args == ("GET", f"mailsec/{OID}/actions/bulk/b")
 
 
 class TestPathSegmentsAreEscaped:

--- a/tests/unit/test_sdk_mailsec.py
+++ b/tests/unit/test_sdk_mailsec.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from limacharlie.sdk.mailsec import Mailsec
+from limacharlie.sdk.mailsec import Mailsec, normalize_bulk_selection
 
 
 OID = "11111111-2222-3333-4444-555555555555"
@@ -289,6 +289,122 @@ class TestRules:
         assert body["since"] == "2026-08-01"
 
 
+class TestBulkSelectionNormalization:
+    """The confirmation token is DERIVED from the normalized member list, so
+    this function is the contract and not a tidy-up: if the client's
+    normalization disagreed with the server's, a preview a human approved would
+    mint a token its own execute could not spend."""
+
+    def test_duplicates_collapse_and_order_is_canonical(self):
+        assert normalize_bulk_selection(["b", "a", "b", " a "]) == ["a", "b"]
+
+    def test_reordering_the_input_does_not_change_the_selection(self):
+        """The property the token binding rests on: the same SET is the same
+        list, whatever order a caller happened to build it in."""
+        assert normalize_bulk_selection(["c", "a", "b"]) == normalize_bulk_selection(["b", "c", "a"])
+
+    def test_blank_entries_are_dropped_not_sent(self):
+        assert normalize_bulk_selection(["a", "", "   ", "b"]) == ["a", "b"]
+
+    def test_an_empty_selection_is_refused(self):
+        with pytest.raises(ValueError, match="at least one msg_uuid"):
+            normalize_bulk_selection([])
+
+    def test_a_selection_of_only_blanks_is_refused(self):
+        """Empty AFTER normalization is still empty; a caller that passed
+        whitespace gets the same refusal as one who passed nothing."""
+        with pytest.raises(ValueError, match="at least one msg_uuid"):
+            normalize_bulk_selection(["", "  "])
+
+    def test_a_bare_string_is_refused_rather_than_split_into_characters(self):
+        with pytest.raises(ValueError, match="not a single string"):
+            normalize_bulk_selection("0057db2b-3a06-5aab-b3be-c1e6c15dcf10")
+
+    def test_the_cap_is_not_enforced_client_side(self):
+        """500 is the SERVER's policy and it refuses an oversized selection
+        rather than truncating it. A client that trimmed to fit would leave the
+        remainder in inboxes nobody looks at, and the caller would never learn
+        it had happened."""
+        assert len(normalize_bulk_selection([f"m{i:04d}" for i in range(900)])) == 900
+
+
+class TestBulkRemediation:
+    def test_preview_sends_the_normalized_selection(self, ms, mock_org):
+        ms.bulk_action_preview("quarantine_message", ["b", "a", "a"], attempt="inc-1")
+        url, body = _post_call(mock_org)
+        assert url == f"mailsec/{OID}/actions/bulk/preview"
+        assert body == {
+            "action": "quarantine_message",
+            "msg_uuids": ["a", "b"],
+            "attempt": "inc-1",
+        }
+
+    def test_preview_omits_an_absent_attempt(self, ms, mock_org):
+        """attempt participates in the token, so an absent one and an empty one
+        are different selections. Sending "" for absent would mint a token the
+        server derived over a different input."""
+        ms.bulk_action_preview("trash_message", ["a"])
+        _, body = _post_call(mock_org)
+        assert "attempt" not in body
+
+    def test_execute_carries_the_confirmation_and_the_same_list(self, ms, mock_org):
+        ms.bulk_action_execute("trash_message", ["b", "a"], "tok-1", attempt="inc-1")
+        url, body = _post_call(mock_org)
+        assert url == f"mailsec/{OID}/actions/bulk/execute"
+        assert body == {
+            "action": "trash_message",
+            "msg_uuids": ["a", "b"],
+            "confirm": "tok-1",
+            "attempt": "inc-1",
+        }
+
+    def test_preview_and_execute_agree_on_the_wire_selection(self, ms, mock_org):
+        """The binding property, asserted where it is actually observable: two
+        differently-ordered spellings of one set produce byte-identical
+        msg_uuids on both routes, so a token minted by the preview is spendable
+        by the execute."""
+        ms.bulk_action_preview("trash_message", ["c", "a", "b"])
+        _, preview_body = _post_call(mock_org)
+        ms.bulk_action_execute("trash_message", ["b", "c", "a"], "tok-1")
+        _, execute_body = _post_call(mock_org)
+        assert preview_body["msg_uuids"] == execute_body["msg_uuids"] == ["a", "b", "c"]
+
+    def test_banner_is_spelled_banner_on_the_wire(self, ms, mock_org):
+        """The gateway translates `banner` to the collector's `banner_html`.
+        Sending banner_html here would be dropped by its allow-list, and
+        banner_message would run with no banner."""
+        ms.bulk_action_execute("banner_message", ["a"], "tok", banner="<b>caution</b>")
+        _, body = _post_call(mock_org)
+        assert body["banner"] == "<b>caution</b>"
+        assert "banner_html" not in body
+
+    def test_execute_omits_absent_optionals(self, ms, mock_org):
+        ms.bulk_action_execute("trash_message", ["a"], "tok")
+        _, body = _post_call(mock_org)
+        assert set(body) == {"action", "msg_uuids", "confirm"}
+
+    def test_an_empty_selection_never_reaches_the_network(self, ms, mock_org):
+        for call in (
+            lambda: ms.bulk_action_preview("trash_message", []),
+            lambda: ms.bulk_action_execute("trash_message", [], "tok"),
+        ):
+            mock_org.client.request.reset_mock()
+            with pytest.raises(ValueError, match="at least one msg_uuid"):
+                call()
+            mock_org.client.request.assert_not_called()
+
+    def test_status_reads_the_job_by_id(self, ms, mock_org):
+        ms.bulk_action_status("bulk-1")
+        url, qp = _get_call(mock_org)
+        assert url == f"mailsec/{OID}/actions/bulk/bulk-1"
+        assert qp is None
+
+    def test_a_slash_in_a_bulk_id_cannot_change_the_route(self, ms, mock_org):
+        ms.bulk_action_status("a/b")
+        url, _ = _get_call(mock_org)
+        assert url == f"mailsec/{OID}/actions/bulk/a%2Fb"
+
+
 class TestPathSegmentsAreEscaped:
     """A caller-supplied id must not be able to change which route is addressed.
 
@@ -360,9 +476,14 @@ class TestRouteCoverage:
             (lambda: ms.validate_rule({}), "POST", f"mailsec/{OID}/rules/validate"),
             (lambda: ms.backtest_rule({}), "POST", f"mailsec/{OID}/rules/backtest"),
             (lambda: ms.test_connection("rec"), "POST", f"mailsec/{OID}/connections/rec/test"),
+            (lambda: ms.bulk_action_preview("trash_message", ["m"]), "POST",
+             f"mailsec/{OID}/actions/bulk/preview"),
+            (lambda: ms.bulk_action_execute("trash_message", ["m"], "tok"), "POST",
+             f"mailsec/{OID}/actions/bulk/execute"),
+            (lambda: ms.bulk_action_status("b"), "GET", f"mailsec/{OID}/actions/bulk/b"),
         ]
-        # 25 gateway routes, 25 SDK methods.
-        assert len(calls) == 25
+        # 28 gateway routes, 28 SDK methods.
+        assert len(calls) == 28
         for fn, method, expected_url in calls:
             mock_org.client.request.reset_mock()
             fn()


### PR DESCRIPTION
Binds the three bulk-remediation routes the API gateway serves as SDK methods and two CLI verbs. This is what turns any search result — the message index, a hunt, a shell pipeline — into provider-side action, instead of a loop of single-message calls.

## The routes

| Route | Permission | Shape |
| --- | --- | --- |
| `POST /mailsec/{oid}/actions/bulk/preview` | `mailsec.get` | Reads the index, reports per-message state, mints a selection-bound `confirm`. Changes nothing and creates no job. A POST only because it carries up to 500 ids. |
| `POST /mailsec/{oid}/actions/bulk/execute` | `mailsec.act` | Accepts a confirmed action and returns a `bulk_id` immediately. The provider work runs on the collector that holds the org's lease. |
| `GET /mailsec/{oid}/actions/bulk/{bulk_id}` | `mailsec.get` | The durable job record: `state`, running `counts`, per-message `items` with each one's `action_id`, and `stalled`. |

Vocabulary: `quarantine_message`, `trash_message`, `move_to_spam`, `restore_message`, `banner_message`, `unbanner_message`. Note it is not the per-message list — it adds `move_to_spam` and drops `submit_to_triage`, which moves no mail.

## The property this is built around

The `confirm` token is **derived from the exact selection**, not issued as a nonce: it hashes (oid, action, attempt, normalized member list). Any change to any of those invalidates it. So a client that re-ran its search between the preview a human read and the execute it sent is refused rather than acting on messages nobody approved.

The CLI therefore normalizes **one** list — trim, drop blanks, dedupe, sort, mirroring the server's own normalization — and never rebuilds it. Because the token binds the attempt and the action too, the help text names all three (`--action`, `--msg-uuids`, `--attempt`) rather than only the selection: previewing with `--attempt inc-9` and executing without it is a stale-token error pointing at a list the caller never changed.

## CLI

```
limacharlie mailsec message bulk-action --action ACTION
    [--msg-uuids a,b,c]... [--input-file uuids.txt|-]
    [--attempt TOKEN] [--banner HTML] [--confirm TOKEN]
    [--wait/--no-wait] [--timeout 300] [--poll-interval 3]

limacharlie mailsec message bulk-status BULK_ID
```

**The grammar is the siblings' grammar.** `campaign action` and `hunt remediate`, in this same file, spell the two-step one way: omit `--confirm` to preview, pass `--confirm TOKEN` to execute. `bulk-action` now does the same.

| | |
| --- | --- |
| no `--confirm` | Runs the preview. The blast-radius report goes to stderr for a human; the preview **document**, `confirm` token included, goes to stdout for a script. Exit 0. Nothing is changed. |
| `--confirm TOKEN` | Skips the preview entirely — re-previewing would mint a fresh token and discard the one that was reviewed — and executes the normalized selection. |

There is no `--yes`, no `--preview-only`, no prompt and no mutual-exclusion guard. Note that within the mailsec group `--confirm` takes a value, unlike the boolean `--confirm` used by 19 other command modules; a bare `--confirm` now fails with click's "requires an argument", which is the safe direction.

Selection input: `--msg-uuids` (repeatable, comma-separated), `--input-file` (a JSON/YAML list or one id per line, `-` for stdin), or — following hive.py's idiom — piped stdin when neither is named.

- **Every member is listed**, including the ones no longer indexed. The point of the preview is the blast radius, and a truncated one under-reports exactly the thing being approved. `mailbox_count` is shown beside the message count because "38 messages" and "38 people's inboxes" feel very different.
- **The wait is bounded and always terminates with exactly one line**, whichever of `complete`, `interrupted`, `stalled` or the deadline stopped it.
- **stdout carries exactly one document.** Progress narration, the job handle and the terminal line go to stderr, so `--output json` keeps its promise.

## The exit code carries the outcome

A runbook chains with `&&` and reads nothing else, so the outcome has to be in the exit code:

| Outcome | Exit |
| --- | --- |
| Preview produced a token | 0 |
| `--no-wait`, `accepted: true` | 0 |
| `complete`, at least one message acted on | 0 (per-item failures are the caller's data, in `counts`) |
| `complete` with `ok == 0` and failures | non-zero — nothing was remediated |
| `interrupted` / `stalled` / still running at the timeout | non-zero |
| `accepted != true`, no `bulk_id`, or a poll that errored | non-zero |

The stall message states the gateway's own documented repair: *re-send the same execute request with the same confirmation token to finish it* — every message already acted on collapses onto its existing action row rather than being acted on twice.

`--quiet` silences both streams, as it does everywhere in this CLI; with it, the exit code above and `bulk-status` are how the result is read. The explain text says so.

## Two deliberate deviations from the obvious shape

**No `--reason`.** The gateway's execute allow-list forwards only `action`, `msg_uuids`, `confirm`, `attempt` and the banner. A `reason` would be accepted by this client and dropped in transit — a justification that silently never reaches the audit trail is worse than one the caller knows it cannot give. Documented in the explain text, which points at `mailsec message action --reason` for the per-message case.

**No client-side 500 cap.** The server refuses an oversized selection rather than truncating it, and names the cap in the refusal (`error_code: bulk_too_large`). A client that trimmed 900 to 500 would report success over a batch whose tail was silently left in inboxes nobody will look at.

## Honest outcomes, preserved

Expired ids and already-done messages are **reported, not dropped and not errors** — acting on a search result taken minutes ago legitimately includes both. They stay in the confirmed set and the provider re-checks each one, because `already_in_target_state` is read off the index and is advisory. Partial failure is reported beside what worked and is never a rollback: provider actions are not transactional, and "restoring" a quarantined message is a second visible move in somebody's mailbox rather than an undo.

## Review pass

Beyond the grammar and the exit codes, six things the review found and this now fixes:

- **The bulk_id could be orphaned.** Measured: a 502 on the first poll exited 1 with an empty stdout and the id nowhere, leaving a running job with no handle. It is now announced on stderr *before* anything that can fail, and a failed poll prints the resume command and puts the acceptance document (which carries the id) on stdout.
- **`--poll-interval 0` issued 30,580 requests in two seconds**, and a negative one crashed *after* the provider writes were already ordered. Both bounds are now `click.IntRange`, enforced before the execute fires.
- **A pasted CSV export silently corrupted the consent surface.** Its header row and second column became members, and the preview reports a phantom member as "NOT IN INDEX" — the same answer a legitimately expired id gets — so `member_count` and `mailbox_count` were wrong in a way nobody could see. Ids are now shape-checked against the msg_uuid format (the backend derives them as v5-shaped UUIDs) and a bad one is refused *by name*.
- **The preview rendered itself away in a table.** Measured: `format_table` renders `messages` as `[2 items]` and `summary` as `{7 keys}`, and those two *are* the preview. Now that the preview is this verb's default output, it falls back to JSON when the format would be a table. (The token itself was never truncated — the gateway's is 32 hex characters and the renderer's cell width never drops below 40 — but it is also printed on stderr, so a copy-paste does not depend on that arithmetic staying true.)
- **The wait loop moved into the SDK** as `Mailsec.wait_for_bulk`, mirroring `Jobs.wait`: three terminal conditions, the last status document returned either way, no timeout exception. The CLI half is now narration only. It uses the existing status route, so the route inventory stays at 28.
- **Reuse convergence**: `--input-file` goes through `_input_helpers`' canonical loader (whose docstring mandates it for new code) and accepts `-`; `_note` becomes a shared `note()` beside `command_output` in `_output_helpers`. The local id splitter deliberately stays local — a cross-module comma-split helper would widen this PR past its subject — but is now comma-only, matching the twelve existing comma-splitters.

One thing the review flagged that turned out to be **correct as written**, checked against the gateway source: the SDK sends `banner`, and `mailsecBulkExecuteArgs` translates it to the collector's `banner_html`. The pin stays. Its test *comment* did not: it claimed the allow-list would drop a literal `banner_html`, which is false (it forwards both spellings), and a pin that encodes a wrong belief about the gateway is worse than no pin. The comment now says what the allow-list actually does and why the documented public name is still the one to pin.

## Tests

`tests/unit/test_cli_mailsec_bulk.py` (54 tests) and the `TestBulkSelectionNormalization` / `TestBulkRemediation` / `TestWaitForBulk` trio in `tests/unit/test_sdk_mailsec.py` (64 tests in the file). The CLI tests wire `wait_for_bulk` to the real SDK implementation and stub only the HTTP-facing status call, so the loop whose terminal semantics decide the exit code is the shipped one.

Covered: preview-as-default and the token on stdout; the two-step sending a byte-identical selection across two invocations; every exit code in the table above; the first-poll exception leaving the bulk_id in both streams; `--poll-interval` and `--timeout` rejections happening before the execute; stdin via `-` and via a bare pipe; JSON-array and YAML-list input files; the CSV-paste refusal naming its offending token; the table-format preview keeping its substance; and `wait_for_bulk`'s three terminal conditions. The route-coverage inventory stays exact at 28.

The old prompt-path tests are not carried forward: they were inert, because the `sys.stdin.isatty` patch never took effect under `CliRunner`.

Full suite: **4083 passed, 5 skipped** (up from 4048; the 5 are pre-existing platform/docstring skips).
