### PR TITLE
Fix MailSec sender-domain filtering

### DIFF
--- a/limacharlie/sdk/mailsec.py
+++ b/limacharlie/sdk/mailsec.py
@@ -331,7 +331,9 @@ class Mailsec:
                 ``unknown`` (repeatable).
             mailbox: Protected mailbox address (exact).
             sender_email: Envelope/header sender address (exact).
-            sender_domain: Sender registrable root domain.
+            sender_domain: Sender registrable root domain. Sent to the API as
+                ``sender_root_domain``; the Python name is retained for
+                compatibility with existing callers.
             campaign_id: Only members of one campaign.
             state: Message lifecycle state (repeatable).
             direction: ``inbound``, ``outbound``, ``internal`` (repeatable).
@@ -358,7 +360,7 @@ class Mailsec:
         for key, val in (
             ("mailbox", mailbox),
             ("sender_email", sender_email),
-            ("sender_domain", sender_domain),
+            ("sender_root_domain", sender_domain),
             ("campaign_id", campaign_id),
             ("min_score", min_score),
             ("link_domain", link_domain),

--- a/tests/unit/test_cli_mailsec.py
+++ b/tests/unit/test_cli_mailsec.py
@@ -46,10 +46,38 @@ def invoke_campaign_action(*args: str):
         return result, mailsec
 
 
+def invoke_message_list(*args: str):
+    with (
+        patch("limacharlie.commands.mailsec.Client"),
+        patch("limacharlie.commands.mailsec.Organization"),
+        patch("limacharlie.commands.mailsec.Mailsec") as mailsec_cls,
+    ):
+        mailsec = MagicMock()
+        mailsec.list_messages.return_value = {"messages": [], "next_cursor": ""}
+        mailsec_cls.return_value = mailsec
+        result = CliRunner().invoke(
+            cli,
+            [
+                "--oid", "11111111-2222-3333-4444-555555555555",
+                "--output", "json",
+                "mailsec", "message", "list",
+                *args,
+            ],
+        )
+        return result, mailsec
+
+
 def test_connection_diagnostic_is_read_only_by_default():
     result, mailsec = invoke_connection("workspace")
     assert result.exit_code == 0, result.output
     mailsec.test_connection.assert_called_once_with("workspace", include_watch=False)
+
+
+def test_sender_domain_cli_argument_reaches_the_sdk_unchanged():
+    result, mailsec = invoke_message_list("--sender-domain", "evil.example")
+    assert result.exit_code == 0, result.output
+    _, kwargs = mailsec.list_messages.call_args
+    assert kwargs["sender_domain"] == "evil.example"
 
 
 def test_include_watch_reaches_the_public_sdk_call():

--- a/tests/unit/test_sdk_mailsec.py
+++ b/tests/unit/test_sdk_mailsec.py
@@ -1,13 +1,15 @@
 """Tests for limacharlie.sdk.mailsec module."""
 
-import warnings
 import json
-
+import warnings
 from unittest.mock import MagicMock, patch
+from urllib.parse import parse_qsl, urlsplit
 
 import pytest
 
+from limacharlie.client import Client
 from limacharlie.sdk.mailsec import BULK_TERMINAL_STATES, Mailsec, normalize_bulk_selection
+from limacharlie.sdk.organization import Organization
 
 
 OID = "11111111-2222-3333-4444-555555555555"
@@ -94,6 +96,34 @@ class TestRepeatableFilters:
         assert ("mailbox", "cfo@corp.example") in qp
         assert ("link_domain", "evil.example") in qp
         assert ("limit", "50") in qp
+
+    @patch("limacharlie.client.urlopen")
+    def test_sender_domain_reaches_the_gateway_wire_key(self, mock_urlopen):
+        """Drive the real client transport, not only Mailsec's query-pair seam.
+
+        The gateway ignores unknown selectors, so a misspelled key still returns
+        a successful, unfiltered page. Pinning the encoded URL is what prevents
+        that dangerous success from looking like a working filter again.
+        """
+        response = MagicMock()
+        response.read.return_value = json.dumps({
+            "messages": [{"msg_uuid": "filtered-message"}],
+            "next_cursor": "",
+        }).encode()
+        response.getheaders.return_value = []
+        response.close = MagicMock()
+        mock_urlopen.return_value = response
+
+        client = Client(oid=OID, jwt="test-jwt")
+        result = Mailsec(Organization(client)).list_messages(
+            sender_domain="evil.example",
+        )
+
+        sent = mock_urlopen.call_args.args[0]
+        assert parse_qsl(urlsplit(sent.full_url).query) == [
+            ("sender_root_domain", "evil.example"),
+        ]
+        assert result["messages"] == [{"msg_uuid": "filtered-message"}]
 
 
 class TestEMLRequiresJustification:


### PR DESCRIPTION
## Why

The public Python argument `sender_domain` and CLI flag `--sender-domain` were serialized as `sender_domain`. The MailSec message-list gateway accepts `sender_root_domain`, so the old key was ignored and a successful response could contain an unfiltered page.

## Design

- keep the Python argument and CLI flag unchanged for caller compatibility
- serialize that argument as the established `sender_root_domain` query key
- document the public-to-wire mapping
- exercise the real Click handoff and the real HTTP request builder, asserting the encoded query contains exactly the accepted key

The separate gateway scalar-vocabulary work is intentionally outside this SDK fix.

## Verification

- `.venv/bin/pytest -q tests/unit/test_sdk_mailsec.py tests/unit/test_cli_mailsec.py` — 91 passed
- `.venv/bin/pytest tests/unit/ tests/microbenchmarks/ --benchmark-disable -q` — 4,156 passed, 5 skipped
- `git diff --check`

No release or deployment is included. A package release remains a separate operator-owned step.
