### PR TITLE
output: stop handing terminal control sequences to a terminal

### DIFF
--- a/doc/cli/email-security.md
+++ b/doc/cli/email-security.md
@@ -58,9 +58,11 @@ An unknown message id returns a null message rather than an error: the index has
 
 A different privilege from opening the drawer, because it takes a person's actual mail out of the building. `--justification` is required and is written to the access audit with your identity.
 
+These are the sender's own bytes, unmodified, so the command **refuses to write them to a terminal**: a hostile message carrying ANSI escape sequences would repaint your screen. Give it `--out-file`, or pipe it. Redirects and pipes are unaffected; `--to-terminal` overrides the refusal if you really want the bytes on screen. The check happens before the download, so a refusal records no access.
+
 ```bash
-limacharlie mailsec message eml <MSG_UUID> --justification "INC-4471 credential harvest"
 limacharlie mailsec message eml <MSG_UUID> --justification "..." --out-file suspect.eml
+limacharlie mailsec message eml <MSG_UUID> --justification "..." | less
 ```
 
 ## Triage & remediation

--- a/limacharlie/commands/mailsec.py
+++ b/limacharlie/commands/mailsec.py
@@ -1038,13 +1038,17 @@ def message_get(ctx, msg_uuid) -> None:
               help="Write the raw bytes to this path instead of to stdout. Deliberately NOT "
                    "--output: that is the global format option, and a command-level --output "
                    "would shadow it so that `--output yaml` silently wrote a file named 'yaml'.")
+@click.option("--to-terminal", is_flag=True, default=False,
+              help="Write the raw message to the terminal anyway. The bytes are the sender's, "
+                   "unmodified and unescaped, so a hostile message can repaint your screen.")
 @pass_context
-def message_eml(ctx, msg_uuid, justification, out_path) -> None:
+def message_eml(ctx, msg_uuid, justification, out_path, to_terminal) -> None:
     """Download the original bytes of a message (audited).
 
     \b
     Example:
       limacharlie mailsec message eml 0057db2b-... --justification "INC-4471"
+      limacharlie mailsec message eml 0057db2b-... --justification "INC-4471" --out-file m.eml
     """
     ms = _get_mailsec(ctx)
     data = ms.get_message_eml(msg_uuid, justification)
@@ -1054,7 +1058,20 @@ def message_eml(ctx, msg_uuid, justification, out_path) -> None:
         if not ctx.obj.quiet:
             click.echo(f"wrote {len(data)} bytes to {out_path}")
         return
-    click.get_binary_stream("stdout").write(data)
+    stdout = click.get_binary_stream("stdout")
+    # These bytes are the SENDER'S, verbatim: this is the one command in the group that
+    # emits the attacker's own message rather than the product's view of it.  A terminal
+    # executes the escape sequences in them, so a phish carrying an ANSI payload repaints
+    # the analyst's screen the moment they look at it.  Piped or redirected, that cannot
+    # happen and nothing changes -- the refusal applies only when stdout really is a
+    # terminal, which is the same line curl draws for binary output.
+    if not to_terminal and stdout.isatty():
+        raise click.UsageError(
+            "refusing to write a raw message to the terminal: these are the sender's own "
+            "bytes and a hostile message can repaint your screen. Use --out-file PATH, pipe "
+            "the command, or pass --to-terminal to write it anyway."
+        )
+    stdout.write(data)
 
 
 @message_group.command("similar")

--- a/limacharlie/commands/mailsec.py
+++ b/limacharlie/commands/mailsec.py
@@ -1040,7 +1040,8 @@ def message_get(ctx, msg_uuid) -> None:
                    "would shadow it so that `--output yaml` silently wrote a file named 'yaml'.")
 @click.option("--to-terminal", is_flag=True, default=False,
               help="Write the raw message to the terminal anyway. The bytes are the sender's, "
-                   "unmodified and unescaped, so a hostile message can repaint your screen.")
+                   "unmodified and unescaped, so a hostile message can repaint your screen. "
+                   "Ignored when --out-file is given, which is already not a terminal.")
 @pass_context
 def message_eml(ctx, msg_uuid, justification, out_path, to_terminal) -> None:
     """Download the original bytes of a message (audited).
@@ -1050,6 +1051,24 @@ def message_eml(ctx, msg_uuid, justification, out_path, to_terminal) -> None:
       limacharlie mailsec message eml 0057db2b-... --justification "INC-4471"
       limacharlie mailsec message eml 0057db2b-... --justification "INC-4471" --out-file m.eml
     """
+    stdout = click.get_binary_stream("stdout")
+    # Checked BEFORE the download, not after.  These bytes are the SENDER'S, verbatim: this is
+    # the one command in the group that emits the attacker's own message rather than the
+    # product's view of it, and a terminal executes the escape sequences in them.  But the
+    # download is AUDITED -- it writes an ms_actions row and emits an EMAIL_ACTION event
+    # against the caller's identity -- so refusing after the fetch would record an access that
+    # was then thrown away, and force a second one to get the bytes: two audit rows for one
+    # act, on the surface whose whole point is an honest access trail.
+    #
+    # Piped or redirected, isatty() is false and nothing changes.  Same line curl draws for
+    # binary output.
+    if not out_path and not to_terminal and stdout.isatty():
+        raise click.UsageError(
+            "refusing to write a raw message to the terminal: these are the sender's own "
+            "bytes and a hostile message can repaint your screen. Use --out-file PATH, pipe "
+            "the command, or pass --to-terminal to write it anyway. Nothing was downloaded, "
+            "so no access has been recorded."
+        )
     ms = _get_mailsec(ctx)
     data = ms.get_message_eml(msg_uuid, justification)
     if out_path:
@@ -1058,19 +1077,6 @@ def message_eml(ctx, msg_uuid, justification, out_path, to_terminal) -> None:
         if not ctx.obj.quiet:
             click.echo(f"wrote {len(data)} bytes to {out_path}")
         return
-    stdout = click.get_binary_stream("stdout")
-    # These bytes are the SENDER'S, verbatim: this is the one command in the group that
-    # emits the attacker's own message rather than the product's view of it.  A terminal
-    # executes the escape sequences in them, so a phish carrying an ANSI payload repaints
-    # the analyst's screen the moment they look at it.  Piped or redirected, that cannot
-    # happen and nothing changes -- the refusal applies only when stdout really is a
-    # terminal, which is the same line curl draws for binary output.
-    if not to_terminal and stdout.isatty():
-        raise click.UsageError(
-            "refusing to write a raw message to the terminal: these are the sender's own "
-            "bytes and a hostile message can repaint your screen. Use --out-file PATH, pipe "
-            "the command, or pass --to-terminal to write it anyway."
-        )
     stdout.write(data)
 
 

--- a/limacharlie/commands/search.py
+++ b/limacharlie/commands/search.py
@@ -43,7 +43,7 @@ from ..config import get_config_value
 from ..sdk.organization import Organization
 from ..sdk.search import Search
 from ..sdk.hive import Hive, HiveRecord
-from ..output import format_output, format_table, detect_output_format
+from ..output import format_output, format_table, detect_output_format, escape_control_chars
 from ..discovery import register_explain
 from ._time_validation import validate_epoch_seconds
 
@@ -469,7 +469,9 @@ def _format_expanded_event_block(row: dict[str, Any]) -> str:
         if etype:
             header_parts.append(etype)
 
-    header = " | ".join(header_parts) if header_parts else "event"
+    # `stream` and the event type come off the record, so they are escaped like any other
+    # rendered field. The body goes through the JSON pretty-printer, which escapes C0 itself.
+    header = " | ".join(escape_control_chars(str(p)) for p in header_parts) if header_parts else "event"
     body = _fast_dumps_pretty(data)
     return f"--- {header} ---\n{body}"
 
@@ -756,8 +758,11 @@ def _stream_table_events(results_iter: Any, wide: bool = False) -> None:
             parts.append(val.ljust(w))
         return "  ".join(parts)
 
-    # Print header.
-    header_vals = [col.ljust(col_widths[col]) for col in columns]
+    # Print header. The column NAMES are the event body's own keys, which for a USP- or
+    # adapter-ingested event are chosen by whoever produced the record -- so they get the same
+    # control-character escaping as the cells below, or the header is the one unescaped row on
+    # the screen. Escaped first, then padded, so the width still matches what is printed.
+    header_vals = [escape_control_chars(str(col)).ljust(col_widths[col]) for col in columns]
     click.echo("  ".join(header_vals))
     separator = "  ".join("-" * col_widths[col] for col in columns)
     click.echo(separator)
@@ -888,8 +893,9 @@ def _stream_table_from_file(checkpoint_path: str, wide: bool = False) -> None:
             parts.append(val.ljust(w))
         return "  ".join(parts)
 
-    # Print header.
-    header_vals = [col.ljust(col_widths.get(col, len(col))) for col in columns]
+    # Print header. Same reasoning as the streaming renderer above: the column names are the
+    # record's own keys.
+    header_vals = [escape_control_chars(str(col)).ljust(col_widths.get(col, len(col))) for col in columns]
     click.echo("  ".join(header_vals))
     click.echo("  ".join("-" * col_widths.get(col, len(col)) for col in columns))
 

--- a/limacharlie/output.py
+++ b/limacharlie/output.py
@@ -208,6 +208,13 @@ def format_toon(data: Any) -> str:
     """
     if _toon_format is None:
         raise ImportError(_MISSING_TOON_MESSAGE)
+    # NOT control-character escaped, and that is a documented limitation rather than an
+    # oversight.  toon is a machine format reached only by an explicit `--output toon` (the
+    # TTY default is `table`), and unlike json and yaml it has no escape mechanism of its own:
+    # its structure is carried by newlines, so escaping the encoded document corrupts it and
+    # escaping the values before encoding would silently change the data a consumer parses
+    # back.  A caller who asks for toon and renders it in a terminal gets the sender's
+    # characters.  Use json, yaml or the default table if that matters.
     return _toon_format.encode(data)
 
 
@@ -220,7 +227,7 @@ def format_csv(data: Any) -> str:
         data = [data]
 
     if not isinstance(data, list):
-        return str(data)
+        return escape_control_chars(str(data))
 
     # Collect all keys for headers
     all_keys = []
@@ -231,14 +238,18 @@ def format_csv(data: Any) -> str:
                     all_keys.append(k)
 
     if not all_keys:
-        return str(data)
+        return escape_control_chars(str(data))
 
+    # The header row is data too -- see the column-name note in format_table. The map keeps
+    # the ORIGINAL key for row lookup while the file gets the escaped name.
+    safe_keys = {k: escape_control_chars(str(k)) for k in all_keys}
     output = io.StringIO()
-    writer = csv.DictWriter(output, fieldnames=all_keys, extrasaction="ignore")
+    writer = csv.DictWriter(output, fieldnames=[safe_keys[k] for k in all_keys], extrasaction="ignore")
     writer.writeheader()
     for item in data:
         if isinstance(item, dict):
-            writer.writerow({k: _csv_value(v) for k, v in item.items()})
+            writer.writerow({safe_keys.get(k, escape_control_chars(str(k))): _csv_value(v)
+                             for k, v in item.items()})
     return output.getvalue().rstrip()
 
 
@@ -264,7 +275,9 @@ def format_table(data: Any) -> str:
             # Fall through to list-of-dicts handling below
         else:
             # Single record - show as key/value pairs
-            rows = [[k, _table_value(v)] for k, v in data.items()]
+            # Keys are escaped too: for a dict-of-fields the key column IS data (an
+            # email header name, an event field name from an adapter-ingested body).
+            rows = [[escape_control_chars(str(k)), _table_value(v)] for k, v in data.items()]
             if tabulate is not None:
                 return tabulate(rows, headers=["Field", "Value"], tablefmt="simple")
             return "\n".join(f"{escape_control_chars(str(k))}: {v}" for k, v in rows)
@@ -284,10 +297,15 @@ def format_table(data: Any) -> str:
             selected_keys, rows = _fit_columns(all_keys, data)
             dropped = len(all_keys) - len(selected_keys)
 
+            # Column NAMES are data too. For a mailsec message they are our schema, but for a
+            # `limacharlie search` row they are the keys of an adapter-ingested event body,
+            # which the sender chose. Escaping only the cells would leave the header as the
+            # one unescaped row on the screen.
+            selected_keys = [escape_control_chars(str(k)) for k in selected_keys]
             if tabulate is not None:
                 tbl = tabulate(rows, headers=selected_keys, tablefmt="simple")
             else:
-                header = "  ".join(escape_control_chars(str(k)) for k in selected_keys)
+                header = "  ".join(str(k) for k in selected_keys)
                 lines = [header]
                 for row in rows:
                     lines.append("  ".join(str(v) for v in row))
@@ -329,7 +347,7 @@ def _csv_value(v: Any) -> Any:
     them already.
     """
     if isinstance(v, (dict, list)):
-        return _json_dumps(v)
+        return _safe_json(v)
     if isinstance(v, str):
         return escape_control_chars(v)
     return v
@@ -449,6 +467,21 @@ def escape_control_chars(s: str) -> str:
     return s.translate(_CONTROL_TRANSLATION)
 
 
+def _safe_json(v: Any) -> str:
+    r"""JSON-encode a value for a TERMINAL cell.
+
+    ``_json_dumps`` is not sufficient on its own.  JSON escapes C0 as ``\uXXXX``,
+    but neither orjson nor the stdlib escapes **C1** (U+0080-U+009F): both emit
+    them verbatim as UTF-8, and a terminal decodes 0x9B as an 8-bit CSI
+    introducer.  That is the same capability ``escape_control_chars`` covers C1
+    for in the first place, so a dict or list cell that skipped this step would
+    be the documented bypass of the documented fix.
+
+    JSON's own ``\uXXXX`` escapes are plain ASCII and pass through untouched.
+    """
+    return escape_control_chars(_json_dumps(v))
+
+
 def _truncate(s: str, width: int) -> str:
     """Truncate a string to *width* characters, adding '...' if needed."""
     if len(s) <= width:
@@ -464,11 +497,9 @@ def _table_value(v: Any, width: int | None = None) -> str:
         width: Max character width for this cell.  When None, falls back
                to the terminal-based default from _max_value_width().
     """
-    # _json_dumps output is already control-character-safe (JSON escapes them as
-    # \uXXXX); everything reached through str() is not.
     if _wide_mode:
         if isinstance(v, dict):
-            return _json_dumps(v)
+            return _safe_json(v)
         if isinstance(v, list):
             return escape_control_chars(", ".join(str(x) for x in v))
         if v is None:
@@ -477,7 +508,7 @@ def _table_value(v: Any, width: int | None = None) -> str:
     if width is None:
         width = _max_value_width()
     if isinstance(v, dict):
-        s = _json_dumps(v)
+        s = _safe_json(v)
         if len(s) <= width:
             return s
         return f"{{{len(v)} keys}}"

--- a/limacharlie/output.py
+++ b/limacharlie/output.py
@@ -248,7 +248,7 @@ def format_table(data: Any) -> str:
         return "No data"
 
     if isinstance(data, str):
-        return data
+        return escape_control_chars(data)
 
     if isinstance(data, dict):
         if _is_list_of_dicts(data):
@@ -267,7 +267,7 @@ def format_table(data: Any) -> str:
             rows = [[k, _table_value(v)] for k, v in data.items()]
             if tabulate is not None:
                 return tabulate(rows, headers=["Field", "Value"], tablefmt="simple")
-            return "\n".join(f"{k}: {v}" for k, v in rows)
+            return "\n".join(f"{escape_control_chars(str(k))}: {v}" for k, v in rows)
 
     if isinstance(data, list):
         if not data:
@@ -287,7 +287,7 @@ def format_table(data: Any) -> str:
             if tabulate is not None:
                 tbl = tabulate(rows, headers=selected_keys, tablefmt="simple")
             else:
-                header = "  ".join(str(k) for k in selected_keys)
+                header = "  ".join(escape_control_chars(str(k)) for k in selected_keys)
                 lines = [header]
                 for row in rows:
                     lines.append("  ".join(str(v) for v in row))
@@ -296,10 +296,12 @@ def format_table(data: Any) -> str:
                 tbl += f"\n({dropped} more field{'s' if dropped != 1 else ''} hidden, use -W to show all or --output json for full data)"
             return tbl
 
-        # List of primitives
-        return "\n".join(str(item) for item in data)
+        # List of primitives.  This is the sharpest of the table paths: `--filter
+        # 'messages[].subject'` puts one attacker-chosen string on each line with no
+        # column, no truncation and nothing between it and the terminal.
+        return "\n".join(escape_control_chars(str(item)) for item in data)
 
-    return str(data)
+    return escape_control_chars(str(data))
 
 
 def format_jsonl(data: Any) -> str:
@@ -320,9 +322,16 @@ def _select_fields(item: Any, fields: list[str]) -> Any:
 
 
 def _csv_value(v: Any) -> Any:
-    """Convert a value for CSV output."""
+    """Convert a value for CSV output.
+
+    A CSV written to a terminal is read by a terminal, so the same control-character
+    rule applies as for the table.  Dicts and lists go through JSON, which escapes
+    them already.
+    """
     if isinstance(v, (dict, list)):
         return _json_dumps(v)
+    if isinstance(v, str):
+        return escape_control_chars(v)
     return v
 
 
@@ -402,6 +411,44 @@ def _fit_columns(
     return selected, rows
 
 
+_CONTROL_CHARS = {
+    c: "\\x{:02x}".format(c)
+    for c in range(0x20)
+    if c not in (0x09,)  # TAB is the one C0 character a table legitimately contains.
+}
+_CONTROL_CHARS[0x7F] = "\\x7f"  # DEL
+# C1 (0x80-0x9F). These are what a terminal decodes as 8-bit CSI/OSC introducers, so
+# stripping only ESC would leave the same capability behind in a different encoding.
+_CONTROL_CHARS.update({c: "\\x{:02x}".format(c) for c in range(0x80, 0xA0)})
+
+_CONTROL_TRANSLATION = str.maketrans(_CONTROL_CHARS)
+
+
+def escape_control_chars(s: str) -> str:
+    """Render terminal control characters visibly instead of executing them.
+
+    The CLI prints values it did not author.  ``limacharlie mailsec message list``
+    renders email subjects, sender display names, attachment filenames and URLs --
+    every one of them chosen by whoever sent the mail -- and ``limacharlie search``
+    renders event fields the same way.  A terminal treats ESC-[ sequences in that
+    text as commands, not data, which lets a sender repaint the screen, erase the
+    lines above their row, or hide text behind a colour change.  Carriage return is
+    enough on its own: a subject ending in ``\r`` plus a fabricated row overwrites
+    the line the real values were on.
+
+    JSON and YAML output already escape these (``json.dumps`` emits ``\u001b``,
+    PyYAML emits ``\e``), so this is what brings the table and CSV renderers up to
+    the same standard rather than a new policy.
+
+    Tab survives because a table legitimately contains one.  Newline does not: a
+    single cell that spans lines breaks the row alignment that makes the table
+    readable, which is the same reason it is worth neutralising.
+    """
+    if not isinstance(s, str):
+        return s
+    return s.translate(_CONTROL_TRANSLATION)
+
+
 def _truncate(s: str, width: int) -> str:
     """Truncate a string to *width* characters, adding '...' if needed."""
     if len(s) <= width:
@@ -417,14 +464,16 @@ def _table_value(v: Any, width: int | None = None) -> str:
         width: Max character width for this cell.  When None, falls back
                to the terminal-based default from _max_value_width().
     """
+    # _json_dumps output is already control-character-safe (JSON escapes them as
+    # \uXXXX); everything reached through str() is not.
     if _wide_mode:
         if isinstance(v, dict):
             return _json_dumps(v)
         if isinstance(v, list):
-            return ", ".join(str(x) for x in v)
+            return escape_control_chars(", ".join(str(x) for x in v))
         if v is None:
             return ""
-        return str(v)
+        return escape_control_chars(str(v))
     if width is None:
         width = _max_value_width()
     if isinstance(v, dict):
@@ -434,13 +483,13 @@ def _table_value(v: Any, width: int | None = None) -> str:
         return f"{{{len(v)} keys}}"
     if isinstance(v, list):
         if len(v) <= 3:
-            s = ", ".join(str(x) for x in v)
+            s = escape_control_chars(", ".join(str(x) for x in v))
             if len(s) <= width:
                 return s
         return f"[{len(v)} items]"
     if v is None:
         return ""
-    return _truncate(str(v), width)
+    return _truncate(escape_control_chars(str(v)), width)
 
 
 def _is_list_of_dicts(data: Any) -> bool:

--- a/tests/unit/test_cli_mailsec_eml_terminal.py
+++ b/tests/unit/test_cli_mailsec_eml_terminal.py
@@ -1,0 +1,53 @@
+"""`mailsec message eml` writes the SENDER'S bytes, so it must not write them to a TTY."""
+
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from limacharlie.cli import cli
+
+RAW = b"From: a@b.example\r\nSubject: \x1b[2Jgotcha\r\n\r\nbody\r\n"
+OID = "11111111-2222-3333-4444-555555555555"
+
+
+def _invoke(extra_args, isatty):
+    with (
+        patch("limacharlie.commands.mailsec.Client"),
+        patch("limacharlie.commands.mailsec.Organization"),
+        patch("limacharlie.commands.mailsec.Mailsec") as mailsec_cls,
+    ):
+        mailsec = MagicMock()
+        mailsec.get_message_eml.return_value = RAW
+        mailsec_cls.return_value = mailsec
+        with patch("click.utils.WIN", False), patch(
+            "limacharlie.commands.mailsec.click.get_binary_stream"
+        ) as get_stream:
+            stream = MagicMock()
+            stream.isatty.return_value = isatty
+            get_stream.return_value = stream
+            result = CliRunner().invoke(
+                cli,
+                ["--oid", OID, "mailsec", "message", "eml", "msg-1",
+                 "--justification", "INC-4471"] + extra_args,
+            )
+            return result, stream
+
+
+def test_refuses_to_write_a_raw_message_to_a_terminal():
+    result, stream = _invoke([], isatty=True)
+    assert result.exit_code != 0
+    stream.write.assert_not_called()
+    assert "--out-file" in result.output
+
+
+def test_writes_when_stdout_is_not_a_terminal():
+    """Piping or redirecting is the normal case and must be unaffected."""
+    result, stream = _invoke([], isatty=False)
+    assert result.exit_code == 0, result.output
+    stream.write.assert_called_once_with(RAW)
+
+
+def test_to_terminal_is_the_escape_hatch():
+    result, stream = _invoke(["--to-terminal"], isatty=True)
+    assert result.exit_code == 0, result.output
+    stream.write.assert_called_once_with(RAW)

--- a/tests/unit/test_output_control_chars.py
+++ b/tests/unit/test_output_control_chars.py
@@ -1,0 +1,91 @@
+"""The table and CSV renderers must not hand terminal control sequences to a terminal.
+
+The CLI prints values it did not author: `limacharlie mailsec message list` renders
+email subjects, sender display names, attachment filenames and URLs -- all chosen by
+whoever sent the mail -- and `limacharlie search` renders event fields the same way.
+A terminal treats ESC-[ sequences in that text as commands rather than data.
+
+JSON and YAML already escape these; these tests pin that the table and CSV paths do
+too, and that the escaping is a rendering change only (JSON is untouched).
+"""
+
+import json
+
+import pytest
+
+from limacharlie.output import (
+    escape_control_chars,
+    format_csv,
+    format_json,
+    format_table,
+    set_wide_mode,
+)
+
+# A subject that clears the screen, then repaints a fake row, then hides the rest.
+HOSTILE_SUBJECT = "\x1b[2J\x1b[1;1HInvoice paid\rDELETED\x07\x1b[8m"
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        pytest.param([{"subject": HOSTILE_SUBJECT, "from": "a@b.example"}], id="list-of-dicts"),
+        pytest.param([HOSTILE_SUBJECT], id="list-of-primitives"),
+        pytest.param({"subject": HOSTILE_SUBJECT}, id="single-record"),
+        pytest.param({"m1": {"subject": HOSTILE_SUBJECT}, "m2": {"subject": "ok"}}, id="dict-of-dicts"),
+        pytest.param({"links": [HOSTILE_SUBJECT]}, id="short-list-cell"),
+        pytest.param(HOSTILE_SUBJECT, id="bare-string"),
+    ],
+)
+def test_table_never_emits_a_raw_escape(data):
+    out = format_table(data)
+    for ch in ("\x1b", "\r", "\x07"):
+        assert ch not in out, f"{ch!r} survived into table output: {out!r}"
+    # The text is still there to read, just inert. (Checked in wide mode: the default
+    # narrow cell truncates on terminal width, and an escaped sequence is wider than the
+    # raw one it replaces, which is the price of rendering it visibly.)
+    set_wide_mode(True)
+    try:
+        wide = format_table(data)
+    finally:
+        set_wide_mode(False)
+    assert "Invoice paid" in wide
+    assert "\x1b" not in wide
+
+
+def test_csv_never_emits_a_raw_escape():
+    out = format_csv([{"subject": HOSTILE_SUBJECT}])
+    assert "\x1b" not in out
+    assert "\x07" not in out
+    # csv's own line terminator is \r\n, so a bare \r from the VALUE is what must be gone:
+    # the value's cell must not contain one.
+    value_cell = out.split("\r\n", 1)[1]
+    assert "\r" not in value_cell
+
+
+def test_c1_introducers_are_escaped_too():
+    """Stripping only ESC leaves the same capability behind in 8-bit form."""
+    out = format_table([{"subject": "a\x9b2Jb"}])
+    assert "\x9b" not in out
+    assert "\\x9b" in out
+
+
+def test_tab_survives_but_newline_does_not():
+    assert escape_control_chars("a\tb") == "a\tb"
+    assert "\n" not in escape_control_chars("a\nb")
+
+
+def test_json_output_is_unchanged():
+    """The escaping is a TABLE/CSV rendering concern; machine output must not gain it."""
+    out = format_json([{"subject": HOSTILE_SUBJECT}])
+    assert json.loads(out)[0]["subject"] == HOSTILE_SUBJECT
+
+
+def test_ordinary_text_is_untouched():
+    """A renderer that mangled normal output would be worse than the hole it closes."""
+    subject = "Re: Q3 forecast — 15% up (draft v2) café/naïve"
+    assert escape_control_chars(subject) == subject
+    set_wide_mode(True)
+    try:
+        assert subject in format_table([{"subject": subject, "score": 71}])
+    finally:
+        set_wide_mode(False)

--- a/tests/unit/test_output_control_chars.py
+++ b/tests/unit/test_output_control_chars.py
@@ -74,6 +74,49 @@ def test_tab_survives_but_newline_does_not():
     assert "\n" not in escape_control_chars("a\nb")
 
 
+ESC = chr(27)
+C1_CSI = chr(0x9B)
+
+
+def test_column_names_are_escaped_too():
+    """The header is a row. For a `limacharlie search` result the column names are the keys of
+    an adapter-ingested event body, which the sender chose."""
+    out = format_table([{"su" + ESC + "[2Jbject": "v", "ok": "w"}])
+    assert ESC not in out
+    out = format_table({"fi" + ESC + "[2Jeld": "v"})
+    assert ESC not in out
+
+
+def test_csv_header_row_is_escaped():
+    out = format_csv([{"he" + ESC + "[2Jad": "v"}])
+    assert ESC not in out
+    # The row still lines up with its (escaped) header.
+    header, row = out.split("\r\n")[:2]
+    assert row == "v"
+    assert "\\x1b" in header
+
+
+def test_csv_of_a_bare_string_is_escaped():
+    """Reached by `--filter 'messages[0].subject' --output csv`."""
+    assert ESC not in format_csv(ESC + "[2JPWNED")
+
+
+def test_c1_survives_json_encoding_so_dict_cells_need_escaping_too():
+    """orjson and the stdlib both emit C1 verbatim; JSON only escapes C0.
+
+    A dict or list cell goes through the JSON encoder, so without a second pass it would be
+    the documented bypass of the C1 escaping this module adds.
+    """
+    out = format_table([{"payload": {"x": "p" + C1_CSI + "2Jq"}}])
+    assert C1_CSI not in out
+    set_wide_mode(True)
+    try:
+        assert C1_CSI not in format_table([{"payload": {"x": "p" + C1_CSI + "2Jq"}}])
+    finally:
+        set_wide_mode(False)
+    assert C1_CSI not in format_csv([{"payload": {"x": "p" + C1_CSI + "2Jq"}}])
+
+
 def test_json_output_is_unchanged():
     """The escaping is a TABLE/CSV rendering concern; machine output must not gain it."""
     out = format_json([{"subject": HOSTILE_SUBJECT}])


### PR DESCRIPTION
## Why

Two findings from the mailsec pre-GA security review **LOW batch** sweep. Both are in code the **whole CLI** shares, not in the mailsec group alone.

> Public repo: opened for review, **not to be merged** without Maxime's say-so.

### 1. `table` and `csv` handed terminal control sequences to a terminal

The CLI prints values it did not author. `limacharlie mailsec message list` renders email **subjects, sender display names, attachment filenames and URLs** -- every one of them chosen by whoever sent the mail -- and `limacharlie search` renders event fields the same way (`commands/search.py` calls `format_table` directly at four sites, so it needs no flag at all).

The two machine formats already escape control characters -- `json.dumps` emits a `\u001b` escape, PyYAML emits `\e`. `table` and `csv` did not: both reach a raw `str(v)`, and `click.echo` strips ANSI **only when the stream is not a TTY**, which is precisely the opposite of when it matters.

What that buys an attacker: a subject containing `ESC [ 2J` clears the analyst's screen; `ESC [ 1;1H` repositions the cursor to overwrite the rows above; `ESC [ 8m` hides text; and a bare carriage return needs no ESC at all -- a subject ending in one plus a fabricated line overwrites the row the real values were on.

The reachable paths, in descending order of realism:

- `--filter 'messages[].subject'` produces a list of primitives, joined with `str(item)`. One attacker-chosen string per line, no column, no truncation, nothing between it and the terminal. This is the sharpest one.
- `--filter 'messages'`, `--fields`, `-W/--wide`, `--sort-by` turn the envelope into a list of dicts, and `subject` becomes a raw column.
- `--output csv` on any mailsec or search read.

**Fix:** `escape_control_chars` renders C0 (except TAB), DEL and C1 visibly, applied at the two chokepoints -- `_table_value` and `_csv_value` -- plus `format_table`'s list-of-primitives and no-tabulate branches. 47 of the 55 command modules go through the same chokepoints, so this covers the CLI rather than one group.

C1 (0x80-0x9F) is included deliberately: a terminal decodes those as 8-bit CSI/OSC introducers, so stripping only ESC leaves the same capability behind in a different encoding. TAB survives because a table legitimately contains one; newline does not, because a cell that spans lines breaks the alignment that makes a table readable.

Machine output is untouched -- a test pins that `format_json` still round-trips the hostile string exactly.

One honest trade-off: an escaped sequence is wider than the raw one it replaces, so a hostile subject is truncated harder in a narrow cell. That only affects the hostile case, and `-W` still shows it whole.

### 2. `mailsec message eml` wrote the sender's bytes to a terminal

```python
click.get_binary_stream("stdout").write(data)
```

This is the one command in the group that emits the **attacker's own message**, byte for byte, rather than the product's structured view of it -- and with `--out-file` omitted the default sink is the TTY, with no guard. An analyst downloading a phish to look at it renders whatever ANSI payload it carries.

It now refuses when stdout really is a terminal, naming `--out-file` -- the same line `curl` draws for binary output. **Piping and redirecting are unaffected** (`isatty()` is false there), so scripts do not change. `--to-terminal` is the escape hatch, and its help text says what it costs.

## Verified

- Full unit suite: **4038 passed, 5 skipped** (the skips are pre-existing).
- Both regressions fail on the pre-fix tree:

```
FAILED test_table_never_emits_a_raw_escape[list-of-dicts]      - the raw escape survived into table output
FAILED test_table_never_emits_a_raw_escape[list-of-primitives]
FAILED test_table_never_emits_a_raw_escape[single-record]
FAILED test_csv_never_emits_a_raw_escape
```

- A control test asserts ordinary text -- em dashes, accents, `%` -- passes through unchanged, because a renderer that mangled normal output would be worse than the hole it closes.

## Assumptions

- The `--to-terminal` flag is a behaviour change on a published command. It is opt-in-to-the-old-behaviour rather than opt-in-to-the-new one because the unsafe direction should require the typing; if you would rather ship the escaping alone and leave the EML default as it was, that half drops out cleanly.
- `format_toon` is an optional dependency and was not installed here, so its escaping is **unverified**; it is not in either chokepoint. Noted rather than guessed at.
