### PR TITLE
Use the correct Replay stream for detection and audit rule tests

### DIFF
--- a/doc/cli/detection-response.md
+++ b/doc/cli/detection-response.md
@@ -15,9 +15,17 @@ limacharlie dr create --name my-rule \
   --respond '[{"action":"report","name":"my-detection"}]'
 limacharlie dr update --name my-rule --detect '...' --respond '[...]'
 limacharlie dr delete --name my-rule
-limacharlie dr test --detect '...' --respond '[...]' --events '[{...}]'
+limacharlie dr test --input-file rule.yaml --events events.json
+limacharlie dr test --name audit-rule --events audit-events.json --stream audit
 limacharlie dr validate --detect '...' --respond '[...]'
 ```
+
+`dr test` infers the Replay event layout from an inline rule's `detect.target`:
+`detection` selects `detect` (event name in `cat`), `audit` selects `audit`
+(event name in `etype`), and other targets select `event` (event name in
+`routing.event_type`). `--stream event|detect|audit` overrides this choice;
+specify it for non-EDR rules tested by name. Fixtures must preserve the real
+target's event structure rather than wrapping audit or detection data as EDR.
 
 ## fp
 

--- a/limacharlie/commands/dr.py
+++ b/limacharlie/commands/dr.py
@@ -540,6 +540,12 @@ Events should match the structure LimaCharlie uses internally:
 Use --trace for a detailed step-by-step evaluation trace showing
 which operators matched or failed, useful for debugging rules.
 
+For an inline rule, the Replay stream is inferred from detect.target:
+detection uses detect, audit uses audit, and other targets use event.
+Use --stream to select a stream explicitly, including when testing an
+existing rule by --name. Detection events use cat for their event name;
+audit events use etype and do not need an EDR routing wrapper.
+
 The response includes num_evals, eval_time, num_events, responses
 (list of actions that would fire), and errors.
 
@@ -556,12 +562,14 @@ register_explain("dr.test", _EXPLAIN_TEST)
 @click.option("--events", "events_path", required=True, type=click.Path(exists=True), help="Path to JSON file with events.")
 @click.option("--input-file", default=None, type=click.Path(exists=True), help="Path to rule file (JSON or YAML with 'detect' and 'respond' keys).")
 @click.option("--trace", is_flag=True, default=False, help="Include detailed evaluation trace in output.")
+@click.option("--stream", default=None, type=click.Choice(["event", "detect", "audit"]),
+              help="Replay event layout. Inferred from an inline rule's target; otherwise event.")
 @click.option(
     "--namespace", default=None, type=_NS_CHOICES,
     help="Rule namespace (when using --name).",
 )
 @pass_context
-def test(ctx, name, events_path, input_file, trace, namespace) -> None:
+def test(ctx, name, events_path, input_file, trace, stream, namespace) -> None:
     rule_content = None
 
     if name is None:
@@ -580,6 +588,11 @@ def test(ctx, name, events_path, input_file, trace, namespace) -> None:
 
     events = _load_events(events_path)
 
+    if stream is None:
+        detect = rule_content.get("detect", {}) if isinstance(rule_content, dict) else {}
+        target = detect.get("target", "edr") if isinstance(detect, dict) else "edr"
+        stream = {"detection": "detect", "audit": "audit"}.get(target, "event")
+
     org = _get_org(ctx)
     replay = ReplaySDK(org)
     data = replay.scan_events(
@@ -588,6 +601,7 @@ def test(ctx, name, events_path, input_file, trace, namespace) -> None:
         namespace=namespace,
         rule_content=rule_content,
         trace=trace,
+        stream=stream,
     )
     _output(ctx, data)
 

--- a/tests/unit/test_dr_test_stream.py
+++ b/tests/unit/test_dr_test_stream.py
@@ -1,0 +1,46 @@
+"""The CLI must preserve target-specific event layouts at the Replay boundary."""
+import json
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+from limacharlie.cli import cli
+
+
+@pytest.mark.parametrize("target,stream,event", [
+    ("edr", "event", {"routing": {"event_type": "NEW_PROCESS"}, "event": {}}),
+    ("detection", "detect", {"cat": "original-report", "routing": {"event_type": "NEW_PROCESS"}}),
+    ("audit", "audit", {"etype": "user_login", "oid": "org"}),
+    ("schedule", "event", {"routing": {"event_type": "1h_per_org"}, "event": {"frequency": 3600}}),
+])
+def test_inline_target_selects_replay_layout(tmp_path, target, stream, event):
+    rule = {"detect": {"target": target, "op": "exists", "path": "marker"},
+            "respond": [{"action": "report", "name": "fixture"}]}
+    rp, ep = tmp_path / "rule.json", tmp_path / "events.json"
+    rp.write_text(json.dumps(rule))
+    ep.write_text(json.dumps([event]))
+    with patch("limacharlie.commands.dr._get_org"), patch("limacharlie.commands.dr.ReplaySDK") as replay:
+        replay.return_value.scan_events.return_value = {"did_match": True}
+        result = CliRunner().invoke(cli, ["dr", "test", "--input-file", str(rp), "--events", str(ep)])
+        assert result.exit_code == 0, result.output
+        call = replay.return_value.scan_events.call_args
+        assert call.args[0] == [event]
+        assert call.kwargs["rule_content"] == rule
+        assert call.kwargs["stream"] == stream
+
+
+@pytest.mark.parametrize("stream", [None, "event", "detect", "audit"])
+def test_named_rule_accepts_explicit_stream(tmp_path, stream):
+    ep = tmp_path / "events.json"
+    ep.write_text('[{"etype":"login"}]')
+    with patch("limacharlie.commands.dr._get_org"), patch("limacharlie.commands.dr.ReplaySDK") as replay:
+        replay.return_value.scan_events.return_value = {"did_match": False}
+        args = ["dr", "test", "--name", "existing", "--namespace", "managed", "--events", str(ep)]
+        if stream:
+            args += ["--stream", stream]
+        result = CliRunner().invoke(cli, args)
+        assert result.exit_code == 0, result.output
+        call = replay.return_value.scan_events.call_args
+        assert call.kwargs["stream"] == (stream or "event")
+        assert call.kwargs["rule_name"] == "existing"
+        assert call.kwargs["namespace"] == "managed"


### PR DESCRIPTION
`dr test` sent every inline fixture to Replay as an EDR event. Detection-target rules with an event name in `cat` could silently miss matching fixtures, and audit fixtures could fail with “event missing routing.” Infer `detect` or `audit` from an inline rule's `detect.target`, and expose `--stream` for explicit selection, including named rules. Other targets and named rules without an override retain the event layout.

Validation: SDK unit and microbenchmark suites passed; CLI boundary tests cover inferred layouts, unchanged fixtures, explicit named-rule layouts and the existing default. Live disposable-org validation plus positive/negative Replay checks passed for EDR, detection, audit, schedule, deployment and artifact-event rules. The pre-fix detection and audit failures were reproduced first.
