### PR TITLE
feat(mailsec): --attempt on campaign action, and CLI help that stops denying --reason

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@
 
 ### Email Security
 
+- **Campaign sweeps take an `attempt`**: `limacharlie mailsec campaign action
+  --attempt <token>` / `Mailsec.act_on_campaign(attempt=...)` ask for a
+  DELIBERATE second run. A sweep is idempotent per member — the per-member
+  audit key is the campaign itself, so a double click or a retried request
+  collapses onto the row each member already has — which meant a re-run after a
+  provider outage overwrote the rows recording what failed. A new `attempt`
+  composes with the campaign, minting a new action id per member and a new
+  sweep record, so the retry is recorded *beside* the failure; repeating the
+  same value collapses again. It is an opaque handle, bounded server-side at
+  128 characters and refused rather than truncated, and it is not part of the
+  confirmation token, so adding one after previewing does not invalidate it.
+- `mailsec message bulk-action --ai-help` no longer ends with a stale paragraph
+  claiming there is no `--reason`. The flag exists, and the justification it
+  carries is recorded on the job's audit row and on every message's.
 - **Tenant purge**: `limacharlie mailsec tenant purge` /
   `Mailsec.prepare_tenant_purge()` and `Mailsec.purge_tenant()` permanently
   delete everything Email Security holds for an organization — the message

--- a/doc/cli/email-security.md
+++ b/doc/cli/email-security.md
@@ -79,9 +79,11 @@ Bulk remediation is two-step: without `--confirm` it previews, and the preview's
 
 ```bash
 limacharlie mailsec message bulk-action --action quarantine_message --input-file ids.json
-limacharlie mailsec message bulk-action --action quarantine_message --input-file ids.json --confirm <TOKEN>
+limacharlie mailsec message bulk-action --action quarantine_message --input-file ids.json --confirm <TOKEN> --reason "INC-4471"
 limacharlie mailsec message bulk-status <BULK_ID>
 ```
+
+`--reason` belongs to the execute and is recorded on the job's audit row *and* on every message's. It is deliberately not part of the confirmation token, so rewording it between previewing and executing neither invalidates a token you hold nor starts a second job over the same messages.
 
 ## Campaigns, senders & the audit trail
 
@@ -89,10 +91,13 @@ limacharlie mailsec message bulk-status <BULK_ID>
 limacharlie mailsec campaign list --state active --min-members 5
 limacharlie mailsec campaign get <CAMPAIGN_ID>
 limacharlie mailsec campaign action <CAMPAIGN_ID> --action quarantine_message              # preview
-limacharlie mailsec campaign action <CAMPAIGN_ID> --action quarantine_message --confirm <TOKEN>
+limacharlie mailsec campaign action <CAMPAIGN_ID> --action quarantine_message --confirm <TOKEN> --reason "confirmed credential harvest"
+limacharlie mailsec campaign action <CAMPAIGN_ID> --action quarantine_message --confirm <TOKEN> --attempt after-the-outage
 limacharlie mailsec sender get sender@corp.example
 limacharlie mailsec action get <ACTION_ID>
 ```
+
+A sweep's `--reason` lands on the sweep's own record and on every member's audit row. Repeating a sweep is idempotent per member, so a double run collapses onto the rows it already wrote; `--attempt` is how you ask for a deliberate second run — a retry after a provider outage recorded *beside* what failed rather than over it. It is an opaque handle, at most 128 characters, refused rather than truncated. Neither field is part of the confirmation token, so adding either one after previewing does not invalidate it.
 
 ## Reports, analysis, hunts & rules
 

--- a/limacharlie/commands/mailsec.py
+++ b/limacharlie/commands/mailsec.py
@@ -237,18 +237,13 @@ action row rather than being acted on twice.
 exit code above and `mailsec message bulk-status <bulk_id>` are how you
 read the result.
 
-There is no --reason: the execute route does not carry one, and a
-justification that never reaches the audit trail would be worse than an
-absent one. Use `mailsec message action --reason` per message when the
-reason matters.
-
 Examples:
   limacharlie mailsec message bulk-action --action trash_message --msg-uuids 0057db2b-3a06-5aab-b3be-c1e6c15dcf10
   limacharlie mailsec message bulk-action --action quarantine_message --input-file uuids.txt
   limacharlie mailsec message list --verdict malicious --output json \\
     | jq -r '.messages[].msg_uuid' \\
     | limacharlie mailsec message bulk-action --action quarantine_message --input-file -
-  limacharlie mailsec message bulk-action --action quarantine_message --msg-uuids 0057db2b-... --confirm 3f31ed...
+  limacharlie mailsec message bulk-action --action quarantine_message --msg-uuids 0057db2b-... --confirm 3f31ed... --reason "INC-4471"
 """
 
 _EXPLAIN_MESSAGE_BULK_STATUS = """\
@@ -296,9 +291,38 @@ PREVIEWS BY DEFAULT. Copy the preview's member-bound `confirm` token into
 --confirm to execute exactly the reviewed member set. A campaign id is not
 a confirmation token and is refused by the server.
 
+--reason is your justification for moving mail in every mailbox the
+campaign reached. It is recorded on the sweep's own record AND stamped
+onto every member's audit row, so an analyst reading one message's
+timeline sees why it was acted on without having to discover that the row
+belongs to a sweep. Bounded at 1024 characters, refused rather than
+truncated — on the PREVIEW as well as the execute, so an over-long one is
+reported before the confirmation is minted rather than after.
+
+--attempt asks for a SECOND, SEPARATELY RECORDED run. Re-running a sweep
+is idempotent by default: the per-member key is the campaign itself, so a
+double click — or a retry of a request whose response was lost — collapses
+onto the audit row each member already has instead of claiming a move that
+happened once as two. A new --attempt composes with the campaign, which
+mints a new action id per member and a new sweep record, so a re-run after
+a provider outage is recorded BESIDE the run that failed instead of over
+it. Repeating the SAME value collapses again, which is what makes a lost
+response safe to re-send.
+
+It is an opaque handle you mint, not prose: bounded at 128 characters —
+much shorter than the reason, because it is written verbatim onto every
+member's row — and refused rather than truncated, since a clipped
+idempotency key is a DIFFERENT key that would act again instead of
+collapsing.
+
+Neither field is part of the confirmation token, which is derived from the
+member set alone: adding a reason or an attempt between previewing and
+executing does not invalidate a token you already hold.
+
 Examples:
   limacharlie mailsec campaign action ec7e273b-... --action quarantine_message
-  limacharlie mailsec campaign action ec7e273b-... --action quarantine_message --confirm 3c514e...
+  limacharlie mailsec campaign action ec7e273b-... --action quarantine_message --confirm 3c514e... --reason "confirmed credential harvest"
+  limacharlie mailsec campaign action ec7e273b-... --action quarantine_message --confirm 3c514e... --attempt after-the-outage
 """
 
 _EXPLAIN_SENDER_GET = """\
@@ -1332,20 +1356,33 @@ def campaign_get(ctx, campaign_id) -> None:
 @click.option("--action", "action_name", required=True, help="The typed action to sweep.")
 @click.option("--confirm", default=None,
               help="Pass the member-bound token returned by the preview to EXECUTE. Omit to preview.")
-@click.option("--reason", default=None, help="Recorded on every resulting audit row.")
+@click.option("--reason", default=None,
+              help="Why you are sweeping. Recorded on the sweep's own record and stamped onto "
+                   "every member's audit row. Not part of the confirmation, so adding it does "
+                   "not invalidate a token the preview already minted.")
+@click.option("--attempt", default=None,
+              help="Ask for a SECOND, separately recorded run. A sweep is idempotent per member "
+                   "by default, so a repeat collapses onto the rows it already wrote; a new "
+                   "attempt records the re-run beside what failed instead of over it. An opaque "
+                   "handle, not prose: at most 128 characters, refused rather than truncated.")
 @pass_context
-def campaign_action(ctx, campaign_id, action_name, confirm, reason) -> None:
+def campaign_action(ctx, campaign_id, action_name, confirm, reason, attempt) -> None:
     """Sweep an action across a whole campaign (mailsec.act).
 
     \b
-    Previews unless --confirm is given.
+    Previews unless --confirm is given. Repeating a sweep is idempotent
+    per member; --attempt is how you ask for a deliberate second run that
+    is recorded beside the first rather than over it.
 
     \b
     Example:
       limacharlie mailsec campaign action ec7e273b-... --action quarantine_message --confirm 3c514e...
+      limacharlie mailsec campaign action ec7e273b-... --action quarantine_message --confirm 3c514e... --attempt after-the-outage
     """
     ms = _get_mailsec(ctx)
-    _output(ctx, ms.act_on_campaign(campaign_id, action_name, confirm=confirm, reason=reason))
+    _output(ctx, ms.act_on_campaign(
+        campaign_id, action_name, confirm=confirm, reason=reason, attempt=attempt,
+    ))
 
 
 # ---------------------------------------------------------------------------

--- a/limacharlie/commands/mailsec.py
+++ b/limacharlie/commands/mailsec.py
@@ -313,8 +313,9 @@ It is an opaque handle you mint, not prose: bounded at 128 characters —
 much shorter than the reason, because it is written verbatim onto every
 member's row — and refused rather than truncated, since a clipped
 idempotency key is a DIFFERENT key that would act again instead of
-collapsing. Checked on the preview leg too, for the reason the reason's
-bound is.
+collapsing. Like the justification's bound, it is checked on the preview
+leg as well, so an over-long token is reported before the dialog asks you
+to confirm rather than after.
 
 Neither field is part of the confirmation token, which is derived from the
 member set alone: adding a reason or an attempt between previewing and

--- a/limacharlie/commands/mailsec.py
+++ b/limacharlie/commands/mailsec.py
@@ -313,7 +313,8 @@ It is an opaque handle you mint, not prose: bounded at 128 characters —
 much shorter than the reason, because it is written verbatim onto every
 member's row — and refused rather than truncated, since a clipped
 idempotency key is a DIFFERENT key that would act again instead of
-collapsing.
+collapsing. Checked on the preview leg too, for the reason the reason's
+bound is.
 
 Neither field is part of the confirmation token, which is derived from the
 member set alone: adding a reason or an attempt between previewing and

--- a/limacharlie/sdk/mailsec.py
+++ b/limacharlie/sdk/mailsec.py
@@ -826,6 +826,7 @@ class Mailsec:
         *,
         confirm: str | None = None,
         reason: str | None = None,
+        attempt: str | None = None,
         actor: str | None = None,
     ) -> dict[str, Any]:
         """Sweep an action across every member of a campaign.
@@ -837,18 +838,44 @@ class Mailsec:
         default for an operation whose blast radius is "every mailbox that got
         this attack".
 
+        Re-running a sweep is idempotent per member: the default per-member
+        attempt key is the campaign itself, so a double-click — or a retry of a
+        request whose response was lost — collapses onto the audit row each
+        member already has rather than claiming a second move. ``attempt`` is
+        the escape hatch when the second run is a DELIBERATE one.
+
         Args:
             campaign_id: The campaign to sweep.
             action: The typed action, as for :meth:`act_on_message`.
             confirm: Pass the member-bound token returned by the preview to
                 execute. Omit to preview.
-            reason: Recorded on every resulting audit row.
+            reason: The operator's justification. Recorded on the sweep's own
+                record and stamped onto every member's audit row, so an analyst
+                reading one message's timeline sees why it was acted on without
+                having to find the sweep. Bounded server-side at 1024
+                characters and refused rather than truncated.
+            attempt: An opaque idempotency handle the caller mints. Omit for the
+                normal case. A NEW value composes with the campaign to make a
+                new action id for every member and a new sweep record, so a
+                re-run after a provider outage is recorded BESIDE what failed
+                instead of over it; the same value twice collapses onto the same
+                rows. Bounded server-side at 128 characters — shorter than the
+                reason because it is written verbatim onto every member's row —
+                and refused rather than truncated, since a clipped idempotency
+                key is a different key.
             actor: Ignored if supplied — the gateway stamps the acting
                 identity from the authenticated claims, so an audit trail's
                 subject can never be chosen by its subject.
+
+        Note:
+            Neither ``reason`` nor ``attempt`` is part of the confirmation
+            token, which is derived from the member set alone. Adding either one
+            between previewing and executing therefore does not invalidate a
+            token you already hold.
         """
         body: dict[str, Any] = {"action": action}
-        for key, val in (("confirm", confirm), ("reason", reason), ("actor", actor)):
+        for key, val in (("confirm", confirm), ("reason", reason),
+                         ("attempt", attempt), ("actor", actor)):
             if val is not None:
                 body[key] = val
         return self._post(f"campaigns/{_seg(campaign_id)}/actions", body)

--- a/limacharlie/sdk/mailsec.py
+++ b/limacharlie/sdk/mailsec.py
@@ -686,13 +686,14 @@ class Mailsec:
             not a failure.
 
         Note:
-            ``reason`` requires a backend that reads it. Older deployments
-            forwarded only ``action``, ``msg_uuids``, ``confirm`` and ``attempt``
-            on this route and dropped a reason in transit; against
-            those, a justification sent here never reaches the audit trail. It is
-            an ordinary optional argument rather than a version probe, because a
-            client cannot tell the two apart from the response — the execute
-            answers 200 either way.
+            ``reason`` requires a backend that reads it. Deployments older than
+            the fix forwarded only ``action``, ``msg_uuids``, ``confirm`` and
+            ``attempt`` on this route and dropped a reason in transit; against
+            those, a justification sent here never reaches the audit trail.
+            Current deployments forward and record it. It is an ordinary
+            optional argument rather than a version probe, because a client
+            cannot tell the two apart from the response — the execute answers
+            200 either way.
         """
         body: dict[str, Any] = {
             "action": action,
@@ -862,7 +863,9 @@ class Mailsec:
                 rows. Bounded server-side at 128 characters — shorter than the
                 reason because it is written verbatim onto every member's row —
                 and refused rather than truncated, since a clipped idempotency
-                key is a different key.
+                key is a different key. Validated on the preview leg as well as
+                the execute, and surrounding whitespace is trimmed before the
+                bound is applied.
             actor: Ignored if supplied — the gateway stamps the acting
                 identity from the authenticated claims, so an audit trail's
                 subject can never be chosen by its subject.

--- a/tests/unit/test_cli_mailsec.py
+++ b/tests/unit/test_cli_mailsec.py
@@ -1,8 +1,7 @@
 """Tests for the mailsec CLI's public lifecycle probe."""
 
-from unittest.mock import MagicMock, patch
-
 import re
+from unittest.mock import MagicMock, patch
 
 import click
 from click.testing import CliRunner

--- a/tests/unit/test_cli_mailsec.py
+++ b/tests/unit/test_cli_mailsec.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import MagicMock, patch
 
+import click
 from click.testing import CliRunner
 
 from limacharlie.cli import cli
@@ -75,4 +76,83 @@ def test_campaign_action_forwards_the_preview_token_unchanged():
         "quarantine_message",
         confirm="member-bound-token",
         reason="reviewed current set",
+        attempt=None,
     )
+
+
+def test_campaign_action_forwards_a_deliberate_second_run():
+    """--attempt is the only way to ask for a sweep that is recorded BESIDE the
+    one it retries. A sweep is idempotent per member by default — the per-member
+    key is the campaign itself — so without the flag reaching the SDK an operator
+    re-running after a provider outage silently overwrites the rows recording
+    what failed, which is the evidence they were retrying because of."""
+    result, mailsec = invoke_campaign_action(
+        "--action", "quarantine_message",
+        "--confirm", "member-bound-token",
+        "--reason", "re-running after the provider outage",
+        "--attempt", "after-the-outage",
+    )
+    assert result.exit_code == 0, result.output
+    mailsec.act_on_campaign.assert_called_once_with(
+        "campaign-1",
+        "quarantine_message",
+        confirm="member-bound-token",
+        reason="re-running after the provider outage",
+        attempt="after-the-outage",
+    )
+
+
+def test_campaign_action_sends_no_attempt_when_none_is_asked_for():
+    """The control for the test above, and the important half of the contract:
+    omitting the flag must reach the server as an ABSENCE. An empty string is a
+    non-empty attempt token as far as nothing, but a defaulted one — say the
+    campaign id — would change every member's action id on every sweep and turn
+    the ordinary double click back into two rows claiming two moves."""
+    result, mailsec = invoke_campaign_action(
+        "--action", "quarantine_message",
+        "--confirm", "member-bound-token",
+    )
+    assert result.exit_code == 0, result.output
+    _, kwargs = mailsec.act_on_campaign.call_args
+    assert kwargs["attempt"] is None
+
+
+def test_no_mailsec_ai_help_denies_a_flag_the_command_really_has():
+    """The defect this pins is help that CONTRADICTS the command it documents.
+
+    `message bulk-action` grew a --reason, and its --ai-help went on telling
+    operators "There is no --reason ... use `message action --reason` per
+    message when the reason matters" — advice that costs a 500-message
+    quarantine its justification, from the one surface an operator is most
+    likely to read before acting at that scale. The check is over the whole
+    mailsec surface rather than that one string, because the failure mode is
+    generic: prose that outlives the code it describes.
+    """
+    from limacharlie.commands import mailsec as mailsec_cmd
+    from limacharlie.discovery import get_explain
+
+    def walk(cmd, path, checked):
+        if isinstance(cmd, click.Group):
+            for name, sub in cmd.commands.items():
+                walk(sub, path + [name], checked)
+            return
+        explain = get_explain(".".join(path))
+        if not explain:
+            return
+        checked.append(" ".join(path))
+        for param in cmd.params:
+            for opt in getattr(param, "opts", []):
+                if not opt.startswith("--"):
+                    continue
+                denial = "There is no %s" % opt
+                assert denial.lower() not in explain.lower(), (
+                    f"`{' '.join(path)}` accepts {opt} but its --ai-help says "
+                    f"{denial!r}"
+                )
+
+    checked: list[str] = []
+    walk(mailsec_cmd.group, ["mailsec"], checked)
+    # The walk is only worth anything if it actually reached the explain texts:
+    # an empty registry would pass every assertion above by never running one.
+    assert "mailsec message bulk-action" in checked
+    assert "mailsec campaign action" in checked

--- a/tests/unit/test_cli_mailsec.py
+++ b/tests/unit/test_cli_mailsec.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import MagicMock, patch
 
+import re
+
 import click
 from click.testing import CliRunner
 
@@ -103,11 +105,18 @@ def test_campaign_action_forwards_a_deliberate_second_run():
 
 
 def test_campaign_action_sends_no_attempt_when_none_is_asked_for():
-    """The control for the test above, and the important half of the contract:
-    omitting the flag must reach the server as an ABSENCE. An empty string is a
-    non-empty attempt token as far as nothing, but a defaulted one — say the
-    campaign id — would change every member's action id on every sweep and turn
-    the ordinary double click back into two rows claiming two moves."""
+    """The control for the test above: omitting the flag must reach the SDK as
+    None rather than as a value the CLI chose.
+
+    A default would be stable — the backend composes the campaign with whatever
+    it is given, so a double click would still collapse — but it would change
+    the identity of every per-member row from the campaign id alone to
+    `<campaign>#<default>`, so it would disagree with every row every sweep has
+    already written. That is why the backend keys an empty attempt on the bare
+    campaign id, and why the CLI must not supply one.
+
+    `test_campaign_action_sends_no_attempt_by_default` in the SDK tests is what
+    pins the resulting absence ON THE WIRE; this one only pins the hand-off."""
     result, mailsec = invoke_campaign_action(
         "--action", "quarantine_message",
         "--confirm", "member-bound-token",
@@ -131,11 +140,20 @@ def test_no_mailsec_ai_help_denies_a_flag_the_command_really_has():
     from limacharlie.commands import mailsec as mailsec_cmd
     from limacharlie.discovery import get_explain
 
-    def walk(cmd, path, checked):
-        if isinstance(cmd, click.Group):
-            for name, sub in cmd.commands.items():
-                walk(sub, path + [name], checked)
-            return
+    # The phrasings a stale paragraph reaches for. Matched against the flag on
+    # the same line, so "there is no --reason" fails and prose that merely
+    # mentions the words does not.
+    _BEFORE = (r"(?:there is no|there's no|there are no|has no|have no|"
+               r"(?:does|do) not (?:take|accept|carry|support|have))")
+    _AFTER = (r"(?:is|are) not (?:supported|accepted|carried|available|a thing)"
+              r"|(?:does|do) not exist|is ignored")
+    # A stale paragraph denies a flag in one of two word orders: the denial
+    # before the flag ("there is no --reason") or after it ("--reason is not
+    # supported"). Both are matched on ONE line, so ordinary prose that happens
+    # to contain the words several sentences apart is not a false positive.
+    denials = r"%%s[^\n]{0,60}(?:%s)|%s[^\n]{0,60}%%s" % (_AFTER, _BEFORE)
+
+    def check(cmd, path, checked):
         explain = get_explain(".".join(path))
         if not explain:
             return
@@ -144,11 +162,21 @@ def test_no_mailsec_ai_help_denies_a_flag_the_command_really_has():
             for opt in getattr(param, "opts", []):
                 if not opt.startswith("--"):
                     continue
-                denial = "There is no %s" % opt
-                assert denial.lower() not in explain.lower(), (
+                m = re.search(denials % (re.escape(opt), re.escape(opt)),
+                              explain, re.IGNORECASE)
+                assert m is None, (
                     f"`{' '.join(path)}` accepts {opt} but its --ai-help says "
-                    f"{denial!r}"
+                    f"{m.group(0)!r}"
                 )
+
+    def walk(cmd, path, checked):
+        # A GROUP'S OWN explain text is checked too, before recursing: nothing
+        # registers one today, but a group that grew one would otherwise drop
+        # out of coverage silently, which is this test's whole failure mode.
+        check(cmd, path, checked)
+        if isinstance(cmd, click.Group):
+            for name, sub in cmd.commands.items():
+                walk(sub, path + [name], checked)
 
     checked: list[str] = []
     walk(mailsec_cmd.group, ["mailsec"], checked)

--- a/tests/unit/test_sdk_mailsec.py
+++ b/tests/unit/test_sdk_mailsec.py
@@ -176,6 +176,31 @@ class TestActions:
         _, body = _post_call(mock_org)
         assert body["confirm"] == "member-bound-token"
 
+    def test_campaign_action_carries_a_deliberate_second_run(self, ms, mock_org):
+        """A sweep composes the operator's attempt with the campaign to key
+        every member's audit row, so a NEW attempt records a retry beside the
+        run that failed instead of over it. The field has to reach the wire for
+        that to be reachable at all: the route reads it off the body, and a
+        client that never sends it can only ever overwrite."""
+        ms.act_on_campaign(
+            "cmp-1", "quarantine_message",
+            confirm="member-bound-token",
+            reason="re-running after the provider outage",
+            attempt="after-the-outage",
+        )
+        _, body = _post_call(mock_org)
+        assert body["attempt"] == "after-the-outage"
+        assert body["reason"] == "re-running after the provider outage"
+
+    def test_campaign_action_sends_no_attempt_by_default(self, ms, mock_org):
+        """The control, and the ordinary case. Absence means "keep the
+        campaign's own key", which is what makes a double click — or a retry of
+        a request whose response was lost — one audit row per member rather than
+        two claiming two moves that only happened once."""
+        ms.act_on_campaign("cmp-1", "quarantine_message", confirm="member-bound-token")
+        _, body = _post_call(mock_org)
+        assert "attempt" not in body
+
 
 class TestConnectionDiagnostics:
     def test_watch_probe_is_absent_by_default(self, ms, mock_org):


### PR DESCRIPTION
## Why

Two pieces of the Email Security CLI surface disagreed with the product they document.

**1. `message bulk-action --ai-help` denied a flag it accepts.** The text ended with:

> There is no `--reason`: the execute route does not carry one […] Use `mailsec message action --reason` per message when the reason matters.

The flag has been registered the whole time, the gateway forwards it, the backend records it on the job's audit row *and* on every message's, and an earlier paragraph in the same help text describes it correctly. Followed, the stale advice costs a 500-message quarantine its justification — from the surface an operator (or an agent) is most likely to read before acting at that scale, and while the same action from the console records one. The paragraph is deleted; the accurate one stays.

**2. `campaign action` had no `--attempt`, and `Mailsec.act_on_campaign()` had no kwarg for it,** although the route reads the field off the body. A sweep is idempotent per member because the per-member audit key is the campaign itself — which is exactly what makes a double click, or a retry of a request whose response was lost, one row per member instead of two claiming two moves. The consequence without an escape hatch: a deliberate re-run after a provider outage **overwrote the rows recording what failed**, which is the evidence the retry existed because of. A non-empty `attempt` composes with the campaign, minting a new action id per member and a new sweep record, so the retry lands *beside* the failure; the same value twice collapses again.

## What changed

- `limacharlie mailsec campaign action --attempt <token>`, forwarded to `act_on_campaign(attempt=…)` and onto the request body. Omitting it reaches the server as an **absence**, not a defaulted value — a default would change every member's action id on every sweep and turn the ordinary double click back into two rows.
- `act_on_campaign()` gained the `attempt` kwarg with the semantics and the bounds documented.
- The stale bulk-action paragraph is gone; `_EXPLAIN_CAMPAIGN_ACTION` now covers both `--reason` and `--attempt`.
- `doc/cli/email-security.md` and `CHANGELOG.md` updated.

## Design notes

- **Bounds are documented, not re-implemented.** The server refuses (never truncates) a reason over 1024 characters and an attempt over 128, on the preview leg as well as the execute. Validating client-side would give the CLI its own copy of a number that can drift, and a clipped idempotency key is a *different* key, so truncation is wrong in principle anyway. The help text names both numbers; the refusal stays where the contract is.
- **Neither field is part of the confirmation token**, which is derived from the member set alone. That is what lets an operator add or reword a justification between previewing and executing without being told their selection changed.
- No `PROFILES` change: both commands were already profiled, and this adds flags rather than verbs.
- **`hunt remediate` is deliberately left alone.** Its route advertises and forwards an `attempt` too, and it is now the only action verb without one. But its backend is still pending, so there is nothing to observe the flag against — and shipping a flag whose effect cannot be checked is exactly how the stale paragraph this PR deletes came to be written. It has its own Backlog ticket, together with a separate pre-existing wart in that command's help (it tells the operator to pass the hunt id as the confirmation, where the campaign sweep it claims to mirror refuses the id).
- **Bounds are described in the vocabulary the server's own refusal uses** ("128 characters"). The validators apply `len()` to a Go string, so they are bytes, and a 128-character token with non-ASCII is refused — but the error an operator reads says "characters", and an attempt token is a handle a client mints, so the case is close to hypothetical. Making the docs disagree with the error message seemed the worse trade; the SDK docstring notes the trimming instead.

## Verified

- `pytest tests/unit/ tests/microbenchmarks/` (the way CI runs it): 4127 passed, 19 skipped.
- Every new test **fails on pre-fix code** (checked by stashing only the two source files): 5 failures, including the help-consistency lint.
- **Live, against the acceptance org**, driven entirely through this branch's CLI. Three marker messages sent to a test mailbox clustered into a campaign of their own (three members, one mailbox, no other tenant data involved); an automation had already quarantined all three, so every sweep below was a provider no-op (`skipped: 3`) and no mailbox moved. The markers were deleted afterwards.

  | Check | Result |
  |---|---|
  | must-fail: `--attempt` of 129 characters | `400 … the attempt token is too long: it is 129 characters and the limit is 128` — the flag reaches the backend and is validated there |
  | must-pass: `--attempt` of 128 characters | accepted |
  | control: no `--attempt` | accepted, and the `confirm` token is **byte-identical** to the 128-character run's — the attempt is not part of the confirmation, as claimed |
  | execute with `--attempt A` | `action_id 954507b5…`; `mailsec action get` shows `request.attempt: "…run-A"` and the reason on the sweep's own row |
  | re-run with the **same** attempt | `action_id 954507b5…` — collapsed onto the row it already wrote |
  | run with a **different** attempt | `action_id 4e2bdaad…` — a new row, recorded beside the first |
  | control: run with **no** attempt | `action_id a9f1db69…` — a third, distinct row on the campaign's own key |

  The campaign's action strip then listed all three rows, and the per-message audit rows showed the composed key the design specifies: `<campaign>` with no attempt, `<campaign>#run-A` / `<campaign>#run-B` with one, each carrying its own reason.

  `--reason` on `message bulk-action` was not re-executed live: the flag and its pass-through already shipped and are covered by an existing test — the defect there was only the help text denying it.

## Tests

- CLI: `--attempt` reaches the SDK call; and the control — omitting it sends `attempt=None`.
- SDK: the field reaches the request body, and is **absent** from it when no attempt is asked for.
- A generic lint over the whole mailsec command tree: no command's `--ai-help` may deny a flag the command really accepts. That is the class of defect here — prose outliving the code it describes — rather than the one string, and it has its own control so an empty explain registry cannot pass it vacuously.

Note: the ai-sessions/MCP runtime picks this up only after the next PyPI release, which is tracked separately.
