### PR TITLE
discovery: repair the 20 rotted PROFILES entries and lint them

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,31 @@
+# python-limacharlie
+
+Python SDK and CLI for LimaCharlie. `NEW_CLI.md` is the CLI design document.
+`.claude/docs/sdk-docstring-conventions.md` is the docstring checklist for
+`limacharlie/sdk/`.
+
+Run the tests the way CI does: `pytest tests/unit/ tests/microbenchmarks/`.
+
+## Adding, renaming, or moving a CLI command
+
+Three hand-maintained maps describe the command surface. None of them updates
+itself. Update all of them in the same change:
+
+1. **`limacharlie/cli.py` — `_COMMAND_MODULE_MAP`.** Maps a top-level command
+   name to its module so the CLI can lazy-load it. Enforced by
+   `tests/unit/test_cli_command_map_lint.py`.
+2. **`limacharlie/discovery.py` — `PROFILES`.** Groups commands by use-case;
+   this is what `limacharlie help discover` prints. A verb in no profile is
+   invisible to anyone — or any agent — discovering the CLI, and an entry
+   naming a command that no longer exists prints advice that cannot be
+   followed. Enforced by `tests/unit/test_discovery.py`.
+3. **`doc/cli/`.** The user-facing command reference.
+
+Reuse an existing profile name where one fits. `PROFILES` is meant to mirror
+the profiles the LimaCharlie MCP server exposes (`NEW_CLI.md` §1.1), so the
+names are a cross-repo contract, not a local choice.
+
+When the lint reports a `PROFILES` entry that no longer resolves, find the
+command's current spelling before touching the entry — most rotted entries were
+renamed or moved, not removed. Drop an entry only when the command is genuinely
+gone or has become a flag on another command.

--- a/limacharlie/discovery.py
+++ b/limacharlie/discovery.py
@@ -13,7 +13,7 @@ PROFILES = {
     "sensor_management": {
         "description": "Sensor lifecycle, deployment, and monitoring commands",
         "commands": [
-            "sensor list", "sensor get", "sensor delete", "sensor online",
+            "sensor list", "sensor get", "sensor delete",
             "sensor wait-online", "sensor upgrade", "sensor set-version",
             "sensor export", "sensor dump", "sensor sweep",
             "tag list", "tag add", "tag remove", "tag find",
@@ -26,19 +26,19 @@ PROFILES = {
     "detection_engineering": {
         "description": "D&R rule creation, testing, deployment, and false positives",
         "commands": [
-            "rule list", "rule get", "rule create", "rule update", "rule delete",
-            "rule test", "rule replay", "rule validate", "rule export", "rule import",
-            "fp list", "fp get", "fp create", "fp delete",
+            "dr list", "dr get", "dr set", "dr delete",
+            "dr test", "dr replay", "dr validate", "dr export", "dr import",
+            "dr convert-rules",
+            "fp list", "fp get", "fp set", "fp delete",
             "replay run",
             "ai generate-rule", "ai generate-detection", "ai generate-response",
-            "dr convert-rules",
         ],
     },
     "historical_data": {
         "description": "Searching, querying, and analyzing historical telemetry",
         "commands": [
-            "search run", "search validate", "search estimate", "search interactive",
-            "search saved list", "search saved get", "search saved create", "search saved delete",
+            "search run", "search validate", "search estimate",
+            "search saved-list", "search saved-get", "search saved-create", "search saved-delete",
             "event list", "event get", "event children", "event overview", "event timeline",
             "event types", "event schema", "event retention",
             "detection list", "detection get",
@@ -76,14 +76,14 @@ PROFILES = {
             "download sensor", "download adapter", "download list",
             "sensor upgrade", "sensor set-version", "sensor export",
             "tag mass-add", "tag mass-remove",
-            "sync pull", "sync push", "sync diff",
+            "sync pull", "sync push",
         ],
     },
     "platform_admin": {
         "description": "Users, groups, API keys, billing, outputs, and organization management",
         "commands": [
-            "org info", "org list", "org create", "org delete", "org config get",
-            "org config set", "org urls", "org stats", "org errors",
+            "org info", "org list", "org create", "org delete", "org config-get",
+            "org config-set", "org urls", "org stats", "org errors",
             "user list", "user invite", "user remove", "user permissions list",
             "group list", "group create", "group delete",
             "api-key list", "api-key create", "api-key delete",

--- a/tests/unit/test_discovery.py
+++ b/tests/unit/test_discovery.py
@@ -44,6 +44,39 @@ class TestProfiles:
         assert "sensor_management" in names
 
 
+def _resolve(path: str) -> str | None:
+    """Resolve a profile entry against the live command tree.
+
+    Returns None when the path names a real, runnable command, or a
+    human-readable reason when it does not.
+    """
+    import importlib
+
+    from limacharlie.cli import _COMMAND_MODULE_MAP
+
+    parts = path.split()
+    top = parts[0]
+    if top not in _COMMAND_MODULE_MAP:
+        return f"no top-level command named {top!r}"
+
+    modname, attr = _COMMAND_MODULE_MAP[top]
+    cmd = getattr(importlib.import_module(f"limacharlie.commands.{modname}"), attr)
+
+    for i, part in enumerate(parts[1:]):
+        parent = " ".join(parts[: i + 1])
+        if not isinstance(cmd, click.Group):
+            return f"{parent!r} takes no subcommands, so {part!r} cannot exist"
+        sub = cmd.commands.get(part)
+        if sub is None:
+            options = ", ".join(sorted(cmd.commands))
+            return f"{parent!r} has no subcommand {part!r} (it has: {options})"
+        cmd = sub
+
+    if isinstance(cmd, click.Group):
+        return f"{path!r} is a group, not a runnable command"
+    return None
+
+
 def _leaf_paths(cmd: click.BaseCommand, prefix: list[str]) -> list[str]:
     """Every runnable command path under ``cmd``, space-joined."""
     if isinstance(cmd, click.Group):
@@ -52,6 +85,38 @@ def _leaf_paths(cmd: click.BaseCommand, prefix: list[str]) -> list[str]:
             paths.extend(_leaf_paths(sub, prefix + [name]))
         return paths
     return [" ".join(prefix)]
+
+
+class TestProfileEntriesResolve:
+    """Every profile entry must name a command that actually exists.
+
+    ``limacharlie help discover`` prints these strings as literal
+    ``limacharlie <entry>`` invocations, so a rotted entry tells an
+    operator — or an agent — to run something that cannot work. This
+    catches a command being renamed or moved out from under a profile.
+
+    Note this is deliberately one-directional: it does not require that
+    every command appear in some profile. Which commands are worth
+    surfacing is a curation call, and many groups are not profiled yet.
+    """
+
+    def test_no_unresolvable_entries(self):
+        broken = []
+        for profile_name, profile in sorted(PROFILES.items()):
+            for entry in profile["commands"]:
+                reason = _resolve(entry)
+                if reason is not None:
+                    broken.append(f'    [{profile_name}] "{entry}" -> {reason}')
+
+        if broken:
+            pytest.fail(
+                "Discovery profiles advertise commands that do not exist. "
+                "'limacharlie help discover' prints these verbatim, so each "
+                "one is advice that cannot be followed:\n\n"
+                + "\n".join(broken)
+                + "\n\n  Fix the spelling, or drop the entry, in "
+                "limacharlie/discovery.py."
+            )
 
 
 class TestMailsecCoverage:


### PR DESCRIPTION
> **Stacked on #353** (`mailsec-discovery-profiles`). Base is that branch, not `master`, so the two do not conflict; GitHub will retarget this to `master` automatically when #353 merges. Review #353 first — the diff shown here is only this PR's changes.

## What

`limacharlie help discover` prints each `PROFILES` entry verbatim as a `limacharlie <entry>` invocation. 20 entries named commands that no longer exist, so the CLI's own discovery surface was handing out advice that cannot be followed. This is a pure correction PR: it fixes rotted entries and pins them. It adds no new surfaces.

Every replacement was re-derived by walking the live click tree, not from the earlier inventory — which was wrong in two ways worth flagging: there are **10** `rule *` entries (not 11), and they map to `dr *`, **not** `dr rule *` (the `dr` group holds the verbs directly).

## Per-entry disposition

| Old entry | Profile | New entry | Why |
|---|---|---|---|
| `rule list` | detection_engineering | `dr list` | group renamed to `dr` |
| `rule get` | detection_engineering | `dr get` | group renamed to `dr` |
| `rule create` | detection_engineering | `dr set` | no `create`; `dr set` is create-or-update |
| `rule update` | detection_engineering | *(collapsed into `dr set`)* | same command as `rule create` — two entries become one |
| `rule delete` | detection_engineering | `dr delete` | group renamed to `dr` |
| `rule test` | detection_engineering | `dr test` | group renamed to `dr` |
| `rule replay` | detection_engineering | `dr replay` | group renamed to `dr` |
| `rule validate` | detection_engineering | `dr validate` | group renamed to `dr` |
| `rule export` | detection_engineering | `dr export` | group renamed to `dr` |
| `rule import` | detection_engineering | `dr import` | group renamed to `dr` |
| `fp create` | detection_engineering | `fp set` | no `create`; `fp set` is "Create or update a false positive rule" |
| `org config get` | platform_admin | `org config-get` | hyphenated verb, never a `config` subgroup |
| `org config set` | platform_admin | `org config-set` | hyphenated verb, never a `config` subgroup |
| `search saved list` | historical_data | `search saved-list` | hyphenated verb, never a `saved` subgroup |
| `search saved get` | historical_data | `search saved-get` | hyphenated verb |
| `search saved create` | historical_data | `search saved-create` | hyphenated verb |
| `search saved delete` | historical_data | `search saved-delete` | hyphenated verb |
| `search interactive` | historical_data | **dropped** | no successor anywhere in the tree; genuinely gone |
| `sensor online` | sensor_management | **dropped** | became a flag: `sensor list --online`. `sensor list` is already profiled |
| `sync diff` | fleet_management | **dropped** | became a flag: `sync push --dry-run`. `sync push` is already profiled |

Net: 17 corrected (16 entries, since `rule create`/`rule update` merge), 3 dropped.

`dr convert-rules` was already correct; it moved next to the other `dr` entries for readability.

## Widened lint

`TestProfileEntriesResolve` now requires **every** entry in **every** profile to resolve against the live click tree. The mailsec both-directions pin from #353 is unchanged.

Deliberately one-directional: it does not require that every command be profiled. Which commands are worth surfacing is a curation call, and 32 top-level groups are unprofiled — that is curation debt, not a correctness bug, and forcing it here would be a different PR.

**Verified by mechanism**: stashing the `discovery.py` fix makes the new test fail listing exactly the 20 entries with actionable reasons (it prints the group's real subcommands); restoring makes it pass.

## CLAUDE.md

The repo had none. Added a short one covering the thing that caused this rot: the command surface is described by three hand-maintained maps (`_COMMAND_MODULE_MAP`, `PROFILES`, `doc/cli/`) and none updates itself, so a rename must touch all three. It points at both lints and at the MCP-mirroring expectation, and says to look for a renamed command before deleting a profile entry — 17 of the 20 were renames, so "delete until the lint passes" would have been the wrong fix.

## MCP reconciliation (`NEW_CLI.md` §1.1)

Not checkable in this repo — the profile list lives in the separate **`lc-mcp-server`** repo (`configs/profiles.yaml`), so nothing here can enforce it. Reconciled by hand for the record; the claim "matching MCP server profiles" is now only partly true:

- **Shared exactly (7):** `historical_data`, `live_investigation`, `threat_response`, `fleet_management`, `detection_engineering`, `platform_admin`, `ai_powered`.
- **CLI name differs for the same concept (2):** CLI `sensor_management` ≈ MCP `core`; CLI `cases` ≈ MCP `investigation_management`.
- **CLI-only (1):** `email_security` (added in #353) — the MCP server has no email-security profile.
- **MCP-only (6):** `core`, `historical_data_readonly`, `investigation_management`, `api_access`, `cloud_security`, `cloud_security_readonly`.

Renaming CLI profiles to converge would be a user-visible break to `--profile`, so it is not done here. Flagging it as a decision for a follow-up.

## Remaining debt (not this PR)

1. **32 of 58 top-level groups appear in no profile:** `ai-cost-model, ai-memory, ai-skill, app, arl, artifact, auth, cloud-adapter, cloudsec, completion, config, exfil, extension, external-adapter, feedback, help, hive, ingestion-key, integrity, job, logging, lookup, note, payload, playbook, schema, secret, sop, spotcheck, usp, vulnerability` (+ `mailsec`, fixed in #353). Notably the MCP server *does* ship `cloud_security` profiles while the CLI has no `cloudsec` coverage at all.
2. **Unprofiled verbs inside already-profiled groups**, found while fixing the above and left alone to keep this a correction: `dr enable|disable`, `fp enable|disable`, `fp tag add|rm|set`, `search saved-run|queries|limits|checkpoints|checkpoint-show`, and much of `org`.
3. **Doc drift in three files** — `doc/cli/README.md`, `doc/cli/other-commands.md`, `doc/getting-started.md` document `limacharlie discover` and `limacharlie cheatsheet` as top-level commands (they live under `help`), and reference a `--profile incident_response` that does not exist (it is `threat_response`).

## Tests

Full CI suite (`tests/unit/ tests/microbenchmarks/`, matching `cloudbuild_pr.yaml`), clean venv: **4086 passed, 5 skipped** — up from 4085 on #353 (+1 new test), and 4083 on `master`. The 5 skips are pre-existing and unrelated (3 platform-gated, 2 pre-existing-docstring gates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)