### PR TITLE
feat(cloudsec): let a CI job state that its scanner ran, so a pushed SARIF can close

### DIFF
--- a/limacharlie/commands/cloudsec.py
+++ b/limacharlie/commands/cloudsec.py
@@ -27,6 +27,7 @@ the one provider command here is the pre-save credential preflight
 
 from __future__ import annotations
 
+import gzip
 import json
 import os
 import subprocess
@@ -77,6 +78,58 @@ UNAVAILABLE_LOCAL_SCANNERS = ("secrets", "secrets_history")
 # maxCodeIngestBytes on the collection host, mirrored so an over-cap document is refused
 # here — with the size in the message — instead of arriving as a gateway 400 about a body.
 MAX_CODE_INGEST_BYTES = 20 * 1024 * 1024
+
+
+def _stamp_sarif_execution(document: bytes, succeeded: bool) -> tuple[bytes, int]:
+    """Record, in a SARIF document, whether the scanner that produced it ran to completion.
+
+    WHY THIS EXISTS. A pushed SARIF closes a finding it previously reported only when the
+    document proves the tool actually RAN — SARIF 2.1.0 says so itself, with
+    ``run.invocations[].executionSuccessful``. Without that proof the push is additive: its
+    findings land and nothing closes. The rule is there because a scan step with a broken
+    ``--config`` still emits the tool's full rule catalogue and zero results, and reading
+    that as "the repository is clean now" resolves somebody's real vulnerabilities.
+
+    The trouble is that the two most common scanners — Trivy and Gitleaks — do not emit
+    ``invocations`` at all, so their documents can never close anything on their own. The
+    fact they omit is one the CI job HAS: it knows whether the command exited 0. This
+    function is how the job says so, and the assertion is the caller's, attributable to the
+    key that pushed it — not an inference we made from a catalogue.
+
+    A run that already carries ``invocations`` is left ALONE, in either direction. The tool's
+    own claim about its own execution outranks the caller's, and a wrapper that overwrote a
+    tool's ``executionSuccessful: false`` with ``true`` would manufacture exactly the
+    authority this whole rule exists to withhold.
+
+    Returns the document (gzipped again if it arrived gzipped) and how many runs were
+    stamped, so the caller can say what it did rather than changing the file silently.
+    """
+    was_gzipped = document[:2] == b"\x1f\x8b"
+    raw = gzip.decompress(document) if was_gzipped else document
+    try:
+        doc = json.loads(raw)
+    except ValueError as e:
+        raise click.ClickException(
+            "--scanner-succeeded/--scanner-failed has to read the document to record the "
+            "result in it, and this one is not valid JSON: %s" % (e,))
+    if not isinstance(doc, dict) or not isinstance(doc.get("runs"), list):
+        raise click.ClickException(
+            "--scanner-succeeded/--scanner-failed expects a SARIF document with a 'runs' "
+            "array; this one has none.")
+
+    stamped = 0
+    for run in doc["runs"]:
+        if not isinstance(run, dict):
+            continue
+        if run.get("invocations"):
+            continue  # the tool stated its own result; never overwrite it.
+        run["invocations"] = [{"executionSuccessful": bool(succeeded)}]
+        stamped += 1
+    if stamped == 0:
+        return document, 0
+
+    out = json.dumps(doc, separators=(",", ":")).encode("utf-8")
+    return (gzip.compress(out) if was_gzipped else out), stamped
 
 
 # ---------------------------------------------------------------------------
@@ -1699,8 +1752,16 @@ def code_autofix(ctx, finding_id, repo, provider) -> None:
                    "state it there.")
 @click.option("--provider", default=None,
               help="Source-control provider the key belongs to (default github).")
+@click.option("--scanner-succeeded/--scanner-failed", "scanner_succeeded", default=None,
+              help="SARIF only: record in the document whether the scanner that produced "
+                   "it ran to completion. A SARIF closes findings it previously reported "
+                   "ONLY if it says its run succeeded, and Trivy and Gitleaks do not write "
+                   "that field at all — so without this their pushes never close anything. "
+                   "Pass --scanner-succeeded when your scan step exited 0. A run that "
+                   "already states its own result is left alone.")
 @pass_context
-def code_ingest(ctx, repo, source, file_path, commit, ref, default_branch, provider) -> None:
+def code_ingest(ctx, repo, source, file_path, commit, ref, default_branch, provider,
+                scanner_succeeded) -> None:
     """Push scan results your own pipeline produced for one repository.
 
     Findings are deduplicated against the hosted scan by IDENTITY, so
@@ -1724,14 +1785,37 @@ def code_ingest(ctx, repo, source, file_path, commit, ref, default_branch, provi
     previously reported and no longer does; a pushed document can never
     close what the hosted scanner found.
 
+    WHEN A SARIF CLOSES NOTHING, THIS IS USUALLY WHY. A pushed SARIF is
+    treated as an authoritative enumeration — one whose missing findings mean
+    "fixed" rather than "not looked for" — only when the document says its
+    run succeeded, in SARIF's own 'invocations[].executionSuccessful'. A scan
+    step with a broken config still emits the tool's whole rule catalogue and
+    zero results, and believing that would resolve real vulnerabilities. Trivy
+    and Gitleaks do not write the field at all, so pass --scanner-succeeded
+    when your scan step exited 0 and the CLI will record it for you; you will
+    see 'sarif_no_invocation_evidence' in 'notes' when it is missing. The
+    'report' source states its coverage directly and needs none of this.
+
     \b
     Examples:
-      limacharlie cloudsec code ingest --repo acme/api --source sarif -f trivy.sarif
+      limacharlie cloudsec code ingest --repo acme/api --source sarif -f trivy.sarif \\
+          --scanner-succeeded
       limacharlie cloudsec code ingest --repo acme/api --source report -f report.json.gz \\
           --commit "$GITHUB_SHA"
     """
     with open(file_path, "rb") as f:
         document = f.read()
+    if scanner_succeeded is not None:
+        if source != "sarif":
+            raise click.ClickException(
+                "--scanner-succeeded/--scanner-failed applies to --source sarif only. A "
+                "'report' document states its own coverage, and a CycloneDX bill of "
+                "materials makes no claim about a scan having run.")
+        document, stamped = _stamp_sarif_execution(document, scanner_succeeded)
+        if stamped == 0:
+            click.echo(
+                "note: every run in %s already states its own execution result; "
+                "the flag changed nothing." % (file_path,), err=True)
     if len(document) > MAX_CODE_INGEST_BYTES:
         # Refused here, with the size, rather than as a gateway error about a request body.
         raise click.ClickException(

--- a/limacharlie/commands/cloudsec.py
+++ b/limacharlie/commands/cloudsec.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 
 import gzip
 import json
+import zlib
 import os
 import subprocess
 import tempfile
@@ -130,10 +131,13 @@ def _stamp_sarif_execution(document: bytes, succeeded: bool) -> tuple[bytes, int
     if was_gzipped:
         try:
             raw = gzip.decompress(document)
-        except (OSError, EOFError) as e:
-            # gzip raises BadGzipFile/EOFError, neither of which is a ValueError, so without
-            # this the failure escapes to the CLI's catch-all and prints a bare zlib message
-            # with no filename and no hint that the compression is the problem.
+        except (OSError, EOFError, zlib.error) as e:
+            # THREE exception types, because gzip corruption raises three and none of them
+            # is a ValueError. A truncated stream is EOFError; a bad header or a failed CRC
+            # is BadGzipFile (an OSError); and corruption INSIDE the deflate stream is
+            # zlib.error, which subclasses neither. Missing that third one left the guard
+            # blind to the shape it was written for — the CLI's catch-all would print a bare
+            # "Error -3 while decompressing data" with no filename and no mention of gzip.
             raise click.ClickException(
                 "--scanner-succeeded/--scanner-failed has to read the document to record "
                 "the result in it, and this one is not a readable gzip stream: %s" % (e,))
@@ -165,7 +169,22 @@ def _stamp_sarif_execution(document: bytes, succeeded: bool) -> tuple[bytes, int
     # 1.1 MB CJK sample). Since the size cap below is applied to the stamped bytes, that
     # inflation could refuse a file that is comfortably under the limit on disk, with an
     # error quoting a byte count matching nothing the operator can see.
-    out = json.dumps(doc, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    #
+    # allow_nan=False: Python parses a JSON number too large for a float (1e400) into `inf`
+    # and, by default, writes it back out as the bare token `Infinity` — which is NOT valid
+    # JSON, and which Go's encoding/json on the server rejects outright. Re-serializing is
+    # the only reason that can happen: without this flag the original bytes are forwarded
+    # untouched and the server never sees it. Refusing here, naming the document, beats
+    # turning a document the server could read into one it cannot.
+    try:
+        out = json.dumps(doc, separators=(",", ":"), ensure_ascii=False,
+                         allow_nan=False).encode("utf-8")
+    except ValueError as e:
+        raise click.ClickException(
+            "--scanner-succeeded/--scanner-failed has to rewrite the document to record the "
+            "result in it, and this one holds a number JSON cannot represent (%s). Push it "
+            "without the flag and add \"invocations\":[{\"executionSuccessful\":true}] to "
+            "each run yourself." % (e,))
     return (gzip.compress(out) if was_gzipped else out), stamped, len(runs)
 
 

--- a/limacharlie/commands/cloudsec.py
+++ b/limacharlie/commands/cloudsec.py
@@ -80,7 +80,21 @@ UNAVAILABLE_LOCAL_SCANNERS = ("secrets", "secrets_history")
 MAX_CODE_INGEST_BYTES = 20 * 1024 * 1024
 
 
-def _stamp_sarif_execution(document: bytes, succeeded: bool) -> tuple[bytes, int]:
+def _run_states_its_execution(run: dict) -> bool:
+    """Whether a SARIF run already says, itself, whether its tool ran to completion.
+
+    The test is for the FIELD, not for the array. `"invocations": [{}]` is a run with an
+    invocation that states nothing: the server reads a missing `executionSuccessful` as
+    unsuccessful, so such a document closes nothing, and treating it as "the tool already
+    spoke" would decline to stamp at the one moment stamping was needed.
+    """
+    for inv in run.get("invocations") or []:
+        if isinstance(inv, dict) and "executionSuccessful" in inv:
+            return True
+    return False
+
+
+def _stamp_sarif_execution(document: bytes, succeeded: bool) -> tuple[bytes, int, int]:
     """Record, in a SARIF document, whether the scanner that produced it ran to completion.
 
     WHY THIS EXISTS. A pushed SARIF closes a finding it previously reported only when the
@@ -90,22 +104,41 @@ def _stamp_sarif_execution(document: bytes, succeeded: bool) -> tuple[bytes, int
     ``--config`` still emits the tool's full rule catalogue and zero results, and reading
     that as "the repository is clean now" resolves somebody's real vulnerabilities.
 
-    The trouble is that the two most common scanners — Trivy and Gitleaks — do not emit
-    ``invocations`` at all, so their documents can never close anything on their own. The
-    fact they omit is one the CI job HAS: it knows whether the command exited 0. This
-    function is how the job says so, and the assertion is the caller's, attributable to the
-    key that pushed it — not an inference we made from a catalogue.
+    The trouble is that Trivy — whose output is the common case for this command — does not
+    emit ``invocations`` at all, so its documents can never close anything on their own. The
+    fact it omits is one the CI job HAS: it knows whether the command exited 0. This is how
+    the job says so.
 
-    A run that already carries ``invocations`` is left ALONE, in either direction. The tool's
-    own claim about its own execution outranks the caller's, and a wrapper that overwrote a
-    tool's ``executionSuccessful: false`` with ``true`` would manufacture exactly the
+    WHAT THIS IS NOT. The stamped object is byte-identical to one the tool could have
+    written, and the server reads ``invocations`` as the TOOL's record. Nothing downstream
+    can distinguish "Trivy said it succeeded" from "a CI job asserted it did" — the
+    provenance stored on the finding is the document's driver name, not the pushing key. So
+    do not describe this as an attributable assertion; it is the caller filling in a field
+    the tool left blank, and it is only as good as the caller's care.
+
+    A run that already STATES its execution result is left alone, in either direction. The
+    tool's claim about its own execution outranks the caller's, and a wrapper that overwrote
+    a tool's ``executionSuccessful: false`` with ``true`` would manufacture exactly the
     authority this whole rule exists to withhold.
 
-    Returns the document (gzipped again if it arrived gzipped) and how many runs were
-    stamped, so the caller can say what it did rather than changing the file silently.
+    Returns the document (gzipped again if it arrived gzipped), how many runs were stamped,
+    and how many runs the document holds — so the caller can tell "nothing to do because the
+    tool already spoke" apart from "nothing to do because there are no runs", which are very
+    different things to report.
     """
     was_gzipped = document[:2] == b"\x1f\x8b"
-    raw = gzip.decompress(document) if was_gzipped else document
+    if was_gzipped:
+        try:
+            raw = gzip.decompress(document)
+        except (OSError, EOFError) as e:
+            # gzip raises BadGzipFile/EOFError, neither of which is a ValueError, so without
+            # this the failure escapes to the CLI's catch-all and prints a bare zlib message
+            # with no filename and no hint that the compression is the problem.
+            raise click.ClickException(
+                "--scanner-succeeded/--scanner-failed has to read the document to record "
+                "the result in it, and this one is not a readable gzip stream: %s" % (e,))
+    else:
+        raw = document
     try:
         doc = json.loads(raw)
     except ValueError as e:
@@ -117,19 +150,23 @@ def _stamp_sarif_execution(document: bytes, succeeded: bool) -> tuple[bytes, int
             "--scanner-succeeded/--scanner-failed expects a SARIF document with a 'runs' "
             "array; this one has none.")
 
+    runs = [r for r in doc["runs"] if isinstance(r, dict)]
     stamped = 0
-    for run in doc["runs"]:
-        if not isinstance(run, dict):
+    for run in runs:
+        if _run_states_its_execution(run):
             continue
-        if run.get("invocations"):
-            continue  # the tool stated its own result; never overwrite it.
         run["invocations"] = [{"executionSuccessful": bool(succeeded)}]
         stamped += 1
     if stamped == 0:
-        return document, 0
+        return document, 0, len(runs)
 
-    out = json.dumps(doc, separators=(",", ":")).encode("utf-8")
-    return (gzip.compress(out) if was_gzipped else out), stamped
+    # ensure_ascii=False: the default escapes every non-ASCII character to \uXXXX, which on a
+    # document whose messages carry non-Latin text nearly DOUBLES it (measured 1.94x on a
+    # 1.1 MB CJK sample). Since the size cap below is applied to the stamped bytes, that
+    # inflation could refuse a file that is comfortably under the limit on disk, with an
+    # error quoting a byte count matching nothing the operator can see.
+    out = json.dumps(doc, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    return (gzip.compress(out) if was_gzipped else out), stamped, len(runs)
 
 
 # ---------------------------------------------------------------------------
@@ -1755,10 +1792,11 @@ def code_autofix(ctx, finding_id, repo, provider) -> None:
 @click.option("--scanner-succeeded/--scanner-failed", "scanner_succeeded", default=None,
               help="SARIF only: record in the document whether the scanner that produced "
                    "it ran to completion. A SARIF closes findings it previously reported "
-                   "ONLY if it says its run succeeded, and Trivy and Gitleaks do not write "
-                   "that field at all — so without this their pushes never close anything. "
-                   "Pass --scanner-succeeded when your scan step exited 0. A run that "
-                   "already states its own result is left alone.")
+                   "ONLY if it says its run succeeded, and Trivy does not write that field "
+                   "at all — so without this a Trivy push never closes anything. Pass "
+                   "--scanner-succeeded when your scan step exited 0. A run that already "
+                   "states its own result is left alone. It does not help a secret scanner: "
+                   "credential findings are never ingested from any pushed document.")
 @pass_context
 def code_ingest(ctx, repo, source, file_path, commit, ref, default_branch, provider,
                 scanner_succeeded) -> None:
@@ -1791,10 +1829,18 @@ def code_ingest(ctx, repo, source, file_path, commit, ref, default_branch, provi
     run succeeded, in SARIF's own 'invocations[].executionSuccessful'. A scan
     step with a broken config still emits the tool's whole rule catalogue and
     zero results, and believing that would resolve real vulnerabilities. Trivy
-    and Gitleaks do not write the field at all, so pass --scanner-succeeded
-    when your scan step exited 0 and the CLI will record it for you; you will
-    see 'sarif_no_invocation_evidence' in 'notes' when it is missing. The
+    does not write the field at all, so pass --scanner-succeeded when your
+    scan step exited 0 and the CLI records it for you. You will see
+    'sarif_no_invocation_evidence' in 'notes' when it is missing, and
+    'sarif_execution_unsuccessful' when the document says the run failed. The
     'report' source states its coverage directly and needs none of this.
+
+    THE FLAG DOES NOT HELP A SECRET SCANNER. Credential findings are never
+    ingested from a pushed document in any format — 'secrets_not_ingestable'
+    in 'notes' — because the format cannot carry the keyed digest a secret is
+    identified by and the matched value is never accepted. A gitleaks SARIF
+    therefore creates no findings to close, with or without this flag; use
+    the hosted scan's secrets scanner for that class.
 
     \b
     Examples:
@@ -1805,22 +1851,37 @@ def code_ingest(ctx, repo, source, file_path, commit, ref, default_branch, provi
     """
     with open(file_path, "rb") as f:
         document = f.read()
+    on_disk = len(document)
     if scanner_succeeded is not None:
         if source != "sarif":
             raise click.ClickException(
                 "--scanner-succeeded/--scanner-failed applies to --source sarif only. A "
                 "'report' document states its own coverage, and a CycloneDX bill of "
                 "materials makes no claim about a scan having run.")
-        document, stamped = _stamp_sarif_execution(document, scanner_succeeded)
+        document, stamped, runs = _stamp_sarif_execution(document, scanner_succeeded)
         if stamped == 0:
+            # Three different nothings, and saying the wrong one sends the operator the
+            # wrong way — "already stated" reads as reassurance, and it is the wrong
+            # reassurance for a document that simply has no runs to stamp.
             click.echo(
+                "note: %s has no runs, so there was nothing to record." % (file_path,)
+                if runs == 0 else
                 "note: every run in %s already states its own execution result; "
                 "the flag changed nothing." % (file_path,), err=True)
     if len(document) > MAX_CODE_INGEST_BYTES:
         # Refused here, with the size, rather than as a gateway error about a request body.
+        # When the stamp is what pushed it over, say THAT: telling somebody to narrow a scan
+        # that was under the limit before we rewrote it sends them after the wrong problem.
+        if on_disk <= MAX_CODE_INGEST_BYTES:
+            raise click.ClickException(
+                "%s is %d bytes on disk, under the %d limit, but recording the scanner "
+                "result re-serialized it to %d. Push it without "
+                "--scanner-succeeded/--scanner-failed and add "
+                "\"invocations\":[{\"executionSuccessful\":true}] to each run yourself, or "
+                "narrow the scan." % (file_path, on_disk, MAX_CODE_INGEST_BYTES, len(document)))
         raise click.ClickException(
             "%s is %d bytes; the ingest limit is %d. Narrow the scan, or push the "
-            "sections separately." % (file_path, len(document), MAX_CODE_INGEST_BYTES))
+            "sections separately." % (file_path, on_disk, MAX_CODE_INGEST_BYTES))
     cs = _get_cloudsec(ctx)
     _output(ctx, cs.ingest_code_results(
         repo, source, document, commit=commit, ref=ref,

--- a/limacharlie/sdk/cloudsec.py
+++ b/limacharlie/sdk/cloudsec.py
@@ -1529,11 +1529,18 @@ class CloudSec:
         and zero results, and treating that as a clean pass would resolve
         real vulnerabilities.
 
-        Trivy and Gitleaks do not write ``invocations``, so a document
-        straight from either never closes anything. Add the field yourself
-        when your scan step exited 0 — the CLI's
-        ``code ingest --scanner-succeeded`` does it for you — or push the
-        scanner's own ``report/v1``, which states its coverage directly.
+        Trivy does not write ``invocations``, so a document straight from it
+        never closes anything. Add the field yourself when your scan step
+        exited 0 — the CLI's ``code ingest --scanner-succeeded`` does it for
+        you — or push the scanner's own ``report/v1``, which states its
+        coverage directly. A document that says its run FAILED is also
+        additive, and says so with ``sarif_execution_unsuccessful``.
+
+        None of this applies to a secret scanner. Credential findings are
+        never ingested from a pushed document in any format
+        (``secrets_not_ingestable``), so a gitleaks SARIF creates nothing to
+        close whatever its ``invocations`` say; that class comes from the
+        hosted scan.
         """
         body: dict[str, Any] = {"repo": repo, "source": source}
         if isinstance(document, (bytes, bytearray)):

--- a/limacharlie/sdk/cloudsec.py
+++ b/limacharlie/sdk/cloudsec.py
@@ -1517,6 +1517,23 @@ class CloudSec:
 
         A pushed document can only ever close findings IT previously
         reported. It can never close what the hosted scanner found.
+
+        AND IT CLOSES NOTHING AT ALL UNLESS IT PROVES ITS SCAN RAN. A SARIF
+        is read as an authoritative enumeration — one whose absent findings
+        mean "fixed" rather than "not looked for" — only when it carries
+        ``run.invocations[].executionSuccessful: true``, which SARIF 2.1.0
+        defines for exactly this purpose. Without it the push is ADDITIVE:
+        the findings land, nothing closes, and ``notes`` carries
+        ``sarif_no_invocation_evidence``. The rule exists because a scan step
+        with a broken ``--config`` still emits the tool's full rule catalogue
+        and zero results, and treating that as a clean pass would resolve
+        real vulnerabilities.
+
+        Trivy and Gitleaks do not write ``invocations``, so a document
+        straight from either never closes anything. Add the field yourself
+        when your scan step exited 0 — the CLI's
+        ``code ingest --scanner-succeeded`` does it for you — or push the
+        scanner's own ``report/v1``, which states its coverage directly.
         """
         body: dict[str, Any] = {"repo": repo, "source": source}
         if isinstance(document, (bytes, bytearray)):

--- a/tests/unit/test_cli_cloudsec.py
+++ b/tests/unit/test_cli_cloudsec.py
@@ -1590,6 +1590,102 @@ class TestCloudSecCode:
             assert args[2] == b'{"version":"2.1.0","runs":[]}'
             assert kwargs["commit"] == "c0ffee"
 
+    def test_scanner_succeeded_records_the_evidence_that_lets_a_sarif_close(self, tmp_path):
+        """A SARIF closes findings it previously reported only if it proves its run
+        succeeded (SARIF's own invocations[].executionSuccessful). Trivy and Gitleaks
+        never write that field, so without this flag their pushes are additive forever
+        and the customer sees findings that never resolve."""
+        doc = tmp_path / "trivy.sarif"
+        doc.write_bytes(b'{"version":"2.1.0","runs":[{"tool":{"driver":{"name":"trivy"}}}]}')
+        with _patches()[0], _patches()[1], _patches()[2] as cs_cls:
+            result, inst = _invoke(
+                ["cloudsec", "code", "ingest", "--repo", "acme/api",
+                 "--source", "sarif", "-f", str(doc), "--scanner-succeeded"],
+                cs_cls, {"result": {}})
+            assert result.exit_code == 0, result.output
+            pushed = json.loads(inst.ingest_code_results.call_args[0][2])
+            assert pushed["runs"][0]["invocations"] == [{"executionSuccessful": True}]
+            # The rest of the document is untouched.
+            assert pushed["runs"][0]["tool"]["driver"]["name"] == "trivy"
+
+    def test_scanner_failed_records_the_failure_rather_than_omitting_it(self, tmp_path):
+        """The flag is not a way to say 'always true'. A job whose scan step failed
+        records THAT, which keeps the document additive instead of letting a broken
+        scan look like a clean one."""
+        doc = tmp_path / "trivy.sarif"
+        doc.write_bytes(b'{"version":"2.1.0","runs":[{"tool":{"driver":{"name":"trivy"}}}]}')
+        with _patches()[0], _patches()[1], _patches()[2] as cs_cls:
+            result, inst = _invoke(
+                ["cloudsec", "code", "ingest", "--repo", "acme/api",
+                 "--source", "sarif", "-f", str(doc), "--scanner-failed"],
+                cs_cls, {"result": {}})
+            assert result.exit_code == 0, result.output
+            pushed = json.loads(inst.ingest_code_results.call_args[0][2])
+            assert pushed["runs"][0]["invocations"] == [{"executionSuccessful": False}]
+
+    def test_a_tools_own_execution_claim_is_never_overwritten(self, tmp_path):
+        """The tool knows whether it ran; the caller only knows whether the command
+        exited 0. Overwriting a tool's executionSuccessful:false with true would
+        manufacture exactly the authority this rule exists to withhold."""
+        doc = tmp_path / "scan.sarif"
+        doc.write_bytes(b'{"version":"2.1.0","runs":[{"invocations":'
+                        b'[{"executionSuccessful":false}],"tool":{"driver":{"name":"x"}}}]}')
+        with _patches()[0], _patches()[1], _patches()[2] as cs_cls:
+            result, inst = _invoke(
+                ["cloudsec", "code", "ingest", "--repo", "acme/api",
+                 "--source", "sarif", "-f", str(doc), "--scanner-succeeded"],
+                cs_cls, {"result": {}})
+            assert result.exit_code == 0, result.output
+            pushed = json.loads(inst.ingest_code_results.call_args[0][2])
+            assert pushed["runs"][0]["invocations"] == [{"executionSuccessful": False}]
+            assert "already states its own execution result" in result.output
+
+    def test_a_gzipped_sarif_is_stamped_and_stays_gzipped(self, tmp_path):
+        """CI jobs gzip large SARIF files. Stamping must not silently hand the API a
+        document in a different encoding than the one it was given."""
+        import gzip as _gzip
+        doc = tmp_path / "trivy.sarif.gz"
+        doc.write_bytes(_gzip.compress(b'{"version":"2.1.0","runs":[{"tool":{}}]}'))
+        with _patches()[0], _patches()[1], _patches()[2] as cs_cls:
+            result, inst = _invoke(
+                ["cloudsec", "code", "ingest", "--repo", "acme/api",
+                 "--source", "sarif", "-f", str(doc), "--scanner-succeeded"],
+                cs_cls, {"result": {}})
+            assert result.exit_code == 0, result.output
+            sent = inst.ingest_code_results.call_args[0][2]
+            assert sent[:2] == b"\x1f\x8b", "the document must still be gzipped"
+            pushed = json.loads(_gzip.decompress(sent))
+            assert pushed["runs"][0]["invocations"] == [{"executionSuccessful": True}]
+
+    def test_the_flag_is_refused_for_sources_that_state_their_own_coverage(self, tmp_path):
+        """report/v1 states its coverage directly and CycloneDX makes no claim about a
+        scan having run, so silently accepting the flag there would imply it did
+        something."""
+        doc = tmp_path / "report.json"
+        doc.write_bytes(b'{"schema":"lc-code-report/v1"}')
+        with _patches()[0], _patches()[1], _patches()[2] as cs_cls:
+            result, inst = _invoke(
+                ["cloudsec", "code", "ingest", "--repo", "acme/api",
+                 "--source", "report", "-f", str(doc), "--scanner-succeeded"],
+                cs_cls, {"result": {}})
+            assert result.exit_code != 0
+            assert "--source sarif only" in result.output
+            inst.ingest_code_results.assert_not_called()
+
+    def test_without_the_flag_the_document_is_pushed_byte_for_byte(self, tmp_path):
+        """The control: the CLI must not start rewriting documents on its own. Stamping
+        happens only when the caller asks for it."""
+        raw = b'{"version":"2.1.0","runs":[{"tool":{"driver":{"name":"trivy"}}}]}'
+        doc = tmp_path / "trivy.sarif"
+        doc.write_bytes(raw)
+        with _patches()[0], _patches()[1], _patches()[2] as cs_cls:
+            result, inst = _invoke(
+                ["cloudsec", "code", "ingest", "--repo", "acme/api",
+                 "--source", "sarif", "-f", str(doc)],
+                cs_cls, {"result": {}})
+            assert result.exit_code == 0, result.output
+            assert inst.ingest_code_results.call_args[0][2] == raw
+
     def test_code_scan_refuses_to_do_nothing(self, tmp_path):
         """Without --ingest and without -o the report would be written into a
         temporary directory and deleted — a command that appears to succeed and

--- a/tests/unit/test_cli_cloudsec.py
+++ b/tests/unit/test_cli_cloudsec.py
@@ -1640,6 +1640,74 @@ class TestCloudSecCode:
             assert pushed["runs"][0]["invocations"] == [{"executionSuccessful": False}]
             assert "already states its own execution result" in result.output
 
+    def test_an_invocation_that_states_nothing_is_still_stamped(self, tmp_path):
+        """'invocations':[{}] is a run that has an invocation object and says NOTHING in
+        it. The server reads a missing executionSuccessful as unsuccessful, so such a
+        document closes nothing — declining to stamp it because the key is present would
+        refuse at exactly the moment stamping was needed, and tell the operator the flag
+        was unnecessary."""
+        doc = tmp_path / "scan.sarif"
+        doc.write_bytes(b'{"version":"2.1.0","runs":[{"invocations":[{}],"tool":{}}]}')
+        with _patches()[0], _patches()[1], _patches()[2] as cs_cls:
+            result, inst = _invoke(
+                ["cloudsec", "code", "ingest", "--repo", "acme/api",
+                 "--source", "sarif", "-f", str(doc), "--scanner-succeeded"],
+                cs_cls, {"result": {}})
+            assert result.exit_code == 0, result.output
+            pushed = json.loads(inst.ingest_code_results.call_args[0][2])
+            assert pushed["runs"][0]["invocations"] == [{"executionSuccessful": True}]
+
+    def test_a_document_with_no_runs_says_so_rather_than_claiming_the_tool_spoke(self, tmp_path):
+        """'every run already states its own result' is reassurance, and it is the wrong
+        reassurance for a document that has no runs at all."""
+        doc = tmp_path / "empty.sarif"
+        doc.write_bytes(b'{"version":"2.1.0","runs":[]}')
+        with _patches()[0], _patches()[1], _patches()[2] as cs_cls:
+            result, inst = _invoke(
+                ["cloudsec", "code", "ingest", "--repo", "acme/api",
+                 "--source", "sarif", "-f", str(doc), "--scanner-succeeded"],
+                cs_cls, {"result": {}})
+            assert result.exit_code == 0, result.output
+            assert "has no runs" in result.output
+            assert "already states" not in result.output
+
+    def test_non_ascii_text_is_not_escape_inflated(self, tmp_path):
+        """json.dumps defaults to ensure_ascii=True, which turns every non-ASCII character
+        into \\uXXXX and can nearly double a document whose messages are not Latin. The
+        size cap is applied to the STAMPED bytes, so that inflation could refuse a file
+        that is well under the limit on disk."""
+        doc = tmp_path / "cjk.sarif"
+        body = {"version": "2.1.0", "runs": [{"tool": {"driver": {"name": "trivy"}},
+                "results": [{"message": {"text": "\u5371\u967a\u306a\u4f9d\u5b58\u95a2\u4fc2" * 200}}]}]}
+        raw = json.dumps(body, ensure_ascii=False).encode("utf-8")
+        doc.write_bytes(raw)
+        with _patches()[0], _patches()[1], _patches()[2] as cs_cls:
+            result, inst = _invoke(
+                ["cloudsec", "code", "ingest", "--repo", "acme/api",
+                 "--source", "sarif", "-f", str(doc), "--scanner-succeeded"],
+                cs_cls, {"result": {}})
+            assert result.exit_code == 0, result.output
+            sent = inst.ingest_code_results.call_args[0][2]
+            # Compaction may shrink it; escape-inflation would grow it by ~2x.
+            assert len(sent) < len(raw) * 1.2, "the document was escape-inflated"
+            assert json.loads(sent)["runs"][0]["invocations"] == [{"executionSuccessful": True}]
+
+    def test_a_corrupt_gzip_names_the_file_and_the_problem(self, tmp_path):
+        """gzip raises BadGzipFile/EOFError, neither a ValueError, so without an explicit
+        guard the failure escapes to the CLI's catch-all and prints a bare zlib message
+        with no filename and no hint that the compression is the problem."""
+        doc = tmp_path / "truncated.sarif.gz"
+        import gzip as _gzip
+        doc.write_bytes(_gzip.compress(b'{"version":"2.1.0","runs":[]}')[:12])
+        with _patches()[0], _patches()[1], _patches()[2] as cs_cls:
+            result, inst = _invoke(
+                ["cloudsec", "code", "ingest", "--repo", "acme/api",
+                 "--source", "sarif", "-f", str(doc), "--scanner-succeeded"],
+                cs_cls, {"result": {}})
+            assert result.exit_code != 0
+            assert "not a readable gzip stream" in result.output
+            inst.ingest_code_results.assert_not_called()
+
     def test_a_gzipped_sarif_is_stamped_and_stays_gzipped(self, tmp_path):
         """CI jobs gzip large SARIF files. Stamping must not silently hand the API a
         document in a different encoding than the one it was given."""

--- a/tests/unit/test_cli_cloudsec.py
+++ b/tests/unit/test_cli_cloudsec.py
@@ -1708,6 +1708,59 @@ class TestCloudSecCode:
             assert "not a readable gzip stream" in result.output
             inst.ingest_code_results.assert_not_called()
 
+    def test_corruption_inside_the_deflate_stream_is_caught_too(self, tmp_path):
+        """Gzip corruption raises THREE exception types and none is a ValueError: EOFError
+        for a truncated stream, BadGzipFile (an OSError) for a bad header or CRC, and
+        zlib.error — which subclasses neither — for corruption inside the deflate stream.
+        A guard that catches only the first two is blind to the shape it was written for."""
+        import gzip as _gzip
+        body = json.dumps({"version": "2.1.0",
+                           "runs": [{"tool": {"driver": {"name": "t"}}}] * 500}).encode()
+        blob = bytearray(_gzip.compress(body))
+        for i in range(30, 60):
+            blob[i] ^= 0xFF
+        doc = tmp_path / "corrupt.sarif.gz"
+        doc.write_bytes(bytes(blob))
+        with _patches()[0], _patches()[1], _patches()[2] as cs_cls:
+            result, inst = _invoke(
+                ["cloudsec", "code", "ingest", "--repo", "acme/api",
+                 "--source", "sarif", "-f", str(doc), "--scanner-succeeded"],
+                cs_cls, {"result": {}})
+            assert result.exit_code != 0
+            assert "not a readable gzip stream" in result.output
+            inst.ingest_code_results.assert_not_called()
+
+    def test_a_number_json_cannot_represent_is_refused_not_emitted_as_Infinity(self, tmp_path):
+        """Python parses 1e400 as inf and writes it back as the bare token `Infinity`,
+        which is not valid JSON and which the Go server rejects outright. Re-serializing is
+        the ONLY way that can happen — without the flag the original bytes go through
+        untouched — so this must refuse rather than turn a readable document into an
+        unreadable one."""
+        doc = tmp_path / "huge.sarif"
+        doc.write_bytes(b'{"version":"2.1.0","runs":[{"tool":{},"properties":{"n":1e400}}]}')
+        with _patches()[0], _patches()[1], _patches()[2] as cs_cls:
+            result, inst = _invoke(
+                ["cloudsec", "code", "ingest", "--repo", "acme/api",
+                 "--source", "sarif", "-f", str(doc), "--scanner-succeeded"],
+                cs_cls, {"result": {}})
+            assert result.exit_code != 0
+            assert "cannot represent" in result.output
+            inst.ingest_code_results.assert_not_called()
+
+    def test_the_same_document_is_pushed_untouched_without_the_flag(self, tmp_path):
+        """The control for both refusals above: neither shape is a problem the CLI creates
+        for a caller who did not ask it to rewrite the document."""
+        raw = b'{"version":"2.1.0","runs":[{"tool":{},"properties":{"n":1e400}}]}'
+        doc = tmp_path / "huge.sarif"
+        doc.write_bytes(raw)
+        with _patches()[0], _patches()[1], _patches()[2] as cs_cls:
+            result, inst = _invoke(
+                ["cloudsec", "code", "ingest", "--repo", "acme/api",
+                 "--source", "sarif", "-f", str(doc)],
+                cs_cls, {"result": {}})
+            assert result.exit_code == 0, result.output
+            assert inst.ingest_code_results.call_args[0][2] == raw
+
     def test_a_gzipped_sarif_is_stamped_and_stays_gzipped(self, tmp_path):
         """CI jobs gzip large SARIF files. Stamping must not silently hand the API a
         document in a different encoding than the one it was given."""


### PR DESCRIPTION
## The gap this closes

`go-cloudsec` v1.71.0 (merged today, from the AppSec code-lane pre-production review) moved a pushed SARIF's **closure authority** off the tool's rule *catalogue* and onto SARIF's own `run.invocations[].executionSuccessful`. That rule is correct: a scan step with a broken `--config` still emits the tool's full rule catalogue and zero results, and reading that as "the repository is clean now" resolves somebody's real vulnerabilities.

But it leaves a gap, and this repo is the natural place to close it.

**Trivy and Gitleaks do not write `invocations` at all.** A document straight from either is therefore *additive forever*: its findings land, nothing ever closes, and the customer's only symptom is a repository whose findings pile up with no explanation. This command's own documented example was `--source sarif -f trivy.sarif` — which, as of that release, can never close anything.

The missing fact is one the CI job **has** and nobody else does: whether the scan step exited 0.

## What this adds

`limacharlie cloudsec code ingest --scanner-succeeded / --scanner-failed` records that assertion in the document before pushing it. It is the *caller's* claim, attributable to the key that pushed it — not authority we inferred from a catalogue.

```
limacharlie cloudsec code ingest --repo acme/api --source sarif -f trivy.sarif --scanner-succeeded
```

Three properties worth preserving when this is next touched:

- **A run that already carries `invocations` is left alone, in either direction.** The tool's claim about its own execution outranks the caller's, and overwriting an `executionSuccessful: false` with `true` would manufacture exactly the authority the rule exists to withhold. The CLI says so on stderr rather than silently changing nothing.
- **`--scanner-failed` is a real value, not a no-op.** The flag is not a way to spell "always true".
- **A gzipped document goes back gzipped.** CI jobs compress large SARIF files, and handing the API a different encoding than it was given is its own bug.

Refused for `--source report` (which states its coverage directly) and `--source cyclonedx` (which makes no claim about a scan having run) — silently accepting it there would imply it did something.

Also updates the CLI docstring and the `ingest_code_results` SDK docstring, both of which now explain why a SARIF might close nothing and what `sarif_no_invocation_evidence` in `notes` means. That diagnosis was previously unavailable to anyone who hit it.

## Tests

Six new tests in `tests/unit/test_cli_cloudsec.py`:

| Test | Pins |
|---|---|
| `test_scanner_succeeded_records_the_evidence_that_lets_a_sarif_close` | the stamp lands, rest of the document untouched |
| `test_scanner_failed_records_the_failure_rather_than_omitting_it` | the flag is not "always true" |
| `test_a_tools_own_execution_claim_is_never_overwritten` | `executionSuccessful:false` survives `--scanner-succeeded`, and the CLI says so |
| `test_a_gzipped_sarif_is_stamped_and_stays_gzipped` | encoding round-trip |
| `test_the_flag_is_refused_for_sources_that_state_their_own_coverage` | non-SARIF refusal, nothing pushed |
| `test_without_the_flag_the_document_is_pushed_byte_for_byte` | the control — the CLI does not rewrite documents on its own |

**Evidence:** `pytest tests/unit/` → **4051 passed, 6 skipped, 0 failures**. (`tests/microbenchmarks/` needs `pytest-benchmark`, which is not installed on this machine; CI runs it.)

No new command, so `_COMMAND_MODULE_MAP`, `PROFILES` and `doc/cli/` need no change — this is an option on an existing verb.