### PR TITLE
cloudsec: npm's lockfile IS regenerated by AutoFix, in both docstrings

### DIFF
--- a/limacharlie/commands/cloudsec.py
+++ b/limacharlie/commands/cloudsec.py
@@ -1667,10 +1667,17 @@ def code_autofix(ctx, finding_id, repo, provider) -> None:
     package that already has an AutoFix pull request open; and a connection
     at its daily AutoFix limit.
 
-    For npm and go the LOCKFILE IS NOT REGENERATED — the scanning sandbox
-    has no package-registry access by design — and the pull request says so
-    prominently and names the command to run. pip (requirements.txt) and
-    maven have no lockfile, so those changes are complete.
+    Lockfiles: for npm the package-lock.json IS rewritten by default. One
+    read-only registry metadata document supplies the new version's resolved
+    URL and integrity digest; it is left stale only where the code_scanning
+    policy sets 'autofix_registry_access: false', where the lock is a
+    yarn.lock or pnpm-lock.yaml, or where the entry could not be rewritten
+    safely. For go the go.sum is NOT regenerated — it hashes a module zip
+    nobody downloaded — and only matters where the tree has one. pip
+    (requirements.txt) and maven have no lockfile, so those changes are
+    complete. Wherever a lock is left stale the pull request says so
+    prominently and names the command to run; trust the pull request over
+    this summary.
 
     \b
     Examples:

--- a/limacharlie/sdk/cloudsec.py
+++ b/limacharlie/sdk/cloudsec.py
@@ -1447,11 +1447,19 @@ class CloudSec:
             free-tier quota; a package that already has an AutoFix pull
             request open; and a connection at its daily AutoFix limit.
 
-            For **npm** and **go** the lockfile is not regenerated — the
-            scanning sandbox has no package-registry access by design — and
-            the pull request says so prominently and names the command to
-            run. For **pip** (``requirements.txt``) and **maven** there is no
-            lockfile, so the change is complete.
+            For **npm** the ``package-lock.json`` *is* rewritten by
+            default: one read-only registry metadata document supplies the
+            new version's resolved URL and integrity digest. It is left
+            stale only where the ``code_scanning`` policy sets
+            ``autofix_registry_access: false``, where the lock is a
+            ``yarn.lock``/``pnpm-lock.yaml``, or where the entry could not
+            be rewritten safely. For **go** the ``go.sum`` is *not*
+            regenerated — it hashes a module zip nobody downloaded — and
+            only where the tree has one. For **pip**
+            (``requirements.txt``) and **maven** there is no lockfile, so
+            the change is complete. Wherever a lock is left stale the pull
+            request says so prominently and names the command to run; trust
+            the pull request over this summary.
         """
         body: dict[str, Any] = {"finding_id": finding_id}
         if repo:


### PR DESCRIPTION
Both the CLI's `code autofix` help and the SDK's `autofix_code_finding` docstring said:

> For **npm** and **go** the lockfile is not regenerated — the scanning sandbox has no package-registry access by design

That stopped being true for npm when the AutoFix lane gained a scoped registry metadata read. Found while reconciling the equivalent string in the LimaCharlie MCP server, which carried it independently; this repo is the other copy.

## The shipped contract

`legion_cloudsec_host` `docs/CODE-LANE.md:1701-1702`, with `service/codescan.go` defaulting `AutofixRegistryAccess` to `true`:

| ecosystem | lockfile |
|---|---|
| **npm** | `package-lock.json` **is** rewritten. One read-only registry metadata document supplies the new version's `resolved` URL and `integrity` digest. Left stale only under an explicit `autofix_registry_access: false`, a `yarn.lock`/`pnpm-lock.yaml`, or an entry the surgical editor cannot rewrite safely |
| **go** | `go.sum` is **not** regenerated — it hashes a module zip nobody downloaded — and only matters where the tree has one |
| **pip**, **maven** | no lockfile; complete as opened |

## Why it is worth fixing rather than leaving

It fails in the direction that costs the reader work. Someone told the lock was not updated re-runs `npm install --package-lock-only` against a lock that was already correct, or distrusts a pull request that is complete. Both docstrings now defer to the pull request itself, which carries the authoritative per-case answer in an `[!IMPORTANT]` block (`CODE-LANE.md:892`) — that is the copy that cannot go stale relative to the run.

## Scope

Docstrings only, no behaviour change. No new or renamed commands, so `_COMMAND_MODULE_MAP`, `PROFILES` and `doc/cli/` are untouched (checked: `doc/cli/` never carried the claim).

`pytest tests/unit/ tests/microbenchmarks/` — 4127 passed, 19 skipped (pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)