### PR TITLE
feat(sync): support ACL scope membership in IaC

### DIFF
--- a/doc/cli/infrastructure.md
+++ b/doc/cli/infrastructure.md
@@ -23,10 +23,31 @@ limacharlie sync pull --config-file dr.yaml --hive-dr-general --hive-fp
 limacharlie sync push --config-file dr.yaml --hive-dr-general --hive-fp --dry-run
 ```
 
-Available hive flags: `--hive-dr-general`, `--hive-dr-managed`, `--hive-dr-service`,
+Available hive flags: `--hive-acl`, `--hive-dr-general`, `--hive-dr-managed`, `--hive-dr-service`,
 `--hive-fp`, `--hive-cloud-sensor`, `--hive-extension-config`, `--hive-yara`,
 `--hive-lookup`, `--hive-secret`, `--hive-query`, `--hive-playbook`,
 `--hive-ai-agent`, `--hive-external-adapter`.
+
+### ACL scopes
+
+Use `--hive-acl` to sync scope membership; `--all` includes it too:
+
+```bash
+limacharlie sync pull --config-file acl.yaml --hive-acl --hive-secret
+limacharlie sync push --config-file acl.yaml --hive-acl --hive-secret --dry-run
+```
+
+Scope records are stored under `hives.acl`. Sync preserves `acl:` tags in other
+records' `usr_mtd.tags`; it does not add classification tags automatically.
+The syncing identity needs `acl.get` to fetch membership and `acl.set` to write
+membership or add/remove `acl:` tags, in addition to the usual resource permissions.
+It also needs the relevant scope membership to read restricted record contents;
+`acl.set` does not itself grant that read access. Do not push redacted content
+containing `acl_restricted: true` as a replacement for the original record.
+Permission failures are reported by push and produce a nonzero exit status.
+
+Existing Owner/Administrator assignments may need to be reapplied, or the new
+permissions granted explicitly, before an existing automation identity can sync ACLs.
 
 ## output
 

--- a/doc/cli/infrastructure.md
+++ b/doc/cli/infrastructure.md
@@ -45,6 +45,8 @@ It also needs the relevant scope membership to read restricted record contents;
 `acl.set` does not itself grant that read access. Do not push redacted content
 containing `acl_restricted: true` as a replacement for the original record.
 Permission failures are reported by push and produce a nonzero exit status.
+User members must use their stable UID, not an email address; API-key members
+use the key name.
 
 Existing Owner/Administrator assignments may need to be reapplied, or the new
 permissions granted explicitly, before an existing automation identity can sync ACLs.

--- a/doc/sdk/configs.md
+++ b/doc/sdk/configs.md
@@ -40,6 +40,24 @@ configs.push_from_file("org.yaml", sync_outputs=True,
                        sync_hives={"dr-general": True})
 ```
 
+## ACL Scope Membership
+
+```python
+# Preserve scope membership and the ACL tags on secret records together.
+hives = {"acl": True, "secret": True}
+configs.fetch_to_file("acl.yaml", sync_hives=hives)
+results, errors = configs.push_from_file("acl.yaml", sync_hives=hives, is_dry_run=True)
+if errors:
+    raise RuntimeError("; ".join(errors))
+```
+
+ACL scopes are records under `hives.acl`; classification tags remain in each
+record's `usr_mtd.tags`. Fetching membership requires `acl.get`; writing it or
+changing `acl:` tags requires `acl.set`, alongside the existing resource permissions.
+The syncing identity must also hold each scope needed to read restricted contents.
+Do not use an `acl_restricted: true` redaction marker as replacement record data.
+See [CLI ACL sync](../cli/infrastructure.md#acl-scopes) for permission setup.
+
 ## See Also
 
 - [CLI: sync](../cli/infrastructure.md#sync) — CLI equivalents

--- a/doc/sdk/configs.md
+++ b/doc/sdk/configs.md
@@ -56,6 +56,8 @@ record's `usr_mtd.tags`. Fetching membership requires `acl.get`; writing it or
 changing `acl:` tags requires `acl.set`, alongside the existing resource permissions.
 The syncing identity must also hold each scope needed to read restricted contents.
 Do not use an `acl_restricted: true` redaction marker as replacement record data.
+Use the stable UID (not email) for a user member and the key name for an API-key
+member.
 See [CLI ACL sync](../cli/infrastructure.md#acl-scopes) for permission setup.
 
 ## See Also

--- a/limacharlie/commands/sync.py
+++ b/limacharlie/commands/sync.py
@@ -53,6 +53,7 @@ _SYNC_FLAGS = [
     click.option("--installation-keys", is_flag=True, default=False, help="Sync installation keys."),
     click.option("--yara", is_flag=True, default=False, help="Sync YARA rules and sources."),
     # Hive flags
+    click.option("--hive-acl", is_flag=True, default=False, help="Sync ACL scope membership (hive)."),
     click.option("--hive-dr-general", is_flag=True, default=False, help="Sync D&R rules (general hive)."),
     click.option("--hive-dr-managed", is_flag=True, default=False, help="Sync D&R rules (managed hive)."),
     click.option("--hive-dr-service", is_flag=True, default=False, help="Sync D&R rules (service hive)."),
@@ -72,6 +73,7 @@ _SYNC_FLAGS = [
 
 # Maps CLI flag name -> hive name sent to the backend
 _HIVE_FLAG_MAP = {
+    "hive_acl": "acl",
     "hive_dr_general": "dr-general",
     "hive_dr_managed": "dr-managed",
     "hive_dr_service": "dr-service",
@@ -193,6 +195,7 @@ Resource type flags:
   --yara                 YARA rules and sources
 
 Hive flags (for syncing hive-based resources):
+  --hive-acl             ACL scope membership
   --hive-dr-general      D&R rules (general namespace)
   --hive-dr-managed      D&R rules (managed namespace)
   --hive-dr-service      D&R rules (service namespace)
@@ -231,11 +234,12 @@ def pull(ctx, config_file, sync_all, outputs, integrity,
          hive_fp, hive_cloud_sensor, hive_extension_config,
          hive_yara, hive_lookup, hive_secret, hive_query,
          hive_playbook, hive_ai_agent, hive_ai_skill, hive_ai_memory,
-         hive_external_adapter) -> None:
+         hive_external_adapter, hive_acl) -> None:
     flags = _resolve_sync_flags(
         sync_all, outputs, integrity, exfil,
         artifact, resources, extensions, org_values,
         installation_keys, yara,
+        hive_acl=hive_acl,
         hive_dr_general=hive_dr_general,
         hive_dr_managed=hive_dr_managed,
         hive_dr_service=hive_dr_service,
@@ -300,6 +304,10 @@ shows which resources would be added, modified, or removed.
 Use --force to remove cloud resources not present in the local file.
 Without --force, push only adds or updates; it never removes.
 
+Use --hive-acl to sync ACL scope membership. Writing scope membership or
+adding/removing acl: tags requires acl.set on the syncing identity, in
+addition to the usual resource permissions.
+
 Examples:
   limacharlie sync push --config-file org.yaml --all
   limacharlie sync push --config-file org.yaml --all --dry-run
@@ -324,11 +332,12 @@ def push(ctx, config_file, force, dry_run, sync_all, outputs,
          hive_fp, hive_cloud_sensor, hive_extension_config,
          hive_yara, hive_lookup, hive_secret, hive_query,
          hive_playbook, hive_ai_agent, hive_ai_skill, hive_ai_memory,
-         hive_external_adapter) -> None:
+         hive_external_adapter, hive_acl) -> None:
     flags = _resolve_sync_flags(
         sync_all, outputs, integrity, exfil,
         artifact, resources, extensions, org_values,
         installation_keys, yara,
+        hive_acl=hive_acl,
         hive_dr_general=hive_dr_general,
         hive_dr_managed=hive_dr_managed,
         hive_dr_service=hive_dr_service,

--- a/limacharlie/sdk/configs.py
+++ b/limacharlie/sdk/configs.py
@@ -40,6 +40,7 @@ class Configs:
 
     # All known hive names that can be synced.
     ALL_HIVES = {
+        "acl",
         "dr-general",
         "dr-managed",
         "dr-service",

--- a/tests/unit/test_cli_sync_acl.py
+++ b/tests/unit/test_cli_sync_acl.py
@@ -39,7 +39,7 @@ def test_acl_pull_push_preserves_records_and_tags(tmp_path, sync_transport, flag
             "acl": {
                 "finance": {
                     "data": {"members": [
-                        {"type": "user", "id": "analyst@example.com"},
+                        {"type": "user", "id": "test-user-uid"},
                         {"type": "api_key", "id": "test-key-id"},
                         {"type": "group", "id": "test-group-id"},
                     ]},

--- a/tests/unit/test_cli_sync_acl.py
+++ b/tests/unit/test_cli_sync_acl.py
@@ -1,0 +1,121 @@
+"""Exercise ACL sync through CLI flags, YAML files, and the SDK wire payload."""
+
+import base64
+import copy
+import gzip
+import json
+from unittest.mock import MagicMock
+
+import pytest
+import yaml
+from click.testing import CliRunner
+
+from limacharlie.cli import cli
+from limacharlie.sdk.configs import Configs
+
+
+@pytest.fixture
+def sync_transport(monkeypatch):
+    org = MagicMock()
+    org.oid = "test-oid"
+    org.client._jwt = "sync-test-jwt"
+    monkeypatch.setattr("limacharlie.commands.sync._get_org", lambda _ctx: org)
+    return org.client.request
+
+
+def decode_request(method, path, *, params):
+    assert method == "POST"
+    assert path == "extension/request/ext-infrastructure"
+    assert params["oid"] == "test-oid"
+    assert params["impersonator_jwt"] == "sync-test-jwt"
+    return params["action"], json.loads(gzip.decompress(base64.b64decode(params["gzdata"])))
+
+
+@pytest.mark.parametrize("flags", [["--hive-acl", "--hive-secret"], ["--all"]])
+def test_acl_pull_push_preserves_records_and_tags(tmp_path, sync_transport, flags):
+    original = {
+        "version": 3,
+        "hives": {
+            "acl": {
+                "finance": {
+                    "data": {"members": [
+                        {"type": "user", "id": "analyst@example.com"},
+                        {"type": "api_key", "id": "test-key-id"},
+                        {"type": "group", "id": "test-group-id"},
+                    ]},
+                    "usr_mtd": {"enabled": True, "tags": ["managed"], "comment": "IaC scope"},
+                },
+                "locked": {"data": {"members": []}, "usr_mtd": {"enabled": True}},
+            },
+            "secret": {
+                "credential": {
+                    "data": {"secret": "test-only-value"},
+                    "usr_mtd": {"enabled": False, "tags": ["ordinary", "acl:finance", "acl:locked"],
+                                "comment": "preserve classification", "expiry": 1900000000},
+                },
+            },
+        },
+    }
+    requests = []
+
+    def transport(*args, **kwargs):
+        action, payload = decode_request(*args, **kwargs)
+        requests.append((action, payload))
+        hives = payload["options"]["sync_hives"]
+        if action == "fetch":
+            # Model the backend's selection: --all must actually request ACLs.
+            selected = {name: records for name, records in original["hives"].items() if hives.get(name)}
+            return {"data": {"org": {"version": 3, "hives": copy.deepcopy(selected)}}}
+        assert action == "push"
+        assert hives["acl"] is True
+        assert hives["secret"] is True
+        assert yaml.safe_load(payload["config"]) == original
+        assert payload["options"]["is_force"] is False
+        assert payload["options"]["ignore_inaccessible"] is False
+        return {"data": {"ops": [{"type": "hive.acl", "name": "finance", "is_added": True}]}}
+
+    sync_transport.side_effect = transport
+    config_file = tmp_path / "org.yaml"
+    runner = CliRunner()
+    pulled = runner.invoke(cli, ["sync", "pull", "--config-file", str(config_file), *flags])
+    assert pulled.exit_code == 0, pulled.output
+    assert yaml.safe_load(config_file.read_text()) == original
+    pushed = runner.invoke(cli, ["sync", "push", "--config-file", str(config_file), *flags])
+    assert pushed.exit_code == 0, pushed.output
+    assert "+ hive.acl: finance" in pushed.output
+    assert [action for action, _ in requests] == ["fetch", "push"]
+    assert "acl" in Configs.ALL_HIVES
+
+
+def test_acl_sync_is_opt_in(tmp_path, sync_transport):
+    def transport(*args, **kwargs):
+        action, payload = decode_request(*args, **kwargs)
+        assert action == "fetch"
+        assert payload["options"]["sync_hives"] == {"secret": True}
+        return {"data": {"org": {"version": 3, "hives": {"secret": {}}}}}
+
+    sync_transport.side_effect = transport
+    result = CliRunner().invoke(cli, [
+        "sync", "pull", "--config-file", str(tmp_path / "secrets.yaml"), "--hive-secret",
+    ])
+    assert result.exit_code == 0, result.output
+    sync_transport.assert_called_once()
+
+
+def test_acl_push_permission_error_is_visible_and_nonzero(tmp_path, sync_transport):
+    config_file = tmp_path / "org.yaml"
+    config_file.write_text("version: 3\nhives:\n  acl:\n    finance:\n      data:\n        members: []\n")
+
+    def transport(*args, **kwargs):
+        action, payload = decode_request(*args, **kwargs)
+        assert action == "push"
+        assert payload["options"]["sync_hives"] == {"acl": True}
+        return {"data": {"ops": [], "errors": [{"error": "acl.set required for hive.acl/finance"}]}}
+
+    sync_transport.side_effect = transport
+    result = CliRunner().invoke(cli, [
+        "sync", "push", "--config-file", str(config_file), "--hive-acl",
+    ])
+    assert result.exit_code == 1, result.output
+    assert "acl.set required for hive.acl/finance" in result.output
+    sync_transport.assert_called_once()

--- a/tests/unit/test_sdk_configs.py
+++ b/tests/unit/test_sdk_configs.py
@@ -198,7 +198,7 @@ class TestConfigsFetchToFile:
 class TestAllHives:
     def test_all_hives_constant(self):
         expected = {
-            "dr-general", "dr-managed", "dr-service", "fp",
+            "acl", "dr-general", "dr-managed", "dr-service", "fp",
             "cloud_sensor", "extension_config", "yara", "lookup",
             "secret", "query", "playbook", "ai_agent",
             "ai_skill", "ai_memory", "external_adapter",


### PR DESCRIPTION
## Summary
- add `--hive-acl` to CLI v2 sync pull/push and include the ACL hive in `--all`
- include `acl` in the SDK Configs hive catalogue
- preserve scope records, ACL tags, and Hive metadata across CLI → SDK → compressed request → YAML round trips
- document required `acl.get`/`acl.set`, scope membership, stable principal identifiers, and redaction-marker safety

## Verification
- prescribed unit/microbenchmark suite: 4,094 passed; five unchanged skips
- final focused review run: 20 passed
- red controls proved `--hive-acl` was previously rejected and `--all` omitted ACL scope records

No tags or releases are created by this PR.