### PR TITLE
mailsec: deprecate the caller-supplied banner (rendered from policy now)

### DIFF
--- a/limacharlie/commands/mailsec.py
+++ b/limacharlie/commands/mailsec.py
@@ -471,6 +471,29 @@ Examples:
 # Helpers
 # ---------------------------------------------------------------------------
 
+_DEPRECATED_BANNER_HELP = (
+    "DEPRECATED and ignored. The warning banner is rendered by the server from the "
+    "organization's mailsec_policy record of type 'banners'; set the wording there."
+)
+
+
+def _note_banner_is_ignored(ctx: click.Context, banner: str | None) -> None:
+    """Say out loud that --banner went nowhere.
+
+    The flag used to carry HTML that was spliced into the recipient's mailbox
+    verbatim. It is now rendered by the server from the org's `banners` policy
+    record, escaped into a fixed template. The flag is kept, hidden and ignored
+    for one release so an existing runbook does not start failing on an unknown
+    option — but silently discarding what an operator typed is how a person ends
+    up believing they configured something they did not.
+    """
+    if not banner:
+        return
+    note(ctx, "--banner is deprecated and ignored: the banner's wording comes from the "
+              "organization's mailsec_policy record of type 'banners' "
+              "(limacharlie hive get --hive-name mailsec_policy ...)")
+
+
 def _output(ctx: click.Context, data: Any) -> None:
     fmt = ctx.obj.output_format or detect_output_format()
     if not ctx.obj.quiet:
@@ -1003,7 +1026,7 @@ def message_similar(ctx, msg_uuid, cursor, limit) -> None:
               help="quarantine_message|trash_message|restore_message|banner_message|unbanner_message")
 @click.option("--reason", default=None, help="Recorded on the audit row.")
 @click.option("--attempt", default=None, help="Caller-supplied idempotency token.")
-@click.option("--banner", default=None, help="Banner HTML, for the banner actions.")
+@click.option("--banner", default=None, hidden=True, help=_DEPRECATED_BANNER_HELP)
 @pass_context
 def message_action(ctx, msg_uuid, action_name, reason, attempt, banner) -> None:
     """Remediate one message at the provider (mailsec.act).
@@ -1012,9 +1035,10 @@ def message_action(ctx, msg_uuid, action_name, reason, attempt, banner) -> None:
     Example:
       limacharlie mailsec message action 0057db2b-... --action quarantine_message --reason "phish"
     """
+    _note_banner_is_ignored(ctx, banner)
     ms = _get_mailsec(ctx)
     _output(ctx, ms.act_on_message(
-        msg_uuid, action_name, reason=reason, attempt=attempt, banner=banner,
+        msg_uuid, action_name, reason=reason, attempt=attempt,
     ))
 
 
@@ -1069,7 +1093,7 @@ def message_revisions(ctx, msg_uuid) -> None:
 @click.option("--attempt", default=None,
               help="Idempotency token. It is part of the confirmation, so a NEW attempt over the "
                    "same selection is a deliberate second run rather than a re-run of the first.")
-@click.option("--banner", default=None, help="Banner HTML, for banner_message. Applies to the whole batch.")
+@click.option("--banner", default=None, hidden=True, help=_DEPRECATED_BANNER_HELP)
 @click.option("--reason", default=None,
               help="Why you are doing this. Recorded on the job's audit row and on every message's, "
                    "the same way `message action --reason` records one. It is NOT part of the "
@@ -1110,6 +1134,7 @@ def message_bulk_action(ctx, action_name, msg_uuids, input_file, attempt, banner
     # preview and the execute would be a second chance to disagree with the set
     # the operator just approved, which is exactly what the token exists to catch.
     selection = _bulk_selection(msg_uuids, input_file)
+    _note_banner_is_ignored(ctx, banner)
     ms = _get_mailsec(ctx)
 
     if not confirm:
@@ -1125,7 +1150,7 @@ def message_bulk_action(ctx, action_name, msg_uuids, input_file, attempt, banner
         return
 
     accepted = ms.bulk_action_execute(
-        action_name, selection, confirm, attempt=attempt, banner=banner, reason=reason,
+        action_name, selection, confirm, attempt=attempt, reason=reason,
     )
     bulk_id = accepted.get("bulk_id")
     if not accepted.get("accepted") or not bulk_id:

--- a/limacharlie/sdk/mailsec.py
+++ b/limacharlie/sdk/mailsec.py
@@ -45,6 +45,7 @@ import base64
 import binascii
 import json
 import time
+import warnings
 from typing import Any, Callable, TYPE_CHECKING
 from urllib.parse import quote as _quote
 
@@ -175,6 +176,33 @@ def _add_scalar(pairs: list[tuple[str, str]], key: str, value: Any) -> None:
         pairs.append((key, "true" if value else "false"))
     else:
         pairs.append((key, str(value)))
+
+
+def _warn_banner_is_ignored(banner: str | None) -> None:
+    """Warn once per call that a caller-supplied banner goes nowhere.
+
+    The banner used to travel on the request and was spliced into the
+    recipient's mailbox verbatim, so any caller holding ``mailsec.act`` chose
+    HTML that ran in someone else's mail client. It is now rendered by the
+    server from the organization's ``mailsec_policy`` record of type
+    ``banners``, escaped into a fixed template.
+
+    The argument is kept and IGNORED rather than rejected, for one release: an
+    existing script keeps working and simply gets the organization's configured
+    banner, which is what it wanted. The warning is what stops that from being a
+    silent change — a field that quietly stops meaning anything is worse than
+    one that says so.
+    """
+    if banner is None:
+        return
+    warnings.warn(
+        "mailsec: the `banner` argument is deprecated and ignored. The warning banner is "
+        "rendered by the server from the organization's mailsec_policy record of type "
+        "'banners' (its `text`), so that no caller can inject markup into a user's mailbox. "
+        "Set the wording there instead; this argument will be removed.",
+        DeprecationWarning,
+        stacklevel=3,
+    )
 
 
 class Mailsec:
@@ -402,7 +430,12 @@ class Mailsec:
                 ``restore_message``, ``banner_message``, ``unbanner_message``.
             reason: Free-text justification recorded on the audit row.
             attempt: Caller-supplied idempotency token.
-            banner: Banner HTML, for the banner actions.
+            banner: DEPRECATED and ignored. The warning banner used to be
+                chosen by the caller and was spliced into the mailbox verbatim;
+                it is now rendered by the server from the organization's
+                ``mailsec_policy`` record of type ``banners`` into a fixed,
+                escaped template, so no caller can put markup in a user's mail.
+                Passing it warns and sends nothing; set the wording in policy.
 
         Returns:
             The action record, including ``result`` — note ``alert_only``,
@@ -411,8 +444,9 @@ class Mailsec:
             failure, and it is reported as its own result rather than as
             ``ok``.
         """
+        _warn_banner_is_ignored(banner)
         body: dict[str, Any] = {"action": action}
-        for key, val in (("reason", reason), ("attempt", attempt), ("banner_html", banner)):
+        for key, val in (("reason", reason), ("attempt", attempt)):
             if val is not None:
                 body[key] = val
         return self._post(f"messages/{_seg(msg_uuid)}/actions", body)
@@ -607,9 +641,10 @@ class Mailsec:
                 enough; passing a different set is refused rather than acted on.
             confirm: The token from :meth:`bulk_action_preview`.
             attempt: The same attempt the preview used, when one was used.
-            banner: Banner HTML for ``banner_message``, supplied once for the
-                whole batch — it carries the org's text, which is a property of
-                the org rather than of any one message.
+            banner: DEPRECATED and ignored — see :meth:`act_on_message`. Every
+                member's banner is rendered by the server from the
+                organization's ``banners`` policy record, so the batch carries
+                no banner at all.
             reason: Free-text justification, recorded on the job's audit row AND
                 on every message's, exactly as :meth:`act_on_message` records it
                 for one. It is deliberately NOT part of the confirmation, so
@@ -625,8 +660,8 @@ class Mailsec:
 
         Note:
             ``reason`` requires a backend that reads it. Older deployments
-            forwarded only ``action``, ``msg_uuids``, ``confirm``, ``attempt``
-            and the banner on this route and dropped a reason in transit; against
+            forwarded only ``action``, ``msg_uuids``, ``confirm`` and ``attempt``
+            on this route and dropped a reason in transit; against
             those, a justification sent here never reaches the audit trail. It is
             an ordinary optional argument rather than a version probe, because a
             client cannot tell the two apart from the response — the execute
@@ -637,7 +672,8 @@ class Mailsec:
             "msg_uuids": normalize_bulk_selection(msg_uuids),
             "confirm": confirm,
         }
-        for key, val in (("attempt", attempt), ("banner", banner), ("reason", reason)):
+        _warn_banner_is_ignored(banner)
+        for key, val in (("attempt", attempt), ("reason", reason)):
             if val is not None:
                 body[key] = val
         return self._post("actions/bulk/execute", body)

--- a/tests/unit/test_cli_mailsec_bulk.py
+++ b/tests/unit/test_cli_mailsec_bulk.py
@@ -307,14 +307,21 @@ class TestPreviewToExecuteBinding:
         assert result.exit_code == 0, result.stderr
         ms.bulk_action_preview.assert_not_called()
 
-    def test_the_banner_is_forwarded_on_the_execute(self):
+    def test_the_banner_flag_is_ignored_and_said_so(self):
+        """--banner used to carry HTML that was spliced into up to 500 mailboxes
+        verbatim. The banner is rendered by the server from the org's `banners`
+        policy record now. The flag is accepted and ignored for one release so an
+        existing runbook does not start failing on an unknown option — and the
+        command SAYS it was ignored, because silently discarding what an operator
+        typed is how somebody ends up believing they configured something."""
         result, ms = _invoke(
             "mailsec", "message", "bulk-action", "--action", "banner_message",
             "--msg-uuids", U_A, "--confirm", TOKEN, "--banner", "<b>caution</b>",
             sdk_returns=_HAPPY,
         )
         assert result.exit_code == 0, result.stderr
-        assert ms.bulk_action_execute.call_args.kwargs["banner"] == "<b>caution</b>"
+        assert "banner" not in ms.bulk_action_execute.call_args.kwargs
+        assert "--banner is deprecated and ignored" in result.stderr + result.stdout
 
 
 class TestSelectionAssembly:

--- a/tests/unit/test_sdk_mailsec.py
+++ b/tests/unit/test_sdk_mailsec.py
@@ -1,5 +1,6 @@
 """Tests for limacharlie.sdk.mailsec module."""
 
+import warnings
 import json
 
 from unittest.mock import MagicMock, patch
@@ -142,13 +143,25 @@ class TestActions:
         assert url == f"mailsec/{OID}/messages/msg-1/actions"
         assert body == {"action": "quarantine_message", "reason": "phish"}
 
-    def test_banner_uses_the_gateway_wire_name(self, ms, mock_org):
-        ms.act_on_message("msg-1", "banner_message", banner="<div>external sender</div>")
+    def test_a_caller_supplied_banner_is_deprecated_and_never_sent(self, ms, mock_org):
+        """The banner used to travel on the request and was spliced into the
+        recipient's mailbox verbatim, so a caller chose the HTML that ran in
+        somebody else's mail client. It is rendered by the server from the org's
+        `banners` policy record now. The argument is kept and IGNORED for one
+        release — an existing script keeps working — but it warns, because a
+        field that quietly stops meaning anything is worse than one that says
+        so."""
+        with pytest.deprecated_call():
+            ms.act_on_message("msg-1", "banner_message", banner="<img src=x onerror=alert(1)>")
         _, body = _post_call(mock_org)
-        assert body == {
-            "action": "banner_message",
-            "banner_html": "<div>external sender</div>",
-        }
+        assert body == {"action": "banner_message"}
+
+    def test_a_banner_free_action_does_not_warn(self, ms, mock_org):
+        """The control for the test above: the deprecation fires on the
+        argument, not on every action."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            ms.act_on_message("msg-1", "banner_message")
 
     def test_campaign_action_previews_without_confirm(self, ms, mock_org):
         """confirm is what turns a preview into an execution. Its absence must
@@ -369,16 +382,15 @@ class TestBulkRemediation:
         _, execute_body = _post_call(mock_org)
         assert preview_body["msg_uuids"] == execute_body["msg_uuids"] == ["a", "b", "c"]
 
-    def test_banner_is_spelled_banner_on_the_wire(self, ms, mock_org):
-        """`banner` is the PUBLIC spelling; the gateway translates it to the
-        collector's `banner_html` (mailsecBulkExecuteArgs). Its allow-list
-        happens to forward a literal `banner_html` too, so both would in fact
-        work — but only `banner` is in the documented body schema, and pinning
-        the documented name is what keeps this client on the contract rather
-        than on an implementation detail of the forwarder."""
-        ms.bulk_action_execute("banner_message", ["a"], "tok", banner="<b>caution</b>")
+    def test_a_caller_supplied_banner_is_deprecated_and_never_sent(self, ms, mock_org):
+        """The bulk route mattered most: one request bannered up to 500
+        mailboxes with the caller's HTML. Nothing banner-shaped leaves the
+        client any more; the server renders each member's banner from the org's
+        `banners` policy record."""
+        with pytest.deprecated_call():
+            ms.bulk_action_execute("banner_message", ["a"], "tok", banner="<script>alert(1)</script>")
         _, body = _post_call(mock_org)
-        assert body["banner"] == "<b>caution</b>"
+        assert "banner" not in body
         assert "banner_html" not in body
 
     def test_execute_omits_absent_optionals(self, ms, mock_org):


### PR DESCRIPTION
## Why

Pre-GA finding **H-1** in the Email Security backend: the warning banner used to travel on the
remediation request and was spliced into the recipient's mailbox verbatim, so a caller chose
the HTML that ran in somebody else's mail client. The server now renders it from the
organization's `mailsec_policy` record of type `banners`, HTML-escaped into a fixed template,
and the gateway no longer forwards `banner`/`banner_html` at all.

Backend half: refractionPOINT/lc_api-go#929, refractionPOINT/legion_mailsec#66,
refractionPOINT/go-mailsec#73.

## What this changes

- `Mailsec.act_on_message(..., banner=...)` and `Mailsec.bulk_action_execute(..., banner=...)`
  keep the argument and **stop sending it**, raising a `DeprecationWarning`.
- `limacharlie mailsec message action --banner` and `message bulk-action --banner` keep the
  flag, hidden, and print that it was ignored.

Kept-and-ignored rather than removed for one release: an existing script keeps working and
simply gets the organization's configured banner, which is what it wanted. Both surfaces SAY
so, because a field that quietly stops meaning anything is worse than one that says it stopped
— removing the flag outright would also break runbooks on an unknown-option error.

## Verification

`pytest tests/unit -k mailsec` → 171 passed. The two banner tests now assert nothing
banner-shaped leaves the client and that the deprecation fires, with a control asserting a
banner-free call does **not** warn; the CLI test asserts the notice reaches the operator.

Public repo: PR only, not merged.
