### PR TITLE
mailsec: `--reason` on `message bulk-action` (+ SDK parameter)

### DIFF
--- a/limacharlie/commands/mailsec.py
+++ b/limacharlie/commands/mailsec.py
@@ -192,6 +192,13 @@ execute must therefore repeat the IDENTICAL --action, --msg-uuids and
 --attempt the preview was minted with; change any of the three and the
 server refuses the token as stale rather than acting on a set nobody read.
 
+--reason is NOT one of them. It is your justification, recorded on the
+job's audit row and on every message's, and it belongs to the execute
+alone — rewording it does not invalidate a token you already hold, and
+does not start a second job over the same messages. Passing it to a
+preview does nothing, which the command says rather than accepting it
+quietly.
+
 Expired ids and already-done messages are REPORTED, not errors and not
 dropped. They stay in the confirmed set, and the provider re-checks each
 one and answers `skipped` — the index only records where remediation last
@@ -1063,6 +1070,10 @@ def message_revisions(ctx, msg_uuid) -> None:
               help="Idempotency token. It is part of the confirmation, so a NEW attempt over the "
                    "same selection is a deliberate second run rather than a re-run of the first.")
 @click.option("--banner", default=None, help="Banner HTML, for banner_message. Applies to the whole batch.")
+@click.option("--reason", default=None,
+              help="Why you are doing this. Recorded on the job's audit row and on every message's, "
+                   "the same way `message action --reason` records one. It is NOT part of the "
+                   "confirmation, so rewording it does not invalidate a token or start a second job.")
 @click.option("--confirm", default=None,
               help="Pass the token the preview returned to EXECUTE. Omit to preview. The token is "
                    "derived from the action, the attempt and the member list, so the execute must "
@@ -1074,7 +1085,7 @@ def message_revisions(ctx, msg_uuid) -> None:
 @click.option("--poll-interval", default=3, type=click.IntRange(min=1),
               help="Seconds between polls (default: 3).")
 @pass_context
-def message_bulk_action(ctx, action_name, msg_uuids, input_file, attempt, banner, confirm,
+def message_bulk_action(ctx, action_name, msg_uuids, input_file, attempt, banner, reason, confirm,
                         wait, timeout, poll_interval) -> None:
     """Remediate a set of messages you name, in bulk (mailsec.act).
 
@@ -1093,7 +1104,7 @@ def message_bulk_action(ctx, action_name, msg_uuids, input_file, attempt, banner
     \b
     Example:
       limacharlie mailsec message bulk-action --action trash_message --msg-uuids 0057db2b-...
-      limacharlie mailsec message bulk-action --action trash_message --msg-uuids 0057db2b-... --confirm 3f31ed...
+      limacharlie mailsec message bulk-action --action trash_message --msg-uuids 0057db2b-... --confirm 3f31ed... --reason "INC-4471"
     """
     # ONE list, normalized once, used by both calls. Rebuilding it between the
     # preview and the execute would be a second chance to disagree with the set
@@ -1102,13 +1113,19 @@ def message_bulk_action(ctx, action_name, msg_uuids, input_file, attempt, banner
     ms = _get_mailsec(ctx)
 
     if not confirm:
+        if reason:
+            # Said out loud rather than dropped. The preview mints the
+            # confirmation and takes no reason by design — one that reached it
+            # could end up in the token, which would mean rewording a
+            # justification invalidated a selection somebody already approved.
+            note(ctx, "--reason applies to the execute, not the preview; pass it again with --confirm")
         preview = ms.bulk_action_preview(action_name, selection, attempt=attempt)
         _echo_bulk_preview(ctx, preview)
         _output_preview(ctx, preview)
         return
 
     accepted = ms.bulk_action_execute(
-        action_name, selection, confirm, attempt=attempt, banner=banner,
+        action_name, selection, confirm, attempt=attempt, banner=banner, reason=reason,
     )
     bulk_id = accepted.get("bulk_id")
     if not accepted.get("accepted") or not bulk_id:

--- a/limacharlie/sdk/mailsec.py
+++ b/limacharlie/sdk/mailsec.py
@@ -576,6 +576,7 @@ class Mailsec:
         *,
         attempt: str | None = None,
         banner: str | None = None,
+        reason: str | None = None,
     ) -> dict[str, Any]:
         """Execute a previewed bulk action. Requires ``mailsec.act``.
 
@@ -609,6 +610,11 @@ class Mailsec:
             banner: Banner HTML for ``banner_message``, supplied once for the
                 whole batch — it carries the org's text, which is a property of
                 the org rather than of any one message.
+            reason: Free-text justification, recorded on the job's audit row AND
+                on every message's, exactly as :meth:`act_on_message` records it
+                for one. It is deliberately NOT part of the confirmation, so
+                rewording it between previewing and executing neither invalidates
+                the token nor starts a second job over the same messages.
 
         Returns:
             ``{"accepted": True, "bulk_id": str, "state": str, "counts": {...},
@@ -618,19 +624,20 @@ class Mailsec:
             not a failure.
 
         Note:
-            There is deliberately no ``reason``. The gateway forwards only
-            ``action``, ``msg_uuids``, ``confirm``, ``attempt`` and the banner on
-            this route, so a reason would be accepted by this client and dropped
-            in transit — a justification that silently never reaches the audit
-            trail is worse than one the caller knows it cannot give. Per-message
-            reasons remain available through :meth:`act_on_message`.
+            ``reason`` requires a backend that reads it. Older deployments
+            forwarded only ``action``, ``msg_uuids``, ``confirm``, ``attempt``
+            and the banner on this route and dropped a reason in transit; against
+            those, a justification sent here never reaches the audit trail. It is
+            an ordinary optional argument rather than a version probe, because a
+            client cannot tell the two apart from the response — the execute
+            answers 200 either way.
         """
         body: dict[str, Any] = {
             "action": action,
             "msg_uuids": normalize_bulk_selection(msg_uuids),
             "confirm": confirm,
         }
-        for key, val in (("attempt", attempt), ("banner", banner)):
+        for key, val in (("attempt", attempt), ("banner", banner), ("reason", reason)):
             if val is not None:
                 body[key] = val
         return self._post("actions/bulk/execute", body)

--- a/tests/unit/test_cli_mailsec_bulk.py
+++ b/tests/unit/test_cli_mailsec_bulk.py
@@ -551,6 +551,35 @@ class TestTheHandleIsNeverLost:
         assert f"bulk-status {BULK_ID}" in result.stderr
         ms.bulk_action_execute.assert_called_once()
 
+    def test_the_reason_reaches_the_execute(self):
+        """The justification a human typed, on the verb that moves up to 500
+        people's mail. It is recorded on the job's audit row and on every
+        message's — the same record `message action --reason` produces for one."""
+        result, ms = _invoke(
+            "mailsec", "message", "bulk-action", "--action", "trash_message",
+            "--msg-uuids", U_A, "--confirm", TOKEN, "--reason", "INC-4471",
+            sdk_returns=_HAPPY,
+        )
+        assert result.exit_code == 0, result.stderr
+        assert ms.bulk_action_execute.call_args.kwargs["reason"] == "INC-4471"
+
+    def test_a_reason_on_a_preview_is_said_out_loud_not_dropped(self):
+        """The preview mints the confirmation and takes no reason by design: one
+        that reached it could enter the token, and rewording a justification
+        would then invalidate a selection somebody had already approved. So the
+        verb SAYS the reason applies to the execute rather than accepting it
+        quietly — a justification silently discarded is worse than a refused one,
+        because the caller believes it was recorded."""
+        result, ms = _invoke(
+            "mailsec", "message", "bulk-action", "--action", "trash_message",
+            "--msg-uuids", U_A, "--reason", "INC-4471",
+            sdk_returns=_HAPPY,
+        )
+        assert result.exit_code == 0, result.stderr
+        assert "--reason applies to the execute" in result.stderr
+        # And it really did not travel: the preview call carries no reason.
+        assert "reason" not in ms.bulk_action_preview.call_args.kwargs
+
     def test_adopting_an_existing_job_is_reported_not_hidden(self):
         """started:false is the idempotent path — a re-sent execute adopting the
         job it already created. Saying so is what stops it reading as a second

--- a/tests/unit/test_sdk_mailsec.py
+++ b/tests/unit/test_sdk_mailsec.py
@@ -386,6 +386,27 @@ class TestBulkRemediation:
         _, body = _post_call(mock_org)
         assert set(body) == {"action", "msg_uuids", "confirm"}
 
+    def test_execute_carries_the_operator_reason(self, ms, mock_org):
+        """The justification a human typed, on the route that moves up to 500
+        people's mail at once. It reaches the job's audit row and every
+        message's, the same way act_on_message's does for one."""
+        ms.bulk_action_execute("trash_message", ["a"], "tok", reason="INC-4471")
+        _, body = _post_call(mock_org)
+        assert body["reason"] == "INC-4471"
+
+    def test_the_preview_takes_no_reason(self, ms, mock_org):
+        """The other half, and the reason the execute may carry one at all.
+
+        The preview mints the confirmation, which the backend derives from
+        (oid, action, attempt, members) and NOT from the reason. A reason that
+        reached the preview could end up in that derivation, which would mean
+        rewording a justification invalidated a selection somebody had already
+        approved — and minted a second bulk id over the same messages. So it is
+        not a parameter here, and the gateway's own preview allow-list refuses
+        to forward one."""
+        with pytest.raises(TypeError):
+            ms.bulk_action_preview("trash_message", ["a"], reason="INC-4471")
+
     def test_an_empty_selection_never_reaches_the_network(self, ms, mock_org):
         for call in (
             lambda: ms.bulk_action_preview("trash_message", []),


### PR DESCRIPTION
> **Requires the backend PRs to be merged and deployed first.** Without them the reason is
> accepted here and discarded in transit. Merge order is backend → gateway → **this, last**.
> Draft, and not to be merged before the other two ship.

## Why the SDK said there was no reason

`Mailsec.bulk_action_execute`'s docstring carried this note:

> There is deliberately no `reason`. The gateway forwards only `action`, `msg_uuids`,
> `confirm`, `attempt` and the banner on this route, so a reason would be accepted by this
> client and dropped in transit — a justification that silently never reaches the audit trail
> is worse than one the caller knows it cannot give.

That was the right call against the backend as it stood. The backend changes it: the gateway
now forwards `reason`, and the collector records it on the job's audit row **and** on every
message's — the same record `act_on_message(..., reason=...)` produces for one message.

## The change

- `Mailsec.bulk_action_execute(..., reason=None)`, sent only when supplied (the same
  omit-when-absent discipline every other optional on these routes uses).
- `limacharlie mailsec message bulk-action --reason`, passed on the **execute**.
- The docstring note is replaced with an accurate one: `reason` needs a backend that reads
  it, and a client cannot detect an older one from the response — the execute answers 200
  either way, which is exactly why the old note existed.

## The preview still takes no reason, on purpose

The preview mints the confirmation, and the backend derives that token from
`(oid, action, attempt, members)`. A reason that reached the preview could end up in the
derivation, and then rewording a justification would invalidate a selection somebody had
already approved — and mint a **second bulk id**, i.e. a second job over the same 500
messages instead of the idempotent adoption the design guarantees.

So `--reason` without `--confirm` **prints a note** saying it applies to the execute, rather
than accepting it quietly. A justification silently discarded is worse than a refused one,
because the caller believes it was recorded — which is the entire failure this PR exists to
end, and it would be embarrassing to reintroduce it one layer up.

## Tests

`tests/unit/test_sdk_mailsec.py`
- `test_execute_carries_the_operator_reason`
- `test_the_preview_takes_no_reason` — the structural half, asserted as a `TypeError`.

`tests/unit/test_cli_mailsec_bulk.py`
- `test_the_reason_reaches_the_execute`
- `test_a_reason_on_a_preview_is_said_out_loud_not_dropped`, which also asserts the reason
  did not travel on the preview call.

`pytest tests/unit/` → **3996 passed, 6 skipped** (the same 6 skips as `origin/master`; my
four are the delta from 3992).

## Not included

No `CHANGELOG.md` entry and no version bump: the changelog here is organized per released
version with no Unreleased section, and choosing the version this lands in is a release
decision rather than part of the change.