### PR TITLE
mailsec: tenant purge, the CLI verb and the SDK behind it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+## Unreleased
+
+### Email Security
+
+- **Tenant purge**: `limacharlie mailsec tenant purge` /
+  `Mailsec.prepare_tenant_purge()` and `Mailsec.purge_tenant()` permanently
+  delete everything Email Security holds for an organization — the message
+  index and the long-term evidence lane, campaigns, sender profiles, the
+  remediation audit trail, user reports, the stored raw messages and their
+  parsed copies, the link-detonation results, and the organization's Email
+  Security connection and policy configuration — and stop the mail connections
+  at Microsoft or Google so the provider stops sending notifications. Two-step
+  like `org delete`: without `--confirm` the command prints the warning and
+  mints a token and deletes nothing, and the token is single-use and expires
+  after five minutes. Owner-level authority (`mailsec.act` **and**
+  `billing.ctrl` **and** `user.ctrl`), and the optional `--reason` (max 1024
+  characters) is recorded in the organization's audit log next to the caller's
+  identity. The purge is re-runnable: a partial one returns `complete: false`
+  and counts what did NOT land beside what did, and the CLI exits non-zero in
+  that case so a script cannot mistake a half-purged tenant for a finished one.
+  Most organizations will never need it — the same data is deleted
+  automatically 30 days after an organization unsubscribes from Email Security
+  (a resubscribe inside that window cancels it) and immediately if the
+  organization itself is deleted.
+- The mailsec SDK gained a `_delete` helper alongside `_get`/`_post`; it had no
+  DELETE route until now.
+
+### Documentation
+
+- **`doc/cli/email-security.md`**: the mailsec command surface had no page in
+  the CLI reference at all. Added one, and linked it — plus the Cloud Security
+  page, which existed but was missing from `doc/cli/README.md`'s index — from
+  both command-reference tables.
+
 ## 5.6.1 - July 30, 2026
 
 ### Dependencies & Python support

--- a/doc/README.md
+++ b/doc/README.md
@@ -18,6 +18,7 @@
 | [Hive & Data Stores](cli/hive-data.md) | hive, secret, lookup, playbook, note, sop, adapter, cloud-sensor, extension |
 | [Infrastructure](cli/infrastructure.md) | sync, output, artifact, payload, yara, integrity, logging, exfil |
 | [Cloud Security](cli/cloud-security.md) | cloudsec (findings, inventory, graph, compliance, CAASM, fleet, exports) |
+| [Email Security](cli/email-security.md) | mailsec (triage queue, EML, remediation, campaigns, reports, hunts, rules, tenant purge) |
 | [Other Commands](cli/other-commands.md) | api, arl, usp, spotcheck, job, schema, completion, help/discover |
 
 ## SDK Reference

--- a/doc/cli/README.md
+++ b/doc/cli/README.md
@@ -136,6 +136,8 @@ limacharlie schema dr create
 | [Platform Administration](platform-admin.md) | org, user, group, api-key, ingestion-key, billing, audit |
 | [Hive & Data Stores](hive-data.md) | hive, secret, lookup, playbook, note, sop, adapter, cloud-sensor, extension |
 | [Infrastructure](infrastructure.md) | sync, output, artifact, payload, yara, integrity, logging, exfil |
+| [Cloud Security](cloud-security.md) | cloudsec (findings, inventory, graph, compliance, CAASM, fleet, exports) |
+| [Email Security](email-security.md) | mailsec (triage queue, EML, remediation, campaigns, reports, hunts, rules, tenant purge) |
 | [Other Commands](other-commands.md) | api, arl, usp, spotcheck, job, schema, completion, help/discover, case |
 
 ## See Also

--- a/doc/cli/email-security.md
+++ b/doc/cli/email-security.md
@@ -1,0 +1,134 @@
+[Documentation](../README.md) > [CLI](README.md) > Email Security
+
+# Email Security
+
+Commands for the LimaCharlie Email Security surface: mailbox coverage, the message triage queue and its drawer, the justified raw-EML download, analyst verdict revision, per-message and bulk remediation at the provider, campaigns, sender profiles, the action audit trail, the abuse-mailbox report queue, standalone EML analysis, retro-hunts, custom-rule validation and backtest, the connection preflight, and the tenant purge.
+
+Four permissions rather than the usual get/set pair, because the product asks to be trusted with four different things:
+
+| Permission | Grants |
+|---|---|
+| `mailsec.get` | Read the product's own view: the queue, the drawer, campaigns, senders, the audit trail |
+| `mailsec.set` | Change detection behaviour and triage state |
+| `mailsec.act` | Remediate live mail at the provider |
+| `mailsec.get.eml` | Take the original bytes of somebody's mail out of the building; requires a logged justification |
+
+`mailsec tenant purge` is the exception: it is Owner-level, and needs `mailsec.act` **and** `billing.ctrl` **and** `user.ctrl` — the same trio `org delete` asks for.
+
+Every command requires the org to be subscribed to the `ext-email-security` extension:
+
+```bash
+limacharlie extension subscribe --name ext-email-security
+```
+
+Provider connections and policy are hive records — manage them with the hive commands (`limacharlie hive list --hive-name mailsec_provider`, same for `mailsec_policy` and `dr-mail`).
+
+Every command supports `--ai-help` for a detailed description with examples.
+
+## Coverage & onboarding
+
+```bash
+limacharlie mailsec coverage --window-days 30   # mailboxes protected vs not
+limacharlie mailsec onboarding --provider gworkspace
+limacharlie mailsec onboarding --provider m365
+limacharlie mailsec connection test gws-exp     # post-save credential preflight
+limacharlie mailsec connection test gws-exp --include-watch
+```
+
+`coverage` reports the mailboxes that are NOT protected rather than omitting them, so the number is a coverage statement an admin can act on. `connection test` takes the `mailsec_provider` RECORD NAME, never a credential.
+
+## The triage queue
+
+Repeatable filters are OR within a key and AND across keys. Cursors are opaque and passed back verbatim; changing a filter mid-walk is an error, not a differently-meaning page.
+
+```bash
+limacharlie mailsec message list --verdict suspicious --verdict malicious
+limacharlie mailsec message list --mailbox cfo@corp.example --since 2026-08-01
+limacharlie mailsec message list --user-reported
+limacharlie mailsec message list --link-domain evil.example         # IOC pivot
+limacharlie mailsec message list --attachment-sha256 <SHA256>
+limacharlie mailsec message get <MSG_UUID>                          # the drawer
+limacharlie mailsec message similar <MSG_UUID>                      # who else got this
+limacharlie mailsec message revisions <MSG_UUID>                    # verdict history
+```
+
+An unknown message id returns a null message rather than an error: the index has a 35-day TTL, so a miss is normal.
+
+## Raw EML
+
+A different privilege from opening the drawer, because it takes a person's actual mail out of the building. `--justification` is required and is written to the access audit with your identity.
+
+```bash
+limacharlie mailsec message eml <MSG_UUID> --justification "INC-4471 credential harvest"
+limacharlie mailsec message eml <MSG_UUID> --justification "..." --out-file suspect.eml
+```
+
+## Triage & remediation
+
+`message revise` records a human disposition and appends to the verdict history; `message action` remediates at the provider. Watch for `result=alert_only` — the action was DECIDED and deliberately not performed because the org is not in enforce mode.
+
+```bash
+limacharlie mailsec message revise <MSG_UUID> --verdict malicious --rationale "confirmed credential harvest"
+limacharlie mailsec message action <MSG_UUID> --action quarantine_message --reason "confirmed phish"
+limacharlie mailsec message action <MSG_UUID> --action restore_message
+```
+
+Bulk remediation is two-step: without `--confirm` it previews, and the preview's `confirm` token is derived from the normalized selection, so it can only execute what you previewed. Up to 500 messages per call — a larger selection is refused, not truncated.
+
+```bash
+limacharlie mailsec message bulk-action --action quarantine_message --input-file ids.json
+limacharlie mailsec message bulk-action --action quarantine_message --input-file ids.json --confirm <TOKEN>
+limacharlie mailsec message bulk-status <BULK_ID>
+```
+
+## Campaigns, senders & the audit trail
+
+```bash
+limacharlie mailsec campaign list --state active --min-members 5
+limacharlie mailsec campaign get <CAMPAIGN_ID>
+limacharlie mailsec campaign action <CAMPAIGN_ID> --action quarantine_message              # preview
+limacharlie mailsec campaign action <CAMPAIGN_ID> --action quarantine_message --confirm <TOKEN>
+limacharlie mailsec sender get sender@corp.example
+limacharlie mailsec action get <ACTION_ID>
+```
+
+## Reports, analysis, hunts & rules
+
+```bash
+limacharlie mailsec report list --status open
+limacharlie mailsec report resolve <REPORT_ID> --disposition benign
+limacharlie mailsec report reopen <REPORT_ID>
+limacharlie mailsec analyze --file suspect.eml --org-domain corp.example   # no ingest
+limacharlie mailsec hunt create --lcql "..." --dry-run
+limacharlie mailsec hunt remediate <HUNT_ID> --action quarantine_message --confirm <HUNT_ID>
+limacharlie mailsec rule validate --file rule.json --rule-id custom-lookalike
+limacharlie mailsec rule backtest --file rule.json --since 2026-08-01
+```
+
+`rule backtest` reports `precision: null` — not `0` — when nothing it matched has an analyst disposition yet, and counts what it could not examine, so a precision figure whose denominator silently shrank is visible as one.
+
+## Tenant purge
+
+Permanently deletes everything Email Security holds for the org: the message index and the long-term evidence lane, campaigns, sender profiles, the remediation audit trail, user reports, the stored raw messages and their parsed copies, the link-detonation results, and the org's Email Security connection and policy configuration. It also stops the mail connections at Microsoft or Google, so the provider stops sending notifications.
+
+**This is irreversible.** Two steps, like `org delete`: without `--confirm` the command prints the warning and mints a token and deletes nothing; with `--confirm` it goes through with it. The token is single-use and expires after 5 minutes, so mint it immediately before executing.
+
+```bash
+# Step 1 — preview. Prints the warning and the token; nothing is deleted.
+limacharlie mailsec tenant purge
+
+# Step 2 — execute, with the token from step 1.
+limacharlie mailsec tenant purge --confirm <TOKEN> --reason "customer offboarded"
+```
+
+`--reason` is optional, at most 1024 characters, and is recorded in the org audit log next to your identity.
+
+The purge is re-runnable. A partial one returns `complete: false` and counts what did not land (`objects_failed`, `subscriptions_failed`, `connections_unreachable`, `rows_remained`) beside what did; the command exits non-zero in that case so a script cannot mistake a half-purged tenant for a finished one. Re-run it with a fresh token and it picks up what remains.
+
+You may not need it at all: the same data is deleted automatically 30 days after the org unsubscribes from Email Security — resubscribing inside that window cancels the deletion — and immediately if the org itself is deleted.
+
+## See Also
+
+- [CLI Overview](README.md)
+- [Platform Administration](platform-admin.md) — `org delete`, audit, users
+- [Hive & Data Stores](hive-data.md) — the `mailsec_provider`, `mailsec_policy` and `dr-mail` hives

--- a/limacharlie/commands/mailsec.py
+++ b/limacharlie/commands/mailsec.py
@@ -4,8 +4,8 @@ Commands for the ``/mailsec`` API surface: the coverage screen, the message
 index and its drawer, the justified raw-EML download, bulk remediation across a
 selection you name, campaigns and campaign-wide sweeps, sender profiles, the
 action audit trail, the abuse-mailbox report queue, standalone EML analysis,
-retro-hunts, custom-rule validation and backtest, the connection preflight, and
-the served onboarding guide.
+retro-hunts, custom-rule validation and backtest, the connection preflight, the
+served onboarding guide, and the irreversible tenant purge.
 
 Four permissions rather than the usual get/set pair, because mailsec asks to be
 trusted with four different things:
@@ -16,6 +16,10 @@ trusted with four different things:
   mailsec.act      remediate live mail at the provider
   mailsec.get.eml  take the original bytes of somebody's mail out of the
                    building; requires a logged justification
+
+``mailsec tenant purge`` is the exception: it is Owner-level rather than
+analyst-level, and wants mailsec.act AND billing.ctrl AND user.ctrl — the same
+trio ``org delete`` asks for.
 
 Every command requires the org to be subscribed to the ``ext-email-security``
 extension:
@@ -466,6 +470,47 @@ Examples:
   limacharlie mailsec onboarding --provider m365
 """
 
+_EXPLAIN_TENANT_PURGE = """\
+Permanently delete everything Email Security holds for this org.
+
+THIS IS IRREVERSIBLE. It removes the message index and the long-term
+evidence lane, campaigns, sender profiles, the remediation audit trail,
+user reports, the stored raw messages and their parsed copies, the
+link-detonation results, and the org's Email Security connection and
+policy configuration. It also stops the mail connections at Microsoft
+or Google, so the provider stops sending notifications about mail there
+is no longer anywhere to put.
+
+TWO STEPS, like `org delete`:
+
+  omit --confirm         prints the warning and mints a token; nothing
+                         is deleted
+  --confirm <token>      goes through with it
+
+The token is SINGLE USE and expires after 5 minutes, so mint it
+immediately before you execute rather than early in a script.
+
+Owner-level authority, not analyst-level: mailsec.act AND billing.ctrl
+AND user.ctrl — the same trio `org delete` asks for. --reason is
+optional, at most 1024 characters, and is written to the org audit log
+next to your identity.
+
+RE-RUNNABLE. A partial purge returns complete=false and counts what did
+not land (objects_failed, subscriptions_failed, connections_unreachable,
+rows_remained) beside what did. Run it again with a fresh token and it
+picks up what remains; this command exits non-zero on complete=false so
+a script cannot mistake a half-purged tenant for a finished one.
+
+You may not need this at all. The same data is deleted automatically 30
+days after the org unsubscribes from Email Security -- resubscribing
+inside that window cancels it -- and immediately if the org itself is
+deleted.
+
+Examples:
+  limacharlie mailsec tenant purge
+  limacharlie mailsec tenant purge --confirm 3c514e... --reason "customer offboarded"
+"""
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -786,6 +831,8 @@ def group() -> None:
       rule ...            Custom rule validation and backtest
       connection test     Provider connection preflight
       onboarding          Provider setup guide, with your values filled in
+      tenant purge        Permanently delete all of this org's Email Security
+                          data (two-step, irreversible, Owner-level)
     """
 
 
@@ -828,6 +875,11 @@ def rule_group() -> None:
 @group.group("connection")
 def connection_group() -> None:
     """Provider connections."""
+
+
+@group.group("tenant")
+def tenant_group() -> None:
+    """This org's Email Security tenancy as a whole."""
 
 
 # ---------------------------------------------------------------------------
@@ -1484,6 +1536,69 @@ def connection_test(ctx, record, include_watch) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Tenant
+# ---------------------------------------------------------------------------
+
+@tenant_group.command("purge")
+@click.option("--confirm", default=None,
+              help="Pass the token from the preview call to EXECUTE. Omit to preview.")
+@click.option("--reason", default=None,
+              help="Recorded in the org audit log with your identity (max 1024 chars).")
+@pass_context
+def tenant_purge(ctx, confirm, reason) -> None:
+    """Permanently delete all Email Security data for this org.
+
+    \b
+    Previews unless --confirm is given. IRREVERSIBLE.
+
+    \b
+    Example:
+      limacharlie mailsec tenant purge
+      limacharlie mailsec tenant purge --confirm <token> --reason "offboarding"
+    """
+    ms = _get_mailsec(ctx)
+
+    if confirm is None:
+        if reason is not None:
+            note(ctx, "note: --reason is only recorded by the executing call; "
+                      "pass it again alongside --confirm.")
+        prepared = ms.prepare_tenant_purge()
+        warning = prepared.get("warning")
+        if warning:
+            note(ctx, str(warning))
+            note(ctx, "")
+        token = prepared.get("confirmation")
+        if token:
+            expires = prepared.get("expires_in_seconds")
+            note(ctx, f"confirm:       {token}")
+            if expires is not None:
+                note(ctx, f"expires in:    {expires}s (single use)")
+            note(ctx, "")
+            note(ctx, "Nothing has been deleted. To go through with it:")
+            note(ctx, f"  limacharlie mailsec tenant purge --confirm {token}")
+        _output(ctx, prepared)
+        return
+
+    try:
+        result = ms.purge_tenant(confirm, reason=reason)
+    except ValueError as e:
+        raise click.BadParameter(str(e), param_hint="--reason" if reason else "--confirm")
+
+    _output(ctx, result)
+
+    # An incomplete purge is the outcome this verb most needs to report loudly.
+    # It is not an error — the call did what it could and says so — but a script
+    # that treats it as success leaves a half-purged tenant behind, so it is
+    # narrated on stderr and carried in the exit code as well as in `complete`.
+    if not result.get("complete"):
+        note(ctx, "")
+        note(ctx, "PURGE INCOMPLETE (complete=false). Some of the data is still there.")
+        note(ctx, "Re-run it: the purge is re-runnable and picks up what remains. "
+                  "Mint a fresh token first — tokens are single use.")
+        ctx.exit(1)
+
+
+# ---------------------------------------------------------------------------
 # Explain registration
 # ---------------------------------------------------------------------------
 
@@ -1514,3 +1629,4 @@ register_explain("mailsec.hunt.remediate", _EXPLAIN_HUNT_REMEDIATE)
 register_explain("mailsec.rule.validate", _EXPLAIN_RULE_VALIDATE)
 register_explain("mailsec.rule.backtest", _EXPLAIN_RULE_BACKTEST)
 register_explain("mailsec.connection.test", _EXPLAIN_CONNECTION_TEST)
+register_explain("mailsec.tenant.purge", _EXPLAIN_TENANT_PURGE)

--- a/limacharlie/discovery.py
+++ b/limacharlie/discovery.py
@@ -136,6 +136,7 @@ PROFILES = {
             "mailsec rule validate", "mailsec rule backtest",
             "mailsec connection test",
             "mailsec onboarding",
+            "mailsec tenant purge",
         ],
     },
 }

--- a/limacharlie/sdk/mailsec.py
+++ b/limacharlie/sdk/mailsec.py
@@ -6,7 +6,7 @@ download, analyst verdict revision and its history, bulk remediation across a
 caller-supplied selection, campaigns, sender profiles, the action audit trail,
 the abuse-mailbox report queue and its reopen, standalone EML analysis,
 retro-hunts, custom-rule validation and backtest, the provider connection
-preflight, and the served onboarding guide.
+preflight, the served onboarding guide, and the irreversible tenant purge.
 
 Permissions, which are four rather than the usual get/set pair because mailsec
 asks to be trusted with four different things:
@@ -17,6 +17,12 @@ asks to be trusted with four different things:
 - ``mailsec.act``     remediate live mail at the provider
 - ``mailsec.get.eml`` take the original bytes of somebody's mail out of the
                       building; requires a logged justification
+
+The one exception is the tenant purge (:meth:`Mailsec.prepare_tenant_purge`
+and :meth:`Mailsec.purge_tenant`), which is Owner-level rather than mailsec
+-level: it wants ``mailsec.act`` AND ``billing.ctrl`` AND ``user.ctrl``, the
+same trio org deletion asks for, because destroying a product's entire record
+for a tenant is an ownership decision rather than an analyst one.
 
 Every route additionally requires the org to be subscribed to the
 ``ext-email-security`` extension (403 otherwise)::
@@ -58,6 +64,13 @@ if TYPE_CHECKING:
 # ten, each no longer than 280 characters.
 _MAX_RATIONALE_LINES = 10
 _MAX_RATIONALE_LEN = 280
+
+
+# The audited reason on a tenant purge, bounded the same way and for the same
+# reason, with one extra: the confirmation token a purge spends is single-use
+# and lives five minutes, so learning about an over-long reason from the server
+# costs a re-mint. Checking here costs nothing.
+_MAX_PURGE_REASON_LEN = 1024
 
 
 # The bulk remediation vocabulary, for documentation and for building help text.
@@ -219,6 +232,20 @@ class Mailsec:
             query_params=query_params or None,
             raw_body=json.dumps(body).encode(),
             content_type="application/json",
+            raw_response=raw_response,
+        )
+
+    def _delete(
+        self,
+        path: str,
+        query_params: list[tuple[str, str]] | None = None,
+        *,
+        raw_response: bool = False,
+    ) -> Any:
+        return self._org.client.request(
+            "DELETE",
+            f"mailsec/{self.oid}/{path}",
+            query_params=query_params or None,
             raw_response=raw_response,
         )
 
@@ -1085,3 +1112,86 @@ class Mailsec:
         pairs: list[tuple[str, str]] = []
         _add_scalar(pairs, "provider", provider)
         return self._get("onboarding", pairs)
+
+    # ------------------------------------------------------------------
+    # Tenant purge
+    # ------------------------------------------------------------------
+
+    def prepare_tenant_purge(self) -> dict[str, Any]:
+        """Mint the single-use confirmation token a tenant purge requires.
+
+        Changes nothing. This is the read half of the same two-step shape org
+        deletion uses: it returns the warning describing what a purge would
+        destroy, plus a token that :meth:`purge_tenant` will not act without.
+        Showing a human that warning before anything is destroyed is the whole
+        reason the destructive verb cannot be reached in one call.
+
+        Requires Owner-level authority — ``mailsec.act`` AND ``billing.ctrl``
+        AND ``user.ctrl``, the same trio org deletion asks for, because there
+        is no separate "owner" permission to ask for instead.
+
+        Returns:
+            The mint, with ``confirmation`` (the token), ``expires_in_seconds``
+            (300) and ``warning`` (the human-readable statement of what is
+            about to be destroyed). The token is SINGLE-USE and expires in five
+            minutes: a purge that has to be re-run needs a fresh one, so mint
+            immediately before executing rather than early in a script.
+        """
+        return self._get("tenant")
+
+    def purge_tenant(self, confirmation: str, reason: str | None = None) -> dict[str, Any]:
+        """Permanently delete everything Email Security holds for this org.
+
+        IRREVERSIBLE, and wider than it may look: the message index and the
+        long-term evidence lane, campaigns, sender profiles, the remediation
+        audit trail, user reports, stored raw messages and their parsed copies,
+        link-detonation results, and the org's Email Security connection and
+        policy configuration. It also stops the mail connections at the
+        provider, so Microsoft or Google stops sending notifications about mail
+        this org no longer has anywhere to put.
+
+        RE-RUNNABLE, and that is the intended way to finish a partial one.
+        ``complete`` is ``False`` when some portion did not land — a provider
+        that was unreachable, an object store that refused a delete — and the
+        same call repeated picks up what remains. Nothing is double-deleted by
+        running it again. A fresh ``confirmation`` is needed for each attempt
+        because the token is single-use.
+
+        Args:
+            confirmation: The token from :meth:`prepare_tenant_purge`.
+            reason: Optional free text, at most 1024 characters, recorded in
+                the org's audit log next to the caller's identity.
+
+        Returns:
+            The outcome, whose most important field is ``complete``. The rest
+            are counts of what was removed and — deliberately alongside them —
+            what was not: ``objects_deleted``, ``mdms_deleted``,
+            ``detonation_results_deleted``, ``detonation_results_skipped``,
+            ``objects_failed``, ``tables_purged``, ``subscriptions_stopped``,
+            ``subscriptions_failed``, ``mailboxes_walked``,
+            ``provider_records_deleted``, ``policy_records_deleted``,
+            ``connections_unreachable``, ``rows_remained``. A caller that reads
+            only the successes will believe a partial purge finished.
+
+        Raises:
+            ValueError: If ``confirmation`` is empty, or ``reason`` exceeds
+                1024 characters. Both are checked here rather than left to the
+                server because a rejected request still costs the token, and
+                re-minting is a second round trip to learn something the client
+                already knew.
+        """
+        token = (confirmation or "").strip()
+        if not token:
+            raise ValueError(
+                "purge_tenant needs the confirmation token from "
+                "prepare_tenant_purge(); there is no unconfirmed form of this call"
+            )
+        pairs: list[tuple[str, str]] = [("confirmation", token)]
+        if reason is not None:
+            if len(reason) > _MAX_PURGE_REASON_LEN:
+                raise ValueError(
+                    f"reason is {len(reason)} characters; the audit log records at "
+                    f"most {_MAX_PURGE_REASON_LEN}"
+                )
+            pairs.append(("reason", reason))
+        return self._delete("tenant", pairs)

--- a/tests/unit/test_cli_lazy_loading_regression.py
+++ b/tests/unit/test_cli_lazy_loading_regression.py
@@ -193,7 +193,7 @@ EXPECTED_SUBCOMMANDS: dict[str, frozenset[str]] = {
     "logging": frozenset({"create", "delete", "get", "list"}),
     "mailsec": frozenset({
         "coverage", "analyze", "onboarding", "message", "campaign", "sender",
-        "action", "report", "hunt", "rule", "connection",
+        "action", "report", "hunt", "rule", "connection", "tenant",
     }),
     "lookup": frozenset({"delete", "disable", "enable", "get", "list", "set", "tag"}),
     "note": frozenset({"delete", "disable", "enable", "get", "list", "set", "tag"}),

--- a/tests/unit/test_cli_mailsec_tenant.py
+++ b/tests/unit/test_cli_mailsec_tenant.py
@@ -1,0 +1,171 @@
+"""Tests for `limacharlie mailsec tenant purge`.
+
+The property under test throughout is that the destructive half is
+unreachable by accident: the default invocation must call the PREPARE method
+and must not call the purge, and the token a human read has to be handed back
+explicitly for anything to be destroyed.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from limacharlie.cli import cli
+
+
+OID = "11111111-2222-3333-4444-555555555555"
+
+PREPARED = {
+    "confirmation": "5f1c0de5-0000-4000-8000-abcdefabcdef",
+    "expires_in_seconds": 300,
+    "warning": "This permanently deletes all Email Security data for this org.",
+}
+
+COMPLETE = {
+    "complete": True,
+    "objects_deleted": 12,
+    "objects_failed": 0,
+    "tables_purged": ["messages"],
+    "subscriptions_stopped": 2,
+    "subscriptions_failed": 0,
+    "rows_remained": 0,
+}
+
+
+def invoke_purge(*args: str, prepared=None, purged=None):
+    with (
+        patch("limacharlie.commands.mailsec.Client"),
+        patch("limacharlie.commands.mailsec.Organization"),
+        patch("limacharlie.commands.mailsec.Mailsec") as mailsec_cls,
+    ):
+        mailsec = MagicMock()
+        mailsec.prepare_tenant_purge.return_value = dict(prepared or PREPARED)
+        mailsec.purge_tenant.return_value = dict(purged or COMPLETE)
+        mailsec_cls.return_value = mailsec
+        result = CliRunner().invoke(
+            cli,
+            ["--oid", OID, "--output", "json", "mailsec", "tenant", "purge", *args],
+        )
+        return result, mailsec
+
+
+# ---------------------------------------------------------------------------
+# The preview half
+# ---------------------------------------------------------------------------
+
+def test_without_confirm_it_prepares_and_destroys_nothing():
+    result, mailsec = invoke_purge()
+    assert result.exit_code == 0, result.output
+    mailsec.prepare_tenant_purge.assert_called_once_with()
+    mailsec.purge_tenant.assert_not_called()
+
+
+def test_the_preview_shows_the_warning_and_the_token():
+    result, _ = invoke_purge()
+    assert result.exit_code == 0, result.output
+    assert PREPARED["warning"] in result.output
+    assert PREPARED["confirmation"] in result.output
+    assert "Nothing has been deleted" in result.output
+
+
+def test_the_preview_document_is_still_the_thing_on_stdout():
+    """The narration goes to stderr; a script reading the pipe gets the mint."""
+    with (
+        patch("limacharlie.commands.mailsec.Client"),
+        patch("limacharlie.commands.mailsec.Organization"),
+        patch("limacharlie.commands.mailsec.Mailsec") as mailsec_cls,
+    ):
+        mailsec = MagicMock()
+        mailsec.prepare_tenant_purge.return_value = dict(PREPARED)
+        mailsec_cls.return_value = mailsec
+        result = CliRunner(mix_stderr=False).invoke(
+            cli, ["--oid", OID, "--output", "json", "mailsec", "tenant", "purge"]
+        )
+    assert result.exit_code == 0, result.stderr
+    import json
+    assert json.loads(result.stdout)["confirmation"] == PREPARED["confirmation"]
+
+
+def test_a_reason_without_confirm_says_it_is_not_recorded_yet():
+    result, mailsec = invoke_purge("--reason", "offboarding")
+    assert result.exit_code == 0, result.output
+    mailsec.purge_tenant.assert_not_called()
+    assert "only recorded by the executing call" in result.output
+
+
+# ---------------------------------------------------------------------------
+# The destructive half
+# ---------------------------------------------------------------------------
+
+def test_confirm_passes_the_token_through_unchanged():
+    result, mailsec = invoke_purge("--confirm", PREPARED["confirmation"])
+    assert result.exit_code == 0, result.output
+    mailsec.purge_tenant.assert_called_once_with(
+        PREPARED["confirmation"], reason=None
+    )
+    mailsec.prepare_tenant_purge.assert_not_called()
+
+
+def test_confirm_carries_the_audited_reason():
+    result, mailsec = invoke_purge(
+        "--confirm", "tok", "--reason", "customer offboarded"
+    )
+    assert result.exit_code == 0, result.output
+    mailsec.purge_tenant.assert_called_once_with("tok", reason="customer offboarded")
+
+
+def test_an_incomplete_purge_exits_non_zero_and_says_to_re_run():
+    partial = dict(COMPLETE, complete=False, objects_failed=3, rows_remained=17)
+    result, _ = invoke_purge("--confirm", "tok", purged=partial)
+    assert result.exit_code == 1, result.output
+    assert "PURGE INCOMPLETE" in result.output
+    assert "re-runnable" in result.output
+
+
+def test_a_client_side_refusal_is_a_usage_error_not_a_traceback():
+    with (
+        patch("limacharlie.commands.mailsec.Client"),
+        patch("limacharlie.commands.mailsec.Organization"),
+        patch("limacharlie.commands.mailsec.Mailsec") as mailsec_cls,
+    ):
+        mailsec = MagicMock()
+        mailsec.purge_tenant.side_effect = ValueError(
+            "reason is 1025 characters; the audit log records at most 1024"
+        )
+        mailsec_cls.return_value = mailsec
+        result = CliRunner().invoke(
+            cli,
+            ["--oid", OID, "mailsec", "tenant", "purge", "--confirm", "tok",
+             "--reason", "x" * 1025],
+        )
+    assert result.exit_code == 2, result.output
+    assert "the audit log records at most 1024" in result.output
+    assert result.exception is None or isinstance(result.exception, SystemExit)
+
+
+# ---------------------------------------------------------------------------
+# Help text
+# ---------------------------------------------------------------------------
+
+def test_help_states_the_two_step_and_the_irreversibility():
+    result = CliRunner().invoke(cli, ["mailsec", "tenant", "purge", "--help"])
+    assert result.exit_code == 0, result.output
+    assert "IRREVERSIBLE" in result.output
+    assert "Previews unless --confirm is given" in result.output
+
+
+def test_ai_help_states_the_token_lifetime_and_the_owner_permissions():
+    result = CliRunner().invoke(cli, ["mailsec", "tenant", "purge", "--ai-help"])
+    assert result.exit_code == 0, result.output
+    assert "SINGLE USE" in result.output
+    assert "5 minutes" in result.output
+    for perm in ("mailsec.act", "billing.ctrl", "user.ctrl"):
+        assert perm in result.output
+
+
+def test_ai_help_names_the_automatic_deletion_clocks():
+    """A reader must be able to learn they may not need this command at all."""
+    result = CliRunner().invoke(cli, ["mailsec", "tenant", "purge", "--ai-help"])
+    assert result.exit_code == 0, result.output
+    assert "30" in result.output
+    assert "unsubscribes" in result.output

--- a/tests/unit/test_sdk_mailsec.py
+++ b/tests/unit/test_sdk_mailsec.py
@@ -590,12 +590,78 @@ class TestRouteCoverage:
             (lambda: ms.bulk_action_execute("trash_message", ["m"], "tok"), "POST",
              f"mailsec/{OID}/actions/bulk/execute"),
             (lambda: ms.bulk_action_status("b"), "GET", f"mailsec/{OID}/actions/bulk/b"),
+            (lambda: ms.prepare_tenant_purge(), "GET", f"mailsec/{OID}/tenant"),
+            (lambda: ms.purge_tenant("tok"), "DELETE", f"mailsec/{OID}/tenant"),
         ]
-        # 28 gateway routes, 28 SDK methods.
-        assert len(calls) == 28
+        # 30 gateway routes, 30 SDK methods.
+        assert len(calls) == 30
         for fn, method, expected_url in calls:
             mock_org.client.request.reset_mock()
             fn()
             args, _ = mock_org.client.request.call_args
             assert args[0] == method, f"{expected_url}: wrong HTTP method"
             assert args[1] == expected_url
+
+
+class TestTenantPurge:
+    """The irreversible one.
+
+    Two properties matter more than the rest: the destructive half is a DELETE
+    to its own route and cannot be reached without a token, and the token/reason
+    reach the wire as query params rather than a body the gateway would not read.
+    """
+
+    def test_prepare_is_a_read_and_mints_nothing_of_its_own(self, ms, mock_org):
+        mock_org.client.request.return_value = {
+            "confirmation": "tok", "expires_in_seconds": 300, "warning": "..."
+        }
+        assert ms.prepare_tenant_purge()["confirmation"] == "tok"
+        url, qp = _get_call(mock_org)
+        assert url == f"mailsec/{OID}/tenant"
+        assert qp is None
+
+    def test_purge_is_a_delete_carrying_the_token_as_a_query_param(self, ms, mock_org):
+        ms.purge_tenant("tok")
+        args, kwargs = mock_org.client.request.call_args
+        assert args[0] == "DELETE"
+        assert args[1] == f"mailsec/{OID}/tenant"
+        assert kwargs["query_params"] == [("confirmation", "tok")]
+        # A DELETE with a JSON body would be silently ignored by the gateway.
+        assert kwargs.get("raw_body") is None
+
+    def test_the_audited_reason_is_forwarded(self, ms, mock_org):
+        ms.purge_tenant("tok", reason="customer offboarded")
+        _, kwargs = mock_org.client.request.call_args
+        assert kwargs["query_params"] == [
+            ("confirmation", "tok"), ("reason", "customer offboarded")
+        ]
+
+    def test_an_absent_reason_sends_no_pair(self, ms, mock_org):
+        ms.purge_tenant("tok", reason=None)
+        _, kwargs = mock_org.client.request.call_args
+        assert [k for k, _ in kwargs["query_params"]] == ["confirmation"]
+
+    def test_an_empty_reason_is_still_sent(self, ms, mock_org):
+        """`reason=""` is a caller saying "record that I gave none", which is
+        not the same as never passing the parameter."""
+        ms.purge_tenant("tok", reason="")
+        _, kwargs = mock_org.client.request.call_args
+        assert ("reason", "") in kwargs["query_params"]
+
+    @pytest.mark.parametrize("bad", ["", "   ", None])
+    def test_a_missing_token_never_reaches_the_network(self, ms, mock_org, bad):
+        with pytest.raises(ValueError):
+            ms.purge_tenant(bad)
+        mock_org.client.request.assert_not_called()
+
+    def test_an_over_long_reason_is_refused_before_the_token_is_spent(self, ms, mock_org):
+        """The token is single-use: learning about the bound from the server
+        costs a re-mint, so it is checked here."""
+        with pytest.raises(ValueError, match="1024"):
+            ms.purge_tenant("tok", reason="x" * 1025)
+        mock_org.client.request.assert_not_called()
+
+    def test_the_bound_itself_is_accepted(self, ms, mock_org):
+        ms.purge_tenant("tok", reason="x" * 1024)
+        _, kwargs = mock_org.client.request.call_args
+        assert ("reason", "x" * 1024) in kwargs["query_params"]


### PR DESCRIPTION
Binds the two new Email Security tenant-purge routes into the SDK and the CLI.

A tenant purge permanently deletes everything Email Security holds for one organization — the message index and the long-term evidence lane, campaigns, sender profiles, the remediation audit trail, user reports, the stored raw messages and their parsed copies, the link-detonation results, and the org's Email Security connection and policy configuration — and stops the mail connections at Microsoft or Google so the provider stops sending notifications. It is irreversible.

## Routes

| | |
|---|---|
| `GET /v1/mailsec/{oid}/tenant` | Mint a single-use confirmation token, valid 5 minutes. Destroys nothing. |
| `DELETE /v1/mailsec/{oid}/tenant?confirmation=&reason=` | Go through with it. |

Both are Owner-level: `mailsec.act` **and** `billing.ctrl` **and** `user.ctrl` — the same trio `org delete` asks for.

## SDK

`Mailsec.prepare_tenant_purge()` and `Mailsec.purge_tenant(confirmation, reason=None)`.

The mailsec SDK had no DELETE route until now, so this adds a `_delete` helper alongside `_get`/`_post`. The 1024-character bound on the audited `reason` is mirrored client-side for the same reason the verdict-rationale bounds are, plus one more specific to this call: the token is single-use, so learning the bound from a 400 costs a re-mint.

## CLI

`limacharlie mailsec tenant purge`, two-step on the `org delete` precedent:

```bash
# Step 1 — preview. Prints the warning and the token on stderr; nothing is deleted.
limacharlie mailsec tenant purge

# Step 2 — execute.
limacharlie mailsec tenant purge --confirm <TOKEN> --reason "customer offboarded"
```

An incomplete purge (`complete: false`) is narrated on stderr and exits non-zero. The purge is re-runnable, and a script that read only the success counts would otherwise leave a half-purged tenant behind believing it had finished.

The help also says most orgs never need this: the same data is deleted automatically 30 days after an org unsubscribes from Email Security (a resubscribe inside the window cancels it) and immediately if the org itself is deleted.

## The three hand-maintained maps

- `_COMMAND_MODULE_MAP` — already had `mailsec`; verified, no change needed.
- `PROFILES["email_security"]` — gains `mailsec tenant purge` (`tests/unit/test_discovery.py` enforces it).
- `doc/cli/` — the mailsec surface had **no page in the CLI reference at all**. Added `doc/cli/email-security.md` and linked it from both command-reference tables, along with the Cloud Security page, which existed but was missing from `doc/cli/README.md`'s index.

Every command and flag in the new doc page was verified against the live `--help` output rather than written from memory (37/37 resolve).

## Tests

`tests/unit/test_cli_mailsec_tenant.py` (new, 11 tests) and additions to `tests/unit/test_sdk_mailsec.py` covering the HTTP verb, the route, the query params, the empty-vs-absent `reason` distinction, and the two client-side refusals. The route-coverage table goes 28 → 30.

`pytest tests/unit/ tests/microbenchmarks/`: **4113 passed, 5 skipped**.
